### PR TITLE
feat: update compose skill for ocaml-compose-dsl v0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "compose",
       "source": "./plugins/compose",
       "description": "Describe multi-step agent workflows using an Arrow-style DSL (>>>, ***, &&&, |||, loop) and validate them structurally",
-      "version": "0.3.0"
+      "version": "0.4.0"
     }
   ]
 }

--- a/plugins/compose/skills/compose/README.md
+++ b/plugins/compose/skills/compose/README.md
@@ -36,6 +36,12 @@ read(source: "data.csv")
   >>> upload(tag: "v0.1.0")
 ```
 
+```
+読み込み(ソース: "データ.csv")
+  >>> フィルタ(条件: "年齢 > 18")
+  >>> 出力
+```
+
 More examples in `examples/` — including a meta-workflow that describes how this skill updates itself from the upstream repo.
 
 ## Install

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -15,13 +15,13 @@ Ensure `~/.local/bin` is in `PATH`.
 
 ### Version Check
 
-This skill requires **v0.3.0** or later. After confirming the binary exists, verify the version:
+This skill requires **v0.4.0** or later. After confirming the binary exists, verify the version:
 
 ```bash
 ocaml-compose-dsl --version
 ```
 
-If the output is lower than `0.3.0` or the `--version` flag is not recognized, the binary is outdated. Offer to re-run `scripts/install.sh` to upgrade to the latest release.
+If the output is lower than `0.4.0` or the `--version` flag is not recognized, the binary is outdated. Offer to re-run `scripts/install.sh` to upgrade to the latest release.
 
 ## Core Concepts
 
@@ -158,6 +158,23 @@ resize(width: 1920, height: 1080)
   >>> adjust(offset: -3.14)     -- negative float
 ```
 
+### Unicode Identifiers
+
+Node names, argument keys, and unit suffixes accept any non-ASCII UTF-8 codepoint. The DSL works naturally with non-Latin scripts:
+
+```
+読み込み(ソース: "データ.csv")
+  >>> フィルタ(条件: "年齢 > 18")
+  >>> 出力
+```
+
+```
+加熱(溫度: 72.5℃, 時間: 30分鐘)
+  >>> 冷卻(目標: 4℃)
+```
+
+Error positions report codepoint-level columns, not byte offsets, so diagnostics stay accurate for multibyte characters.
+
 ## Additional Resources
 
 ### Examples
@@ -171,6 +188,13 @@ The `examples/` directory contains ready-to-use `.arr` files demonstrating commo
 - **`examples/resilient-fetch.arr`** — Primary/mirror fallback with `|||`
 - **`examples/numeric-literals.arr`** — Numeric literal values: integers, floats, negatives, and unit suffixes
 - **`examples/mixed-par-fanout.arr`** — Mixing `***` and `&&&`: precedence behavior and explicit grouping
+- **`examples/unicode-identifiers.arr`** — Unicode node names, argument keys, and unit suffixes with non-Latin scripts
+- **`examples/osint-social-media-forensics.arr`** — Crawl social media timelines to extract identifying artifacts and compile evidence
+- **`examples/osint-account-correlation.arr`** — Cross-platform account linking via public breadcrumbs and business registry lookups
+- **`examples/osint-evidence-compilation.arr`** — Systematic screenshot and archival loop for court-ready evidence folders
+- **`examples/osint-geolocation.arr`** — Geolocate facilities from broadcast footage by cross-referencing with satellite imagery
+- **`examples/osint-media-monitoring.arr`** — Monitor state media for military unit designations and map to known bases
+- **`examples/osint-infrastructure-change.arr`** — Temporal satellite imagery comparison to detect new military construction
 
 Use these as starting points: copy, modify node names/arguments, and validate with `ocaml-compose-dsl`.
 

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -160,7 +160,7 @@ resize(width: 1920, height: 1080)
 
 ### Unicode Identifiers
 
-Node names, argument keys, and unit suffixes accept any non-ASCII UTF-8 codepoint. The DSL works naturally with non-Latin scripts:
+Node names, argument keys, and unit suffixes support full UTF-8 identifiers, including non-ASCII characters. The DSL works naturally with non-Latin scripts:
 
 ```
 読み込み(ソース: "データ.csv")
@@ -189,6 +189,8 @@ The `examples/` directory contains ready-to-use `.arr` files demonstrating commo
 - **`examples/numeric-literals.arr`** — Numeric literal values: integers, floats, negatives, and unit suffixes
 - **`examples/mixed-par-fanout.arr`** — Mixing `***` and `&&&`: precedence behavior and explicit grouping
 - **`examples/unicode-identifiers.arr`** — Unicode node names, argument keys, and unit suffixes with non-Latin scripts
+The following OSINT examples are illustrative and should be used only in lawful, ToS-compliant, and privacy-respecting contexts.
+
 - **`examples/osint-social-media-forensics.arr`** — Crawl social media timelines to extract identifying artifacts and compile evidence
 - **`examples/osint-account-correlation.arr`** — Cross-platform account linking via public breadcrumbs and business registry lookups
 - **`examples/osint-evidence-compilation.arr`** — Systematic screenshot and archival loop for court-ready evidence folders

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -189,6 +189,7 @@ The `examples/` directory contains ready-to-use `.arr` files demonstrating commo
 - **`examples/numeric-literals.arr`** — Numeric literal values: integers, floats, negatives, and unit suffixes
 - **`examples/mixed-par-fanout.arr`** — Mixing `***` and `&&&`: precedence behavior and explicit grouping
 - **`examples/unicode-identifiers.arr`** — Unicode node names, argument keys, and unit suffixes with non-Latin scripts
+
 The following OSINT examples are illustrative and should be used only in lawful, ToS-compliant, and privacy-respecting contexts.
 
 - **`examples/osint-social-media-forensics.arr`** — Crawl social media timelines to extract identifying artifacts and compile evidence

--- a/plugins/compose/skills/compose/examples/osint-account-correlation.arr
+++ b/plugins/compose/skills/compose/examples/osint-account-correlation.arr
@@ -1,0 +1,8 @@
+-- Workflow: cross-platform account correlation
+-- Link an online handle to real-world identity via public breadcrumbs
+(搜尋(平台: threads, 關鍵字: handle)
+  &&& 搜尋(平台: facebook, 關鍵字: handle)
+  &&& 搜尋(平台: line, 關鍵字: handle))         -- ref: WebFetch
+  >>> 交叉比對(欄位: [顯示名稱, 大頭貼, 簡介連結])
+  >>> (反查公司登記(來源: "經濟部商工登記") ||| 反查網域(方法: whois))  -- ref: Bash("whois"), WebFetch
+  >>> 建檔(輸出: "身份關聯報告.md")              -- ref: Write

--- a/plugins/compose/skills/compose/examples/osint-account-correlation.arr
+++ b/plugins/compose/skills/compose/examples/osint-account-correlation.arr
@@ -1,4 +1,5 @@
 -- Workflow: cross-platform account correlation
+-- Illustrative only — use in lawful, ToS-compliant, privacy-respecting contexts
 -- Link an online handle to real-world identity via public breadcrumbs
 (搜尋(平台: threads, 關鍵字: handle)
   &&& 搜尋(平台: facebook, 關鍵字: handle)

--- a/plugins/compose/skills/compose/examples/osint-evidence-compilation.arr
+++ b/plugins/compose/skills/compose/examples/osint-evidence-compilation.arr
@@ -1,0 +1,10 @@
+-- Workflow: systematic evidence compilation for legal proceedings
+-- Organize scattered online evidence into court-ready folders
+loop(
+  掃描(來源: 轉發清單, 批次: 50)                 -- ref: WebFetch, Bash("curl")
+    >>> (截圖(含時間戳: true) *** 保存原始頁面(格式: mhtml))  -- ref: Playwright
+    >>> 分類(依據: [發文者, 日期, 侵權類型])
+    >>> evaluate(條件: 清單已處理完畢)
+)
+  >>> 產出(格式: pdf, 結構: 每人一資料夾)         -- ref: Bash("wkhtmltopdf")
+  >>> 匯出(目的: "提告資料")

--- a/plugins/compose/skills/compose/examples/osint-evidence-compilation.arr
+++ b/plugins/compose/skills/compose/examples/osint-evidence-compilation.arr
@@ -1,4 +1,5 @@
 -- Workflow: systematic evidence compilation for legal proceedings
+-- Illustrative only — use in lawful, ToS-compliant, privacy-respecting contexts
 -- Organize scattered online evidence into court-ready folders
 loop(
   掃描(來源: 轉發清單, 批次: 50)                 -- ref: WebFetch, Bash("curl")

--- a/plugins/compose/skills/compose/examples/osint-geolocation.arr
+++ b/plugins/compose/skills/compose/examples/osint-geolocation.arr
@@ -1,0 +1,8 @@
+-- Workflow: geolocation from broadcast footage
+-- Identify a facility's coordinates by cross-referencing video frames with satellite imagery
+擷取影格(來源: "官媒報導.mp4", 間隔: 5s)        -- ref: Bash("ffmpeg")
+  >>> 辨識地標(方法: [建築輪廓, 地形, 植被])     -- ref: Agent(vision)
+  >>> (查詢衛星圖(提供者: google_earth, 解析度: 0.5m)
+    &&& 查詢衛星圖(提供者: sentinel2, 日期: "2026-03"))  -- ref: WebFetch
+  >>> 疊合比對(容許誤差: 50m)
+  >>> 標註(輸出格式: geojson, 座標系: "WGS84")   -- ref: Write

--- a/plugins/compose/skills/compose/examples/osint-geolocation.arr
+++ b/plugins/compose/skills/compose/examples/osint-geolocation.arr
@@ -1,4 +1,5 @@
 -- Workflow: geolocation from broadcast footage
+-- Illustrative only — use in lawful, ToS-compliant, privacy-respecting contexts
 -- Identify a facility's coordinates by cross-referencing video frames with satellite imagery
 擷取影格(來源: "官媒報導.mp4", 間隔: 5s)        -- ref: Bash("ffmpeg")
   >>> 辨識地標(方法: [建築輪廓, 地形, 植被])     -- ref: Agent(vision)

--- a/plugins/compose/skills/compose/examples/osint-infrastructure-change.arr
+++ b/plugins/compose/skills/compose/examples/osint-infrastructure-change.arr
@@ -1,0 +1,7 @@
+-- Workflow: military infrastructure change detection
+-- Compare temporal satellite imagery to identify new construction at known facilities
+取得座標(來源: facility_database, 篩選: "近期活動")  -- ref: Read
+  >>> (下載衛星圖(日期: "2024-01") *** 下載衛星圖(日期: "2026-03"))  -- ref: WebFetch
+  >>> 差異分析(方法: pixel_diff, 閾值: 0.15)
+  >>> 標記變化(類型: [新建跑道, 機堡, 雷達陣地, 營舍])
+  >>> 產出報告(格式: markdown, 含圖: true)        -- ref: Write

--- a/plugins/compose/skills/compose/examples/osint-infrastructure-change.arr
+++ b/plugins/compose/skills/compose/examples/osint-infrastructure-change.arr
@@ -1,4 +1,5 @@
 -- Workflow: military infrastructure change detection
+-- Illustrative only — use in lawful, ToS-compliant, privacy-respecting contexts
 -- Compare temporal satellite imagery to identify new construction at known facilities
 取得座標(來源: facility_database, 篩選: "近期活動")  -- ref: Read
   >>> (下載衛星圖(日期: "2024-01") *** 下載衛星圖(日期: "2026-03"))  -- ref: WebFetch

--- a/plugins/compose/skills/compose/examples/osint-media-monitoring.arr
+++ b/plugins/compose/skills/compose/examples/osint-media-monitoring.arr
@@ -1,0 +1,8 @@
+-- Workflow: open-source military media monitoring
+-- Monitor state media broadcasts, extract unit designations, and map to known bases
+監控(頻道: [cctv7, 央視軍事], 關鍵字: [新兵入營, 訓練])  -- ref: WebFetch, Bash("yt-dlp")
+  >>> 擷取資訊(欄位: [部隊番號, 人名, 地名])
+  >>> (查詢已知部隊(資料庫: order_of_battle)
+    *** 地理定位(線索: [受訪者發言, 背景地貌]))
+  >>> 驗證(方法: 比對聲稱地點與定位結果)          -- 新兵未必知道營區真實位置
+  >>> 更新(目標: unit_database, 欄位: [座標, 最後活動日期])

--- a/plugins/compose/skills/compose/examples/osint-media-monitoring.arr
+++ b/plugins/compose/skills/compose/examples/osint-media-monitoring.arr
@@ -1,4 +1,5 @@
 -- Workflow: open-source military media monitoring
+-- Illustrative only — use in lawful, ToS-compliant, privacy-respecting contexts
 -- Monitor state media broadcasts, extract unit designations, and map to known bases
 監控(頻道: [cctv7, 央視軍事], 關鍵字: [新兵入營, 訓練])  -- ref: WebFetch, Bash("yt-dlp")
   >>> 擷取資訊(欄位: [部隊番號, 人名, 地名])

--- a/plugins/compose/skills/compose/examples/osint-social-media-forensics.arr
+++ b/plugins/compose/skills/compose/examples/osint-social-media-forensics.arr
@@ -1,0 +1,7 @@
+-- Workflow: social media timeline forensics
+-- Crawl a target's post history to extract identifying artifacts
+收集(平台: social_media, 範圍: "全部貼文")   -- ref: Bash("gallery-dl"), WebFetch
+  >>> 篩選(類型: [圖片, 個資線索])
+  >>> (擷取文字(方法: ocr) *** 提取metadata(欄位: [時間, 地點, 裝置]))
+  >>> 比對(資料庫: known_identities)           -- ref: Grep, Bash("fzf")
+  >>> 彙整(格式: 證據資料夾)

--- a/plugins/compose/skills/compose/examples/osint-social-media-forensics.arr
+++ b/plugins/compose/skills/compose/examples/osint-social-media-forensics.arr
@@ -1,4 +1,5 @@
 -- Workflow: social media timeline forensics
+-- Illustrative only — use in lawful, ToS-compliant, privacy-respecting contexts
 -- Crawl a target's post history to extract identifying artifacts
 收集(平台: social_media, 範圍: "全部貼文")   -- ref: Bash("gallery-dl"), WebFetch
   >>> 篩選(類型: [圖片, 個資線索])

--- a/plugins/compose/skills/compose/examples/unicode-identifiers.arr
+++ b/plugins/compose/skills/compose/examples/unicode-identifiers.arr
@@ -1,7 +1,6 @@
--- Workflow: data processing with unicode node names, keys, and unit suffixes
--- Demonstrates CJK identifiers and unicode unit suffixes
+-- Workflow: data processing with unicode node names and argument keys
+-- Demonstrates CJK identifiers in a coherent Japanese data pipeline
 読み込み(ソース: "データ.csv")       -- ref: Read
   >>> フィルタ(条件: "年齢 > 18")   -- ref: Bash("jq")
   >>> (集計 *** 抽出(項目: [名前, メール]))
-  >>> 加熱(溫度: 72.5℃, 時間: 30分鐘)
   >>> 出力(形式: レポート)

--- a/plugins/compose/skills/compose/examples/unicode-identifiers.arr
+++ b/plugins/compose/skills/compose/examples/unicode-identifiers.arr
@@ -1,0 +1,7 @@
+-- Workflow: data processing with unicode node names, keys, and unit suffixes
+-- Demonstrates CJK identifiers and unicode unit suffixes
+読み込み(ソース: "データ.csv")       -- ref: Read
+  >>> フィルタ(条件: "年齢 > 18")   -- ref: Bash("jq")
+  >>> (集計 *** 抽出(項目: [名前, メール]))
+  >>> 加熱(溫度: 72.5℃, 時間: 30分鐘)
+  >>> 出力(形式: レポート)

--- a/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
+++ b/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
@@ -32,4 +32,4 @@
   >>> validate_all(checker: "ocaml-compose-dsl")           -- ref: Bash("ocaml-compose-dsl *.arr")
 
   -- Phase 5: verify binary version requirement
-  >>> check_version(binary: "ocaml-compose-dsl", minimum: "0.3.0") -- ref: Bash("ocaml-compose-dsl --version")
+  >>> check_version(binary: "ocaml-compose-dsl", minimum: "0.4.0") -- ref: Bash("ocaml-compose-dsl --version")

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -29,16 +29,24 @@ value    = string
          | "[" , [ value , { "," , value } ] , "]"
          ;
 
-ident    = ( letter | "_" ) , { letter | digit | "-" | "_" } ;
+ident       = ident_start , { ident_char } ;
+ident_start = ? any valid UTF-8 codepoint that is not an ASCII digit,
+                not ASCII whitespace, and not one of ( ) [ ] : , > * | & - " .
+                ! # $ % ^ + = { } < ; ' ` ~ / ? @ \ ? ;
+ident_char  = ? any valid UTF-8 codepoint that is not ASCII whitespace,
+                and not one of ( ) [ ] : , > * | & " .
+                ! # $ % ^ + = { } < ; ' ` ~ / ? @ \ ? ;
 
-string   = '"' , { any char - '"' } , '"' ;
+string   = '"' , { ? any valid UTF-8 codepoint except '"' ? } , '"' ;
 
-number   = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , { letter } ;
+number   = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , [ ident_start , { ident_char } ] ;
 
 comment  = "--" , { any char - newline } ;
 ```
 
 All operators are right-associative (matching Haskell Arrow fixity). Comments can appear after any term and are attached to the preceding node as purpose descriptions or reference tool annotations.
+
+Identifiers and unit suffixes accept any non-ASCII UTF-8 codepoint (CJK, Greek, accented Latin, etc.), so the DSL works naturally with non-Latin scripts. Error positions report codepoint-level columns, not byte offsets.
 
 ## Combinators
 
@@ -146,6 +154,26 @@ mix(volumes: [100ml, 250ml, 50ml])
 ```
 
 Note: leading-dot (`.5`) and trailing-dot (`5.`) forms are **not** valid — use `0.5` and `5.0` respectively.
+
+### Unicode Identifiers
+
+Node names, argument keys, and unit suffixes can use non-Latin scripts:
+
+```
+読み込み(ソース: "データ.csv")
+  >>> フィルタ(条件: "年齢 > 18")
+  >>> 出力
+```
+
+```
+加熱(溫度: 72.5℃, 時間: 30分鐘)
+  >>> 冷卻(目標: 4℃)
+```
+
+```
+dose(amount: 500ミリ秒)            -- unicode unit suffix
+  >>> measure(area: 100m2)         -- digit within unit suffix
+```
 
 ### Cross-Agent Portability
 

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -39,14 +39,16 @@ ident_char  = ? any valid UTF-8 codepoint that is not ASCII whitespace,
 
 string   = '"' , { ? any valid UTF-8 codepoint except '"' ? } , '"' ;
 
+digit    = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+
 number   = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , [ ident_start , { ident_char } ] ;
 
-comment  = "--" , { any char - newline } ;
+comment  = "--" , { ? any valid UTF-8 codepoint except newline ? } ;
 ```
 
 All operators are right-associative (matching Haskell Arrow fixity). Comments can appear after any term and are attached to the preceding node as purpose descriptions or reference tool annotations.
 
-Identifiers and unit suffixes accept any non-ASCII UTF-8 codepoint (CJK, Greek, accented Latin, etc.), so the DSL works naturally with non-Latin scripts. Error positions report codepoint-level columns, not byte offsets.
+Identifiers and unit suffixes support full UTF-8 codepoints, including non-ASCII characters (CJK, Greek, accented Latin, etc.), so the DSL works naturally with non-Latin scripts. Error positions report codepoint-level columns, not byte offsets.
 
 ## Combinators
 


### PR DESCRIPTION
## Summary

- Update compose skill to match [ocaml-compose-dsl v0.4.0](https://github.com/caasi/ocaml-compose-dsl/releases/tag/v0.4.0) which adds unicode identifier and unit suffix support
- Update EBNF grammar from ASCII-only `ident` rules to UTF-8 codepoint exclusion-based rules
- Add unicode identifiers section with CJK examples to SKILL.md and dsl-grammar.md
- Add 6 OSINT workflow `.arr` examples inspired by real-world open-source intelligence patterns
- Add `unicode-identifiers.arr` example
- Bump marketplace version to 0.4.0
- All 14 examples validated against v0.4.0 binary

Related: caasi/ocaml-compose-dsl#12 (loop checker doesn't recognize unicode evaluation node names)

## Test plan

- [x] All 14 `.arr` examples pass `ocaml-compose-dsl` validation
- [x] Existing examples unaffected by grammar doc changes
- [ ] Reviewer: confirm EBNF in `dsl-grammar.md` matches upstream README

🤖 Generated with [Claude Code](https://claude.com/claude-code)