### PR TITLE
feat: update compose skill for ocaml-compose-dsl v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "compose",
       "source": "./plugins/compose",
       "description": "Describe multi-step agent workflows using an Arrow-style DSL (>>>, ***, &&&, |||, loop) and validate them structurally",
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   ]
 }

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -15,13 +15,13 @@ Ensure `~/.local/bin` is in `PATH`.
 
 ### Version Check
 
-This skill requires **v0.2.0** or later. After confirming the binary exists, verify the version:
+This skill requires **v0.3.0** or later. After confirming the binary exists, verify the version:
 
 ```bash
 ocaml-compose-dsl --version
 ```
 
-If the output is lower than `0.2.0` or the `--version` flag is not recognized, the binary is outdated. Offer to re-run `scripts/install.sh` to upgrade to the latest release.
+If the output is lower than `0.3.0` or the `--version` flag is not recognized, the binary is outdated. Offer to re-run `scripts/install.sh` to upgrade to the latest release.
 
 ## Core Concepts
 
@@ -147,6 +147,17 @@ read(source: file)
 
 `&&&` feeds the same input to both sides; `***` feeds separate inputs to each side.
 
+### Numeric Parameters
+
+Numeric literals — integers, floats, negatives, and unit suffixes — can be used directly as values:
+
+```
+resize(width: 1920, height: 1080)
+  >>> compress(quality: 85)
+  >>> dose(amount: 100mg)       -- unit suffix
+  >>> adjust(offset: -3.14)     -- negative float
+```
+
 ## Additional Resources
 
 ### Examples
@@ -158,6 +169,7 @@ The `examples/` directory contains ready-to-use `.arr` files demonstrating commo
 - **`examples/ci-pipeline.arr`** — Fanout lint+test → gate → parallel multi-platform build → upload
 - **`examples/test-fix-loop.arr`** — Iterative edit-test-evaluate feedback loop
 - **`examples/resilient-fetch.arr`** — Primary/mirror fallback with `|||`
+- **`examples/numeric-literals.arr`** — Numeric literal values: integers, floats, negatives, and unit suffixes
 - **`examples/mixed-par-fanout.arr`** — Mixing `***` and `&&&`: precedence behavior and explicit grouping
 
 Use these as starting points: copy, modify node names/arguments, and validate with `ocaml-compose-dsl`.

--- a/plugins/compose/skills/compose/examples/numeric-literals.arr
+++ b/plugins/compose/skills/compose/examples/numeric-literals.arr
@@ -1,0 +1,7 @@
+-- Workflow: image processing pipeline with numeric parameters
+-- Demonstrates numeric literals: integers, floats, negatives, and unit suffixes
+resize(width: 1920, height: 1080)       -- ref: Bash("ffmpeg")
+  >>> adjust(brightness: -0.3, contrast: 1.2)
+  >>> compress(quality: 85)
+  >>> watermark(opacity: 0.5, offset_x: -10, offset_y: -10)
+  >>> upload(max_size: 500kb)           -- unit suffix on numeric literal

--- a/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
+++ b/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
@@ -32,4 +32,4 @@
   >>> validate_all(checker: "ocaml-compose-dsl")           -- ref: Bash("ocaml-compose-dsl *.arr")
 
   -- Phase 5: verify binary version requirement
-  >>> check_version(binary: "ocaml-compose-dsl", minimum: "0.2.0") -- ref: Bash("ocaml-compose-dsl --version")
+  >>> check_version(binary: "ocaml-compose-dsl", minimum: "0.3.0") -- ref: Bash("ocaml-compose-dsl --version")

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -24,6 +24,7 @@ args     = arg , { "," , arg } ;
 arg      = ident , ":" , value ;
 
 value    = string
+         | number
          | ident
          | "[" , [ value , { "," , value } ] , "]"
          ;
@@ -31,6 +32,8 @@ value    = string
 ident    = ( letter | "_" ) , { letter | digit | "-" | "_" } ;
 
 string   = '"' , { any char - '"' } , '"' ;
+
+number   = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , { letter } ;
 
 comment  = "--" , { any char - newline } ;
 ```
@@ -123,6 +126,26 @@ loop(
     >>> evaluate(criteria: all_pass)     -- check pass/fail
 )
 ```
+
+### Numeric Literals
+
+Numbers can be integers, floats, negative, or carry unit suffixes:
+
+```
+resize(width: 1920, height: 1080)     -- integers
+  >>> compress(quality: 85)
+  >>> dose(amount: 100mg)             -- unit suffix
+  >>> adjust(offset: -3.14)           -- negative float
+```
+
+Numbers appear wherever a value is expected — as arguments or inside lists:
+
+```
+mix(volumes: [100ml, 250ml, 50ml])
+  >>> heat(temp: 72.5c, duration: 30min)
+```
+
+Note: leading-dot (`.5`) and trailing-dot (`5.`) forms are **not** valid — use `0.5` and `5` respectively.
 
 ### Cross-Agent Portability
 

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -145,7 +145,7 @@ mix(volumes: [100ml, 250ml, 50ml])
   >>> heat(temp: 72.5c, duration: 30min)
 ```
 
-Note: leading-dot (`.5`) and trailing-dot (`5.`) forms are **not** valid — use `0.5` and `5` respectively.
+Note: leading-dot (`.5`) and trailing-dot (`5.`) forms are **not** valid — use `0.5` and `5.0` respectively.
 
 ### Cross-Agent Portability
 


### PR DESCRIPTION
## Summary
- Update compose skill to require ocaml-compose-dsl v0.3.0 (was v0.2.0)
- Add `number` production to EBNF grammar (integers, floats, negatives, unit suffixes like `100mg`, `-3.14`)
- Add Numeric Literals section to grammar reference with examples and validity notes
- Add Numeric Parameters common pattern to SKILL.md
- Add `examples/numeric-literals.arr` — image processing pipeline showcasing numeric literal features
- Bump marketplace.json compose version to 0.3.0
- Update `update-skill-from-upstream.arr` minimum version reference

## Test plan
- [x] All 7 `.arr` example files validated with ocaml-compose-dsl v0.3.0
- [x] New `numeric-literals.arr` parses correctly (integers, floats, negatives, unit suffixes)
- [x] Existing examples remain valid under v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)