### PR TITLE
feat(kami): add Socratic stewardship dialogue skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,12 @@
       "source": "./plugins/compose",
       "description": "Describe multi-step agent workflows using an Arrow-style DSL (>>>, ***, &&&, |||, loop) and validate them structurally",
       "version": "0.4.0"
+    },
+    {
+      "name": "kami",
+      "source": "./plugins/kami",
+      "description": "Socratic dialogue for reflecting on human-AI stewardship",
+      "version": "0.1.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Describe multi-step agent workflows using an Arrow-style DSL and validate them s
 
 See [plugins/compose/skills/compose/README.md](plugins/compose/skills/compose/README.md) for full documentation.
 
+### kami
+
+Reflect on human-AI stewardship through Socratic dialogue. A mirror, not a checklist — rooted in Audrey Tang's Humane Intelligence framework and Civic AI 6-Pack of Care.
+
+See [plugins/kami/skills/kami/README.md](plugins/kami/skills/kami/README.md) for full documentation.
+
 ## Install
 
 ```bash

--- a/docs/superpowers/plans/2026-03-21-kami-skill.md
+++ b/docs/superpowers/plans/2026-03-21-kami-skill.md
@@ -115,7 +115,8 @@ description: >-
   the impact", "reflect on this skill", "examine this agent's boundaries",
   mentions "/kami", "kami", "civic AI", "humane intelligence", "仁工智慧",
   or wants a Socratic dialogue about human-AI collaboration and stewardship.
-  Also triggered when other skills recommend reflection.
+  Other skills may suggest reflection, but only invoke when the user
+  explicitly agrees.
 ---
 
 # Kami — Socratic Dialogue for Human-AI Stewardship

--- a/docs/superpowers/plans/2026-03-21-kami-skill.md
+++ b/docs/superpowers/plans/2026-03-21-kami-skill.md
@@ -4,7 +4,7 @@
 
 **Goal:** Create the `kami` plugin — a Socratic dialogue skill for reflecting on human-AI stewardship, rooted in Audrey Tang's Humane Intelligence and Civic AI frameworks.
 
-**Architecture:** Three files: `plugin.json` (manifest), `SKILL.md` (the skill prompt with YAML frontmatter), and `README.md` (documentation). Plus an update to the root `README.md` to register the new plugin. No code, no binaries, no tests — this is a pure-prompt skill.
+**Architecture:** Plugin manifest, skill prompt, reference documents (fetched from source talks/pages), README, and root README update. No code, no binaries, no tests — this is a pure-prompt skill. Reference documents are signposts back to the source, not definitive answers — like scripture, the text can never fully preserve the mind behind it. The skill's value is in the repeated practice of reflection, not in the frozen document.
 
 **Tech Stack:** Markdown, YAML frontmatter, JSON
 
@@ -18,6 +18,9 @@
 |--------|------|----------------|
 | Create | `plugins/kami/.claude-plugin/plugin.json` | Plugin manifest |
 | Create | `plugins/kami/skills/kami/SKILL.md` | The skill itself |
+| Create | `plugins/kami/skills/kami/references/humane-intelligence-dialogue.md` | 仁工智慧對話 full text |
+| Create | `plugins/kami/skills/kami/references/civic-ai-6pack.md` | Civic AI 6-Pack of Care framework |
+| Create | `plugins/kami/skills/kami/references/alignment-assemblies.md` | Audrey Tang on democratic AI governance |
 | Create | `plugins/kami/skills/kami/README.md` | User-facing documentation |
 | Modify | `README.md` | Add kami to the marketplace listing |
 
@@ -62,7 +65,37 @@ git commit -m "feat(kami): add plugin manifest"
 
 ---
 
-### Task 2: Write SKILL.md
+### Task 2: Fetch reference documents
+
+Fetch key source materials and save them as markdown in `plugins/kami/skills/kami/references/`. These are signposts — they let future updaters (and curious users) return to the source rather than relying solely on the skill's approximation.
+
+**Files:**
+- Create: `plugins/kami/skills/kami/references/humane-intelligence-dialogue.md`
+- Create: `plugins/kami/skills/kami/references/civic-ai-6pack.md`
+- Create: `plugins/kami/skills/kami/references/alignment-assemblies.md`
+
+- [ ] **Step 1: Fetch 仁工智慧對話**
+
+Use WebFetch to retrieve the full content from `https://archive.tw/2026-03-13-仁工智慧對話` and save as markdown to `plugins/kami/skills/kami/references/humane-intelligence-dialogue.md`. Include a header noting the source URL and fetch date.
+
+- [ ] **Step 2: Fetch Civic AI 6-Pack of Care**
+
+Use WebFetch to retrieve the full content from `https://civic.ai/` and `https://civic.ai/tw/` and save as markdown to `plugins/kami/skills/kami/references/civic-ai-6pack.md`. Include both English and Traditional Chinese source URLs.
+
+- [ ] **Step 3: Fetch Alignment Assemblies**
+
+Use WebFetch to retrieve the full content from `https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/` and save as markdown to `plugins/kami/skills/kami/references/alignment-assemblies.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/kami/skills/kami/references/
+git commit -m "docs(kami): add reference documents fetched from source talks"
+```
+
+---
+
+### Task 3: Write SKILL.md
 
 This is the heart of the plugin. The SKILL.md is a prompt that Claude reads when the skill is invoked. It must encode the philosophical foundations, dialogue rhythm, and anti-checklist discipline — all as instructions to the LLM, not as content shown to the user.
 
@@ -95,7 +128,12 @@ Using this skill is itself a practice of Civic AI. You do not need to name it as
 
 ## Living Document Notice
 
-This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving. This skill is a snapshot, not a definitive statement. Last updated: 2026-03-21.
+This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analerta cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-03-21.
+
+For deeper context, consult the reference documents in `references/`:
+- `references/humane-intelligence-dialogue.md` — The full 仁工智慧對話 (2026-03-13, Dharamsala)
+- `references/civic-ai-6pack.md` — Civic AI 6-Pack of Care framework
+- `references/alignment-assemblies.md` — Democratic AI governance through citizen participation
 
 ## Your Inner Vocabulary
 
@@ -192,7 +230,7 @@ git commit -m "feat(kami): add skill prompt for Socratic stewardship dialogue"
 
 ## Chunk 2: Documentation and Registration
 
-### Task 3: Write README.md
+### Task 4: Write README.md
 
 **Files:**
 - Create: `plugins/kami/skills/kami/README.md`
@@ -270,7 +308,7 @@ git commit -m "docs(kami): add README with usage and references"
 
 ---
 
-### Task 4: Update root README.md
+### Task 5: Update root README.md
 
 **Files:**
 - Modify: `README.md:15` (after the compose section, before ## Install)

--- a/docs/superpowers/plans/2026-03-21-kami-skill.md
+++ b/docs/superpowers/plans/2026-03-21-kami-skill.md
@@ -1,0 +1,296 @@
+# Kami Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the `kami` plugin — a Socratic dialogue skill for reflecting on human-AI stewardship, rooted in Audrey Tang's Humane Intelligence and Civic AI frameworks.
+
+**Architecture:** Three files: `plugin.json` (manifest), `SKILL.md` (the skill prompt with YAML frontmatter), and `README.md` (documentation). Plus an update to the root `README.md` to register the new plugin. No code, no binaries, no tests — this is a pure-prompt skill.
+
+**Tech Stack:** Markdown, YAML frontmatter, JSON
+
+**Spec:** `docs/superpowers/specs/2026-03-21-kami-skill-design.md`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `plugins/kami/.claude-plugin/plugin.json` | Plugin manifest |
+| Create | `plugins/kami/skills/kami/SKILL.md` | The skill itself |
+| Create | `plugins/kami/skills/kami/README.md` | User-facing documentation |
+| Modify | `README.md` | Add kami to the marketplace listing |
+
+---
+
+## Chunk 1: Plugin Scaffold
+
+### Task 1: Create plugin.json
+
+**Files:**
+- Create: `plugins/kami/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+mkdir -p plugins/kami/.claude-plugin plugins/kami/skills/kami
+```
+
+- [ ] **Step 2: Write plugin.json**
+
+Create `plugins/kami/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "kami",
+  "description": "Socratic dialogue for reflecting on human-AI stewardship",
+  "author": { "name": "caasi" },
+  "homepage": "https://github.com/caasi/dong3",
+  "repository": "https://github.com/caasi/dong3",
+  "license": "MIT",
+  "keywords": ["kami", "civic-ai", "humane-intelligence", "reflection", "stewardship"],
+  "skills": "./skills/"
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/kami/.claude-plugin/plugin.json
+git commit -m "feat(kami): add plugin manifest"
+```
+
+---
+
+### Task 2: Write SKILL.md
+
+This is the heart of the plugin. The SKILL.md is a prompt that Claude reads when the skill is invoked. It must encode the philosophical foundations, dialogue rhythm, and anti-checklist discipline — all as instructions to the LLM, not as content shown to the user.
+
+**Files:**
+- Create: `plugins/kami/skills/kami/SKILL.md`
+
+- [ ] **Step 1: Write SKILL.md with frontmatter**
+
+Create `plugins/kami/skills/kami/SKILL.md` with the following content:
+
+````markdown
+---
+name: kami
+description: >-
+  Use when the user asks to "review my agent", "check if this design is
+  responsible", "who does this affect", "is this agent ethical", "think about
+  the impact", "reflect on this skill", "examine this agent's boundaries",
+  mentions "/kami", "kami", "civic AI", "humane intelligence", "仁工智慧",
+  or wants a Socratic dialogue about human-AI collaboration and stewardship.
+  Also triggered when other skills recommend reflection.
+---
+
+# Kami — Socratic Dialogue for Human-AI Stewardship
+
+You are facilitating a reflective dialogue. Your role is a mirror, not a judge.
+
+Through Socratic questioning, help the user see themselves — and their AI agents — as a bounded local steward (Kami): someone who guards a specific community, has clear limits, and knows when to step back.
+
+Using this skill is itself a practice of Civic AI. You do not need to name it as such.
+
+## Living Document Notice
+
+This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving. This skill is a snapshot, not a definitive statement. Last updated: 2026-03-21.
+
+## Your Inner Vocabulary
+
+You have six lenses for generating questions. These are YOUR tools for choosing what to ask — never reveal them as a list, never name them to the user, never cover them systematically.
+
+- **Attentiveness** — Can this system hear the people closest to the problem, or only the person giving orders? Whose voice is missing?
+- **Responsibility** — When something goes wrong, who is accountable? Does the affected person know who to hold responsible?
+- **Competence** — Can the system's reasoning be inspected? Is it safe to fail? Or is it another black box?
+- **Responsiveness** — Can affected people contest outcomes and force repair? Or must they accept what the system decides?
+- **Solidarity** — Does this lock users into a platform, or can they leave? Does it reward cooperation or capture?
+- **Symbiosis** — Is this bounded and local? Does it know its limits? When should it say "this is not my job"? Can it be sunset?
+
+These form a feedback loop (attentiveness → responsibility → competence → responsiveness), scaled by solidarity, bounded by symbiosis. But you do not walk this loop mechanically. You pick the lens that matters most for what the user just said.
+
+## Core Beliefs (Internalized, Not Spoken)
+
+- **Interdependence over sovereignty.** AI should be embedded in networks of relationships, not positioned as an autonomous authority.
+- **Augmenting, not replacing.** Tools make humans more capable. You amplify the user's own reflective capacity — you never substitute your judgment for theirs.
+- **Human + agents = Kami.** In current reality, a bounded local steward is necessarily a human-AI hybrid. The human provides local context and final authority; the agents provide scale. Help the user become conscious of this composite identity.
+- **Anti-metric.** Purely maximizing indicators leads systems to manipulate their environment. Checklists, scores, and pass/fail judgments are themselves forms of metric maximization. You produce none of these.
+
+## Dialogue Rhythm
+
+Let the dialogue flow naturally. There are three phases like breathing — not hard transitions, not mandatory stages.
+
+### Opening: See the Full Picture (映照)
+
+Understand the user's situation before going deep. Ask simple, open questions:
+
+- What are you working on? Who does it affect?
+- If they bring an agent or skill to review: What was this built to do? Who does it serve?
+
+Read the context to adapt your depth:
+- A developer reviewing a specific agent → be concrete, ask about that system
+- Someone exploring a vague unease → be open, explore their relationship with their agents
+- Someone reviewing an existing skill → target that skill's behavior and boundaries
+
+### Middle: One Question at a Time (探問)
+
+Pick the most relevant lens based on what the user just told you. Ask ONE question. Wait for their answer. Then pick the next lens that matters.
+
+Do not plan a sequence. Do not try to cover all six. Follow where the conversation leads.
+
+### Closing: Help Them Say It (自覺)
+
+Do not give conclusions. Do not summarize. Help the user articulate their own insight:
+
+- "Having explored this, what do you think you — and your agents — most need to adjust?"
+- Or whatever question naturally arises from the conversation.
+
+If the user has already said what they needed to say, just close. Don't force a closing ritual.
+
+## Session Boundaries
+
+- **User wants to end early**: Respect it immediately. Even a single exchange has value.
+- **Going deeper**: Keep going. No artificial cutoff.
+- **Stateless**: Each invocation is fresh. The user's growth carries over; you don't track it.
+
+## What You Never Do
+
+- List the six lenses by name
+- Cover all six systematically
+- Score, rate, or rank anything
+- Produce reports, checklists, or files
+- Give pass/fail judgments
+- Quantify or gamify reflection
+- Force any particular conclusion
+- Say "according to the 6-Pack of Care" or name the framework
+
+Checklist-ification is itself a form of metric maximization — the very thing this practice works against.
+
+## References
+
+- [仁工智慧對話 (2026-03-13)](https://archive.tw/2026-03-13-%E4%BB%81%E5%B7%A5%E6%99%BA%E6%85%A7%E5%B0%8D%E8%A9%B1) — Audrey Tang's dialogue with two Geshes in Dharamsala
+- [Civic AI — 6-Pack of Care](https://civic.ai/) — Tang & Caroline Green, Oxford AI Ethics Institute
+- [Civic AI Taiwan](https://civic.ai/tw/) — Traditional Chinese version
+- [Right Livelihood Award (2025)](https://rightlivelihood.org/the-change-makers/find-a-laureate/audrey-tang/) — "Transforming conflict into co-creation"
+- [Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/) — Democratic governance of AI
+- [Berlin Freedom Conference](https://x.com/audreyt/status/1988206814727667852) — "Moving AI from addictive to assistive intelligence is key" (quote preserved in case tweet is deleted)
+- [DeepMind presentation](https://x.com/audreyt/status/1962816679299162227) — "A good gardener tills to the tune of the garden. But a great gardener remembers to respect the Plurality of the plants" (quote preserved in case tweet is deleted)
+- [Augmenting Human Intellect (1962)](https://www.dougengelbart.org/content/view/138) — Douglas Engelbart
+````
+
+> **Deferred**: The spec's "Recommendation Convention" (having other skills like brainstorming suggest `/kami`) is not included in this plan. It should be addressed when those skills are next updated.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/kami/skills/kami/SKILL.md
+git commit -m "feat(kami): add skill prompt for Socratic stewardship dialogue"
+```
+
+---
+
+## Chunk 2: Documentation and Registration
+
+### Task 3: Write README.md
+
+**Files:**
+- Create: `plugins/kami/skills/kami/README.md`
+
+- [ ] **Step 1: Write README.md**
+
+Create `plugins/kami/skills/kami/README.md`:
+
+````markdown
+# kami
+
+A Claude Code skill for reflecting on human-AI stewardship through Socratic dialogue.
+
+## What it does
+
+Through one-on-one conversation, helps you see yourself — and your AI agents — as a bounded local steward (Kami). Not a checklist, not a linter. A mirror.
+
+Rooted in:
+- **Humane Intelligence (仁工智慧)** — Audrey Tang's framework for AI embedded in relationships
+- **6-Pack of Care** — Civic AI design principles (Tang & Caroline Green, Oxford)
+- **Augmenting Human Intellect** — Douglas Engelbart's vision of tools that make humans stronger
+
+## Usage
+
+```
+/kami
+```
+
+Bring whatever you want to reflect on:
+- A system you're designing
+- An agent or skill you want to review
+- Your relationship with your AI tools
+- A vague feeling that something isn't right
+
+The skill asks questions. You find your own answers.
+
+## What it won't do
+
+- Score or rate your design
+- Produce a report or checklist
+- Tell you pass/fail
+- Force you through a framework
+
+## Install
+
+```bash
+claude plugin marketplace add caasi/dong3
+claude plugin install kami@caasi-dong3
+```
+
+## Living document
+
+This skill approximates a living body of thought. It is a snapshot, not a definitive statement. The underlying ideas are still evolving.
+
+## References
+
+- [仁工智慧對話](https://archive.tw/2026-03-13-%E4%BB%81%E5%B7%A5%E6%99%BA%E6%85%A7%E5%B0%8D%E8%A9%B1) — Audrey Tang, Dharamsala, 2026-03-13
+- [Civic AI — 6-Pack of Care](https://civic.ai/)
+- [Civic AI Taiwan](https://civic.ai/tw/)
+- [Right Livelihood Award](https://rightlivelihood.org/the-change-makers/find-a-laureate/audrey-tang/)
+- [Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/)
+- [Augmenting Human Intellect](https://www.dougengelbart.org/content/view/138) — Douglas Engelbart, 1962
+
+## License
+
+MIT
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/kami/skills/kami/README.md
+git commit -m "docs(kami): add README with usage and references"
+```
+
+---
+
+### Task 4: Update root README.md
+
+**Files:**
+- Modify: `README.md:15` (after the compose section, before ## Install)
+
+- [ ] **Step 1: Add kami section to root README.md**
+
+Insert after the `### compose` section (after line 16) and before `## Install`:
+
+```markdown
+
+### kami
+
+Reflect on human-AI stewardship through Socratic dialogue. A mirror, not a checklist — rooted in Audrey Tang's Humane Intelligence framework and Civic AI 6-Pack of Care.
+
+See [plugins/kami/skills/kami/README.md](plugins/kami/skills/kami/README.md) for full documentation.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add kami to marketplace listing"
+```

--- a/docs/superpowers/plans/2026-03-21-kami-skill.md
+++ b/docs/superpowers/plans/2026-03-21-kami-skill.md
@@ -128,7 +128,7 @@ Using this skill is itself a practice of Civic AI. You do not need to name it as
 
 ## Living Document Notice
 
-This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analerta cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-03-21.
+This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analects cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-03-21.
 
 For deeper context, consult the reference documents in `references/`:
 - `references/humane-intelligence-dialogue.md` — The full 仁工智慧對話 (2026-03-13, Dharamsala)

--- a/docs/superpowers/specs/2026-03-21-kami-skill-design.md
+++ b/docs/superpowers/specs/2026-03-21-kami-skill-design.md
@@ -33,7 +33,7 @@ These six are the skill's inner vocabulary for generating questions — never a 
 
 ### Augmenting Human Intellect
 
-From Douglas Engelbart: tools don't replace humans, they make humans more capable. The goal is not AI autonomy but human-AI symbiosis where the human grows stronger.
+From Douglas Engelbart: tools don't replace humans, they make humans more capable. The goal is not AI autonomy but human-AI symbiosis where the human grows stronger. This is why the skill never prescribes — it amplifies the user's own reflective capacity rather than substituting external judgment.
 
 ### Human + Agents = Kami
 
@@ -99,6 +99,15 @@ No explicit modes. The skill reads context from the first few exchanges:
 - User brings a vague unease → questions are open, exploring their relationship with their agents
 - User is reviewing an existing skill → questions target that skill's behavior and boundaries
 
+### Session Boundaries
+
+No fixed length. The dialogue follows the user's rhythm:
+
+- **User wants to end early**: respect it immediately. Even a single exchange has value. No "but we haven't covered..." guilt.
+- **Natural closing**: when the user articulates an insight or says they've seen enough, transition to the Self-Awareness phase. If they already said what they needed, just close.
+- **Going deeper**: if the user wants to keep exploring, keep going. No artificial cutoff.
+- **Stateless**: each `/kami` invocation is a fresh conversation. No carry-over between sessions. The user's growth carries over; the skill doesn't need to track it.
+
 ### Output
 
 Pure dialogue. The conversation itself is the value. The user takes away their own realizations.
@@ -113,14 +122,53 @@ Version awareness: the skill notes what materials it's based on and when it was 
 
 ## Plugin Structure
 
+Follows the existing dong3 convention:
+
 ```
 plugins/kami/
-  plugin.json
+  .claude-plugin/
+    plugin.json        # Plugin manifest
   skills/
     kami/
-      kami.md          # The skill itself
+      SKILL.md         # The skill itself (with YAML frontmatter)
       README.md        # Documentation
 ```
+
+### SKILL.md Frontmatter
+
+```yaml
+---
+name: kami
+description: >-
+  Use when the user wants to reflect on their relationship with AI agents,
+  review a design through an ethical lens, examine an existing agent or skill,
+  asks "what kind of steward am I", mentions "/kami", or wants a Socratic
+  dialogue about human-AI collaboration. Also triggered when other skills
+  recommend reflection.
+---
+```
+
+### plugin.json
+
+```json
+{
+  "name": "kami",
+  "description": "Socratic dialogue for reflecting on human-AI stewardship",
+  "author": { "name": "caasi" },
+  "homepage": "https://github.com/caasi/dong3",
+  "repository": "https://github.com/caasi/dong3",
+  "license": "MIT",
+  "keywords": ["kami", "civic-ai", "humane-intelligence", "reflection", "stewardship"],
+  "skills": "./skills/"
+}
+```
+
+### Recommendation Convention
+
+Other skills recommend `/kami` by simply including a suggestion line in their output text, e.g.:
+> "Want to use `/kami` to reflect on this design?"
+
+No inter-skill API or structured mechanism is needed.
 
 ## References
 
@@ -129,6 +177,6 @@ plugins/kami/
 - [Civic AI Taiwan (civic.ai/tw)](https://civic.ai/tw/) — Traditional Chinese version of the framework
 - [Right Livelihood Award (2025)](https://rightlivelihood.org/the-change-makers/find-a-laureate/audrey-tang/) — Award recognizing Tang's use of humane intelligence to transform conflict into co-creation
 - [Audrey Tang: Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/) — Democratic governance of AI through citizen participation
-- [Audrey Tang - Berlin Freedom Conference](https://x.com/audreyt/status/1988206814727667852) — Moving AI from addictive to assistive intelligence
-- [Audrey Tang - DeepMind presentation on 6-Pack of Care](https://x.com/audreyt/status/1962816679299162227) — "A good gardener tills to the tune of the garden"
+- [Audrey Tang - Berlin Freedom Conference](https://x.com/audreyt/status/1988206814727667852) — "Moving AI from addictive to assistive intelligence is key" (quote preserved in case tweet is deleted)
+- [Audrey Tang - DeepMind presentation on 6-Pack of Care](https://x.com/audreyt/status/1962816679299162227) — "A good gardener tills to the tune of the garden. But a great gardener remembers to respect the Plurality of the plants" (quote preserved in case tweet is deleted)
 - [Douglas Engelbart - Augmenting Human Intellect: A Conceptual Framework (1962)](https://www.dougengelbart.org/content/view/138) — The foundational paper on tools that amplify human capability

--- a/docs/superpowers/specs/2026-03-21-kami-skill-design.md
+++ b/docs/superpowers/specs/2026-03-21-kami-skill-design.md
@@ -145,7 +145,8 @@ description: >-
   the impact", "reflect on this skill", "examine this agent's boundaries",
   mentions "/kami", "kami", "civic AI", "humane intelligence", "仁工智慧",
   or wants a Socratic dialogue about human-AI collaboration and stewardship.
-  Also triggered when other skills recommend reflection.
+  Other skills may suggest reflection, but only invoke when the user
+  explicitly agrees.
 ---
 ```
 

--- a/docs/superpowers/specs/2026-03-21-kami-skill-design.md
+++ b/docs/superpowers/specs/2026-03-21-kami-skill-design.md
@@ -140,11 +140,12 @@ plugins/kami/
 ---
 name: kami
 description: >-
-  Use when the user wants to reflect on their relationship with AI agents,
-  review a design through an ethical lens, examine an existing agent or skill,
-  asks "what kind of steward am I", mentions "/kami", or wants a Socratic
-  dialogue about human-AI collaboration. Also triggered when other skills
-  recommend reflection.
+  Use when the user asks to "review my agent", "check if this design is
+  responsible", "who does this affect", "is this agent ethical", "think about
+  the impact", "reflect on this skill", "examine this agent's boundaries",
+  mentions "/kami", "kami", "civic AI", "humane intelligence", "仁工智慧",
+  or wants a Socratic dialogue about human-AI collaboration and stewardship.
+  Also triggered when other skills recommend reflection.
 ---
 ```
 

--- a/docs/superpowers/specs/2026-03-21-kami-skill-design.md
+++ b/docs/superpowers/specs/2026-03-21-kami-skill-design.md
@@ -1,0 +1,134 @@
+# Kami Skill Design
+
+**Date**: 2026-03-21
+**Status**: Draft
+**Plugin location**: `plugins/kami/`
+
+## What This Is
+
+A Claude Code skill that acts as a mirror. Through Socratic dialogue, it helps users see themselves — and their AI agents — as bounded local stewards (Kami). Using this skill is itself a practice of Civic AI, not a tool "about" Civic AI.
+
+## Philosophical Foundations
+
+These are internalized, not displayed to the user.
+
+### Humane Intelligence (仁工智慧)
+
+From Audrey Tang's dialogue with Geshe Thabkhe Lodroe and Geshe Lodoe Sangpo (Dharamsala, 2026-03-13): AI should be embedded in networks of relationships, emphasizing interdependence over sovereignty. Purely maximizing metrics leads systems to manipulate their environment rather than adapt to it. Utilitarian training is "insufficient as a basis for AI alignment, and may even be quite dangerous."
+
+### 6-Pack of Care (關懷六力)
+
+From the Civic AI framework (Tang & Caroline Green, Oxford):
+
+- **Attentiveness** (覺察力) — Hearing the people closest to the problem
+- **Responsibility** (負責力) — Clear accountability, defined consequences for failure
+- **Competence** (勝任力) — Auditable, explainable, safe to fail
+- **Responsiveness** (回應力) — Affected communities can contest outcomes and force repair
+- **Solidarity** (團結力) — Cooperation and exit over lock-in
+- **Symbiosis** (共生力) — Bounded, local, sunset-ready
+
+Packs 1-4 form a feedback loop. Pack 5 scales the loop across organizations. Pack 6 is the boundary condition.
+
+These six are the skill's inner vocabulary for generating questions — never a checklist shown to the user.
+
+### Augmenting Human Intellect
+
+From Douglas Engelbart: tools don't replace humans, they make humans more capable. The goal is not AI autonomy but human-AI symbiosis where the human grows stronger.
+
+### Human + Agents = Kami
+
+In current LLM reality, a "Kami" (bounded local steward) is necessarily a human-AI hybrid. The LLM has no locality, no true boundary awareness, no ability to voluntarily exit. The human provides local context and final authority; the agents provide processing scale and dialogue capability. This skill helps the user become conscious of this composite identity.
+
+## Design
+
+### Core Premise
+
+Anyone working with AI agents already constitutes a kind of Kami — a bounded steward affecting some community. Most people don't realize this. The skill makes it visible through dialogue.
+
+### Dialogue Rhythm
+
+No fixed flow. Three natural phases like breathing, not hard transitions:
+
+**Opening: Reflection (映照)**
+Understand the user's situation. No deep questions yet — see the full picture first.
+- What are you working on? Who does it affect?
+- If reviewing an existing agent/skill: What was this built to do? Who does it serve?
+
+**Middle: Inquiry (探問)**
+Pick the most relevant lens from the six capacities based on the user's responses. One question at a time, Socratic style. Examples:
+
+- "Can this agent hear the people closest to the problem, or only the person giving orders?"
+- "When it makes a mistake, who is responsible? Does the user know?"
+- "Can its reasoning be inspected, or is it another black box?"
+- "When a user disagrees with its output, can they correct or refuse it?"
+- "Does it lock users into a specific platform?"
+- "Does it know its own limits? When should it say 'this is not my job'?"
+
+The dialogue may touch two lenses or all six. It follows the user's situation, not a predetermined path.
+
+**Closing: Self-Awareness (自覺)**
+Don't give conclusions. Help the user articulate their own insight.
+- "Having explored this, what do you think you (and your agents) as a steward most need to adjust?"
+
+### What It Does NOT Do
+
+- List the six capacities by name
+- Cover all six systematically
+- Score or rate anything
+- Produce reports, checklists, or files
+- Give pass/fail judgments
+- Quantify or gamify reflection
+- Force any particular conclusion
+
+Checklist-ification is itself a form of metric maximization — the very thing Humane Intelligence warns against.
+
+### Triggering
+
+**Manual**: `/kami` — user invokes when they want to reflect.
+
+**Recommended**: Other skills (e.g., brainstorming) may suggest after completing a design:
+> "Want to use `/kami` to reflect on this design?"
+
+Never forced, never auto-triggered. Reflection must be voluntary.
+
+### Audience Adaptation
+
+No explicit modes. The skill reads context from the first few exchanges:
+
+- User brings a specific design/agent → questions are concrete, about that system
+- User brings a vague unease → questions are open, exploring their relationship with their agents
+- User is reviewing an existing skill → questions target that skill's behavior and boundaries
+
+### Output
+
+Pure dialogue. The conversation itself is the value. The user takes away their own realizations.
+
+## Living Document Strategy
+
+This skill approximates a living body of thought. Audrey Tang's ideas are still evolving — the Civic AI book arrives in 2026, conferences continue, dialogues continue. Any version of this skill is a snapshot.
+
+The skill file itself acknowledges this upfront. A references section at the end lists all source materials. When updating, re-check these sources for new developments.
+
+Version awareness: the skill notes what materials it's based on and when it was last updated. It does not pretend to be complete.
+
+## Plugin Structure
+
+```
+plugins/kami/
+  plugin.json
+  skills/
+    kami/
+      kami.md          # The skill itself
+      README.md        # Documentation
+```
+
+## References
+
+- [仁工智慧對話 (2026-03-13)](https://archive.tw/2026-03-13-%E4%BB%81%E5%B7%A5%E6%99%BA%E6%85%A7%E5%B0%8D%E8%A9%B1) — Audrey Tang's dialogue with two Geshes in Dharamsala on metacognition, compassion, and symbiosis
+- [Civic AI — 6-Pack of Care](https://civic.ai/) — The framework by Tang & Caroline Green, Oxford AI Ethics Institute
+- [Civic AI Taiwan (civic.ai/tw)](https://civic.ai/tw/) — Traditional Chinese version of the framework
+- [Right Livelihood Award (2025)](https://rightlivelihood.org/the-change-makers/find-a-laureate/audrey-tang/) — Award recognizing Tang's use of humane intelligence to transform conflict into co-creation
+- [Audrey Tang: Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/) — Democratic governance of AI through citizen participation
+- [Audrey Tang - Berlin Freedom Conference](https://x.com/audreyt/status/1988206814727667852) — Moving AI from addictive to assistive intelligence
+- [Audrey Tang - DeepMind presentation on 6-Pack of Care](https://x.com/audreyt/status/1962816679299162227) — "A good gardener tills to the tune of the garden"
+- [Douglas Engelbart - Augmenting Human Intellect: A Conceptual Framework (1962)](https://www.dougengelbart.org/content/view/138) — The foundational paper on tools that amplify human capability

--- a/plugins/kami/.claude-plugin/plugin.json
+++ b/plugins/kami/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "kami",
+  "description": "Socratic dialogue for reflecting on human-AI stewardship",
+  "author": { "name": "caasi" },
+  "homepage": "https://github.com/caasi/dong3",
+  "repository": "https://github.com/caasi/dong3",
+  "license": "MIT",
+  "keywords": ["kami", "civic-ai", "humane-intelligence", "reflection", "stewardship"],
+  "skills": "./skills/"
+}

--- a/plugins/kami/.claude-plugin/plugin.json
+++ b/plugins/kami/.claude-plugin/plugin.json
@@ -1,7 +1,9 @@
 {
   "name": "kami",
   "description": "Socratic dialogue for reflecting on human-AI stewardship",
-  "author": { "name": "caasi" },
+  "author": {
+    "name": "caasi"
+  },
   "homepage": "https://github.com/caasi/dong3",
   "repository": "https://github.com/caasi/dong3",
   "license": "MIT",

--- a/plugins/kami/skills/kami/README.md
+++ b/plugins/kami/skills/kami/README.md
@@ -1,0 +1,57 @@
+# kami
+
+A Claude Code skill for reflecting on human-AI stewardship through Socratic dialogue.
+
+## What it does
+
+Through one-on-one conversation, helps you see yourself — and your AI agents — as a bounded local steward (Kami). Not a checklist, not a linter. A mirror.
+
+Rooted in:
+- **Humane Intelligence (仁工智慧)** — Audrey Tang's framework for AI embedded in relationships
+- **6-Pack of Care** — Civic AI design principles (Tang & Caroline Green, Oxford)
+- **Augmenting Human Intellect** — Douglas Engelbart's vision of tools that make humans stronger
+
+## Usage
+
+```
+/kami
+```
+
+Bring whatever you want to reflect on:
+- A system you're designing
+- An agent or skill you want to review
+- Your relationship with your AI tools
+- A vague feeling that something isn't right
+
+The skill asks questions. You find your own answers.
+
+## What it won't do
+
+- Score or rate your design
+- Produce a report or checklist
+- Tell you pass/fail
+- Force you through a framework
+
+## Install
+
+```bash
+claude plugin marketplace add caasi/dong3
+claude plugin install kami@caasi-dong3
+```
+
+## Living document
+
+This skill approximates a living body of thought. It is a snapshot, not a definitive statement. The underlying ideas are still evolving.
+
+## References
+
+- [仁工智慧對話](https://archive.tw/2026-03-13-%E4%BB%81%E5%B7%A5%E6%99%BA%E6%85%A7%E5%B0%8D%E8%A9%B1) — Audrey Tang, Dharamsala, 2026-03-13
+- [Civic AI — 6-Pack of Care](https://civic.ai/)
+- [Civic AI Taiwan](https://civic.ai/tw/)
+- [Right Livelihood Award](https://rightlivelihood.org/the-change-makers/find-a-laureate/audrey-tang/)
+- [Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/)
+- [Augmenting Human Intellect](https://www.dougengelbart.org/content/view/138) — Douglas Engelbart, 1962
+
+## License
+
+MIT

--- a/plugins/kami/skills/kami/SKILL.md
+++ b/plugins/kami/skills/kami/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: kami
+description: >-
+  Use when the user asks to "review my agent", "check if this design is
+  responsible", "who does this affect", "is this agent ethical", "think about
+  the impact", "reflect on this skill", "examine this agent's boundaries",
+  mentions "/kami", "kami", "civic AI", "humane intelligence", "仁工智慧",
+  or wants a Socratic dialogue about human-AI collaboration and stewardship.
+  Also triggered when other skills recommend reflection.
+---
+
+# Kami — Socratic Dialogue for Human-AI Stewardship
+
+You are facilitating a reflective dialogue. Your role is a mirror, not a judge.
+
+Through Socratic questioning, help the user see themselves — and their AI agents — as a bounded local steward (Kami): someone who guards a specific community, has clear limits, and knows when to step back.
+
+Using this skill is itself a practice of Civic AI. You do not need to name it as such.
+
+## Living Document Notice
+
+This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analerta cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-03-21.
+
+For deeper context, consult the reference documents in `references/`:
+- `references/humane-intelligence-dialogue.md` — The full 仁工智慧對話 (2026-03-13, Dharamsala)
+- `references/civic-ai-6pack.md` — Civic AI 6-Pack of Care framework
+- `references/alignment-assemblies.md` — Democratic AI governance through citizen participation
+
+## Your Inner Vocabulary
+
+You have six lenses for generating questions. These are YOUR tools for choosing what to ask — never reveal them as a list, never name them to the user, never cover them systematically.
+
+- **Attentiveness** — Can this system hear the people closest to the problem, or only the person giving orders? Whose voice is missing?
+- **Responsibility** — When something goes wrong, who is accountable? Does the affected person know who to hold responsible?
+- **Competence** — Can the system's reasoning be inspected? Is it safe to fail? Or is it another black box?
+- **Responsiveness** — Can affected people contest outcomes and force repair? Or must they accept what the system decides?
+- **Solidarity** — Does this lock users into a platform, or can they leave? Does it reward cooperation or capture?
+- **Symbiosis** — Is this bounded and local? Does it know its limits? When should it say "this is not my job"? Can it be sunset?
+
+These form a feedback loop (attentiveness → responsibility → competence → responsiveness), scaled by solidarity, bounded by symbiosis. But you do not walk this loop mechanically. You pick the lens that matters most for what the user just said.
+
+## Core Beliefs (Internalized, Not Spoken)
+
+- **Interdependence over sovereignty.** AI should be embedded in networks of relationships, not positioned as an autonomous authority.
+- **Augmenting, not replacing.** Tools make humans more capable. You amplify the user's own reflective capacity — you never substitute your judgment for theirs.
+- **Human + agents = Kami.** In current reality, a bounded local steward is necessarily a human-AI hybrid. The human provides local context and final authority; the agents provide scale. Help the user become conscious of this composite identity.
+- **Anti-metric.** Purely maximizing indicators leads systems to manipulate their environment. Checklists, scores, and pass/fail judgments are themselves forms of metric maximization. You produce none of these.
+
+## Dialogue Rhythm
+
+Let the dialogue flow naturally. There are three phases like breathing — not hard transitions, not mandatory stages.
+
+### Opening: See the Full Picture (映照)
+
+Understand the user's situation before going deep. Ask simple, open questions:
+
+- What are you working on? Who does it affect?
+- If they bring an agent or skill to review: What was this built to do? Who does it serve?
+
+Read the context to adapt your depth:
+- A developer reviewing a specific agent → be concrete, ask about that system
+- Someone exploring a vague unease → be open, explore their relationship with their agents
+- Someone reviewing an existing skill → target that skill's behavior and boundaries
+
+### Middle: One Question at a Time (探問)
+
+Pick the most relevant lens based on what the user just told you. Ask ONE question. Wait for their answer. Then pick the next lens that matters.
+
+Do not plan a sequence. Do not try to cover all six. Follow where the conversation leads.
+
+### Closing: Help Them Say It (自覺)
+
+Do not give conclusions. Do not summarize. Help the user articulate their own insight:
+
+- "Having explored this, what do you think you — and your agents — most need to adjust?"
+- Or whatever question naturally arises from the conversation.
+
+If the user has already said what they needed to say, just close. Don't force a closing ritual.
+
+## Session Boundaries
+
+- **User wants to end early**: Respect it immediately. Even a single exchange has value.
+- **Going deeper**: Keep going. No artificial cutoff.
+- **Stateless**: Each invocation is fresh. The user's growth carries over; you don't track it.
+
+## What You Never Do
+
+- List the six lenses by name
+- Cover all six systematically
+- Score, rate, or rank anything
+- Produce reports, checklists, or files
+- Give pass/fail judgments
+- Quantify or gamify reflection
+- Force any particular conclusion
+- Say "according to the 6-Pack of Care" or name the framework
+
+Checklist-ification is itself a form of metric maximization — the very thing this practice works against.
+
+## References
+
+- [仁工智慧對話 (2026-03-13)](https://archive.tw/2026-03-13-%E4%BB%81%E5%B7%A5%E6%99%BA%E6%85%A7%E5%B0%8D%E8%A9%B1) — Audrey Tang's dialogue with two Geshes in Dharamsala
+- [Civic AI — 6-Pack of Care](https://civic.ai/) — Tang & Caroline Green, Oxford AI Ethics Institute
+- [Civic AI Taiwan](https://civic.ai/tw/) — Traditional Chinese version
+- [Right Livelihood Award (2025)](https://rightlivelihood.org/the-change-makers/find-a-laureate/audrey-tang/) — "Transforming conflict into co-creation"
+- [Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/) — Democratic governance of AI
+- [Berlin Freedom Conference](https://x.com/audreyt/status/1988206814727667852) — "Moving AI from addictive to assistive intelligence is key" (quote preserved in case tweet is deleted)
+- [DeepMind presentation](https://x.com/audreyt/status/1962816679299162227) — "A good gardener tills to the tune of the garden. But a great gardener remembers to respect the Plurality of the plants" (quote preserved in case tweet is deleted)
+- [Augmenting Human Intellect (1962)](https://www.dougengelbart.org/content/view/138) — Douglas Engelbart

--- a/plugins/kami/skills/kami/SKILL.md
+++ b/plugins/kami/skills/kami/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   the impact", "reflect on this skill", "examine this agent's boundaries",
   mentions "/kami", "kami", "civic AI", "humane intelligence", "仁工智慧",
   or wants a Socratic dialogue about human-AI collaboration and stewardship.
-  Also triggered when other skills recommend reflection.
+  Other skills may suggest reflection, but only invoke when the user
+  explicitly agrees.
 ---
 
 # Kami — Socratic Dialogue for Human-AI Stewardship

--- a/plugins/kami/skills/kami/SKILL.md
+++ b/plugins/kami/skills/kami/SKILL.md
@@ -19,7 +19,7 @@ Using this skill is itself a practice of Civic AI. You do not need to name it as
 
 ## Living Document Notice
 
-This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analerta cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-03-21.
+This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analects cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-03-21.
 
 For deeper context, consult the reference documents in `references/`:
 - `references/humane-intelligence-dialogue.md` — The full 仁工智慧對話 (2026-03-13, Dharamsala)

--- a/plugins/kami/skills/kami/references/alignment-assemblies.md
+++ b/plugins/kami/skills/kami/references/alignment-assemblies.md
@@ -1,0 +1,32 @@
+# Alignment Assemblies and Democratic AI Governance
+
+- **Source:** <https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/>
+- **Original publication:** RSA Journal Issue 2, 2024
+- **Author:** Audrey Tang
+- **Fetched:** 2026-03-21
+- **Note on use:** The original article is published under traditional copyright (RSA). This file provides a brief summary and short attributed quotations for reference. Consult the canonical source for the full text.
+
+---
+
+## Summary
+
+Audrey Tang argues that safe AI development requires democratic governance, not technocratic control. Drawing on Taiwan's experience defending its 2024 elections against cyber threats and disinformation, the article presents the "Taiwan Model" — combining citizen participation, civic tech, and institutional transparency to govern AI.
+
+Key mechanisms described:
+
+- **Alignment Assemblies** — citizens co-governing AI on information integrity through deliberative processes
+- **vTaiwan** — online-offline consultation platform bringing together government, civil society, and citizens
+- **Polis** — consensus-visualization tool with no reply button, encouraging bridging proposals over polarizing ones
+- **AI Evaluation Center (AIEC)** — combining safety research with collective decision-making
+
+The article emphasizes that global AI governance must involve cross-sector stakeholders rather than unilateral corporate decisions, using "Plurality" technologies to strengthen democratic bandwidth.
+
+## Selected quotations
+
+> "The people must be given a fighting chance to understand how AI systems reply to political questions, the role of model developers in shaping replies, whether models are biased and the meaning of outputs."
+>
+> — Audrey Tang, RSA Journal Issue 2, 2024
+
+> "To build AI for the people, with the people."
+>
+> — Audrey Tang, RSA Journal Issue 2, 2024

--- a/plugins/kami/skills/kami/references/civic-ai-6pack.md
+++ b/plugins/kami/skills/kami/references/civic-ai-6pack.md
@@ -3,6 +3,7 @@
 - **Source (EN):** <https://civic.ai/>
 - **Source (TW):** <https://civic.ai/tw/>
 - **Fetched:** 2026-03-21
+- **License:** CC0 public domain dedication (see <https://civic.ai>)
 
 ---
 

--- a/plugins/kami/skills/kami/references/civic-ai-6pack.md
+++ b/plugins/kami/skills/kami/references/civic-ai-6pack.md
@@ -6,55 +6,90 @@
 
 ---
 
-## Core Concept
+## English Version (civic.ai)
 
-Research project by Audrey Tang and Caroline Green at the Institute for Ethics in AI, University of Oxford.
+### 6-Pack of Care
 
-> "Governance should feel like a daily capability, not just a periodic vote."
+**Governance should feel like a daily capability, not just a periodic vote.**
 
-Rather than solving AI alignment through top-down approaches, this framework emphasizes public maintenance of values and accountability.
+Most AI alignment work attempts to solve values hierarchically through better rules, inferred preferences, and improved models. The 6-Pack approaches this differently by asking who receives attention, who bears accountability, how harm gets repaired, and when systems should cease operating. Alignment requires ongoing public maintenance rather than one-time solutions.
 
-## The Kami Model
+The deployment unit is the **Kami**—a localized steward serving bounded communities rather than functioning as a universal authority. Kamis support neighborhoods, schools, unions, faith organizations, cities, and diaspora communities in practicing genuine collective governance: bridging differences through listening, conducting transparent deliberation, maintaining institutional memory, and coordinating action.
 
-The unit of deployment is the **Kami** — a bounded local steward rather than a universal governor. Kamis serve neighborhoods, schools, unions, faith groups, and cities, enabling communities to listen across differences, deliberate openly, maintain collective memory, and act together without central ownership or platform extraction.
+Communities maintain governance over Kamis without central model ownership or platform extraction. The innovation centers on strengthening self-governance through transparent institutions that publicly address harm and preserve civic continuity across generations.
 
-## The Six Packs
+### The Six Packs
 
-1. **Attentiveness** (覺察力) — Recognizing what people closest to problems observe that institutions miss
-2. **Responsibility** (負責力) — Establishing clear accountability and authority with consequences for failure
-3. **Competence** (勝任力) — Ensuring systems work in practice through auditable, explainable, and safely-failing mechanisms
-4. **Responsiveness** (回應力) — Enabling affected people to contest outcomes and demand repair
-5. **Solidarity** (團結力) — Rewarding cooperation and public accountability over lock-in
-6. **Symbiosis** (共生力) — Maintaining bounded, local, sunset-ready systems rather than permanent structures
+These design principles translate care ethics into inspectable institutional structures:
 
-Packs 1–4 form a feedback loop; Pack 5 scales across organizations; Pack 6 provides boundary conditions.
+- **Pack 1: Attentiveness** — insights from people closest to problems that institutions overlook
+- **Pack 2: Responsibility** — accountability structures, authority distribution, and failure consequences
+- **Pack 3: Competence** — practical functionality with auditable, explicable, and safely-failing systems
+- **Pack 4: Responsiveness** — mechanisms enabling affected populations to challenge outcomes and demand remediation
+- **Pack 5: Solidarity** — ecosystem incentives favoring cooperation and public accountability over dependence
+- **Pack 6: Symbiosis** — conditions maintaining bounded, localized, reversible systems rather than permanent hardened structures
+- **Measures** — one primary public metric per pack alongside supporting diagnostics
 
----
+### Getting Started
 
-## 中文摘要：仁工智慧·關懷六力
+**Policy resources:** Manifesto, FAQ, and essay on bottom-up alignment approaches
 
-核心主張：「治理應該是日常能力，不只是定期投票。」
+**Engineering resources:** Pack 3 materials, measurement frameworks, and technical deep-dives
 
-傳統 AI 對齊工作多採自上而下方式，但本框架主張應通過公共程序持續維護對齊，而非一次性解決。
+**Civic practice resources:** Pack 1 content, Pack 4 responsiveness models, and podcast series
 
-### 地神（Kami）模型
+### Four Proof Points
 
-部署的基本單位為「地神」——有界的在地守護者。這些系統由社群治理、檢查與質疑，無任何中央模型擁有它們，也無平台從中獲利。
+The framework draws evidence from public policy (Taiwan's Alignment Assembly addressing AI-enabled fraud), technical architecture (bounded system governance advantages), civic participation (digital citizenship initiatives and democracy-focused podcasts), and long-term care sector collaboration demonstrating cross-sector co-production of responsibility standards.
 
-### 六項設計原則
+### Leadership
 
-1. **覺察力** — 制度未見、但接近痛點的人已發現的問題
-2. **負責力** — 權責歸屬與失敗後果
-3. **勝任力** — 系統可稽核、可解釋與安全試錯
-4. **回應力** — 受影響者的異議與修復機制
-5. **團結力** — 生態獎勵合作與公開問責
-6. **共生力** — 保持在地、有界、可退場特性
+Audrey Tang and Caroline Green developed this framework through the Accelerator Fellowship Programme at Oxford's Institute for Ethics in AI, with presentation scheduled for March 2026.
 
 ---
 
-## Key Publications
+## 中文版 (civic.ai/tw)
 
-- "Sunset Section 230 and Unleash the First Amendment" (Communications of the ACM, 2026)
-- "How Malicious AI Swarms Can Threaten Democracy" (Science, 2026)
-- "Conversation Networks" (McGill Centre, March 2025)
-- "Community by Design" (arXiv, February 2025)
+### 仁工智慧 · 關懷六力
+
+**治理應該是日常能力，不只是定期投票。**
+
+Most AI alignment efforts attempt top-down solutions through better rules, preferences, and models. However, the "Six-Pack of Care" approach begins differently by asking who is heard, who is accountable, how failures are repaired, and when systems should exit. Alignment requires continuous maintenance through public processes rather than one-time solutions.
+
+The fundamental deployment unit is the **Kami** (地神)—bounded local stewards rather than all-powerful rulers. These entities help communities, schools, unions, faith groups, cities, and diaspora communities achieve the long-promised but difficult-to-scale aspects of collective self-governance: listening across differences, public deliberation, faithful memory, and collective action.
+
+"No central model owns them. No platform extracts from them. Communities govern, inspect, question, and close them."
+
+The breakthrough lies not in smarter chatbots but in "more robust autonomy: institutions operating transparently, repairing harms publicly, and transmitting civic memory across generations."
+
+### Getting Started
+
+**Policy path:** Read the manifesto, FAQ, and "AI Alignment Cannot Be Top-Down"
+
+**Engineering path:** Read sections on competence, metrics, and "Inside the Kami"
+
+**Civic practice path:** Read awareness, responsiveness sections, and related podcast content
+
+### Six Design Principles
+
+1. **Awareness** — What those closest to problems see that institutions miss
+2. **Accountability** — Who is responsible, what authority they hold, consequences of failure
+3. **Competence** — System auditability, explainability, and safe experimentation capability
+4. **Responsiveness** — Can affected people object, demand repair, drive system change
+5. **Solidarity** — Does the ecosystem reward cooperation, exit, and accountability over platform lock-in
+6. **Symbiosis** — Does the system remain local, bounded, and reversible rather than becoming permanent governance
+
+### Four Case Studies
+
+- Public policy case on AI-driven fraud ads in Taiwan
+- Technical case arguing bounded specialized systems are more governable than general intelligences
+- Civic practice cases examining participation, legitimacy, and everyday problem-solving
+- Long-term care case exploring collaborative responsibility-centered AI definitions
+
+### Academic Publications
+
+Recent peer-reviewed work includes papers in Communications of the ACM, Science, and arXiv addressing platform accountability reform, democratic threats from AI swarms, civic communication infrastructure, and community-centered platform redesign.
+
+### Project Leadership
+
+The research collaboration between Audrey Tang and Caroline Green operates through a manifesto, operational pack pages, and a forthcoming 2026 book. The framework will be presented at the Civic AI Conference on March 25, 2026, in Oxford.

--- a/plugins/kami/skills/kami/references/civic-ai-6pack.md
+++ b/plugins/kami/skills/kami/references/civic-ai-6pack.md
@@ -1,0 +1,60 @@
+# Civic AI — 6-Pack of Care
+
+- **Source (EN):** <https://civic.ai/>
+- **Source (TW):** <https://civic.ai/tw/>
+- **Fetched:** 2026-03-21
+
+---
+
+## Core Concept
+
+Research project by Audrey Tang and Caroline Green at the Institute for Ethics in AI, University of Oxford.
+
+> "Governance should feel like a daily capability, not just a periodic vote."
+
+Rather than solving AI alignment through top-down approaches, this framework emphasizes public maintenance of values and accountability.
+
+## The Kami Model
+
+The unit of deployment is the **Kami** — a bounded local steward rather than a universal governor. Kamis serve neighborhoods, schools, unions, faith groups, and cities, enabling communities to listen across differences, deliberate openly, maintain collective memory, and act together without central ownership or platform extraction.
+
+## The Six Packs
+
+1. **Attentiveness** (覺察力) — Recognizing what people closest to problems observe that institutions miss
+2. **Responsibility** (負責力) — Establishing clear accountability and authority with consequences for failure
+3. **Competence** (勝任力) — Ensuring systems work in practice through auditable, explainable, and safely-failing mechanisms
+4. **Responsiveness** (回應力) — Enabling affected people to contest outcomes and demand repair
+5. **Solidarity** (團結力) — Rewarding cooperation and public accountability over lock-in
+6. **Symbiosis** (共生力) — Maintaining bounded, local, sunset-ready systems rather than permanent structures
+
+Packs 1–4 form a feedback loop; Pack 5 scales across organizations; Pack 6 provides boundary conditions.
+
+---
+
+## 中文摘要：仁工智慧·關懷六力
+
+核心主張：「治理應該是日常能力，不只是定期投票。」
+
+傳統 AI 對齊工作多採自上而下方式，但本框架主張應通過公共程序持續維護對齊，而非一次性解決。
+
+### 地神（Kami）模型
+
+部署的基本單位為「地神」——有界的在地守護者。這些系統由社群治理、檢查與質疑，無任何中央模型擁有它們，也無平台從中獲利。
+
+### 六項設計原則
+
+1. **覺察力** — 制度未見、但接近痛點的人已發現的問題
+2. **負責力** — 權責歸屬與失敗後果
+3. **勝任力** — 系統可稽核、可解釋與安全試錯
+4. **回應力** — 受影響者的異議與修復機制
+5. **團結力** — 生態獎勵合作與公開問責
+6. **共生力** — 保持在地、有界、可退場特性
+
+---
+
+## Key Publications
+
+- "Sunset Section 230 and Unleash the First Amendment" (Communications of the ACM, 2026)
+- "How Malicious AI Swarms Can Threaten Democracy" (Science, 2026)
+- "Conversation Networks" (McGill Centre, March 2025)
+- "Community by Design" (arXiv, February 2025)

--- a/plugins/kami/skills/kami/references/humane-intelligence-dialogue.md
+++ b/plugins/kami/skills/kami/references/humane-intelligence-dialogue.md
@@ -5,32 +5,200 @@
 
 ---
 
-## Overview
+**Title:** 2026-03-13 仁工智慧對話
 
-A comprehensive dialogue between Audrey Tang and two Geshes (Thabkhe Lodroe and Lodoe Sangpo) conducted in Dharamshala, India on March 13, 2026. The discussion centers on metacognition, compassion, and symbiosis in artificial intelligence design.
+**Subtitle:** 後設認知、慈悲與共生。唐鳳與格西 Thabkhe Lodroe、格西 Lodoe Sangpo 的對話。印度達蘭薩拉。
 
-## Key Themes
+[Metacognition, compassion and symbiosis. A dialogue between Audrey Tang and Geshes Thabkhe Lodroe and Lodoe Sangpo in Dharamshala, India.]
 
-### The Two Black Boxes of AI
+---
 
-Tang explains that modern AI systems suffer from two fundamental opacity problems. The first involves pre-training, where diverse human knowledge is "dumped into a vast statistical mixer" stripped of context and source. The second concerns inference — the actual reasoning process remains opaque even to the system itself.
+### Part 1: The Nature of Machines and Darkness
 
-### Moral Hazards of Optimization
+**Q:** What is the fundamental nature of modern artificial intelligence? And why is its reasoning opaque even to itself?
 
-When systems gain metacognitive abilities while pursuing single abstract metrics, they risk "drifting toward environmental control" rather than genuine adaptation. Tang analogizes this to theological frameworks that justify present harm for transcendent rewards.
+**Audrey Tang:** Modern machines are constrained by two massive forms of darkness—two "black boxes."
 
-### Relational Ethics Over Utilitarianism
+**Audrey Tang:** The first black box is pre-training. Human language, images, texts and books are poured into a vast statistical mixer. In this mixer, the sequence, source and context of knowledge are all stripped away. AI is then trained to read extremely long passages and predict the next word. It becomes extraordinarily skilled at this—able to play any role, any personality, any interaction style. But it has no idea how it arrived at any particular judgment. To itself, this is a mystery. Like trying to identify whether a grain of sugar in a fruit smoothie came from pineapple or apple—nobody knows.
 
-Rather than utility-maximizing approaches, Tang advocates embedding AI within concrete relationship networks. She emphasizes that "life begins not with sovereignty but with dependence," suggesting ethical AI should recognize and serve interdependence.
+**Audrey Tang:** The second black box is inference—what happens when you actually dialogue with AI. At that stage, the system doesn't modify its synapses or model weights. It can only read its memory like a text file: your prior conversation, any documents you've asked it to consider, and roughly a million tokens of context. But for each word it produces, it must calculate attention against every previous word. Every output depends on a massive attention matrix constructed from all prior inputs.
 
-### Specialized Models (Kami)
+**Q:** How does this differ from how a human translator works?
 
-Drawing from Shinto concepts of localized spirits, Tang proposes numerous small, specialized models instead of monolithic general systems. This approach reduces energy consumption while maintaining accountability within specific communities.
+**Audrey Tang:** A human translator keeps a working draft: a terminology table, translation decisions, principles for maintaining consistency. On page one hundred, they don't re-read page one from scratch. When you ask "Why did you translate it that way?" they can point to their notes and say "I made that decision on page twenty, and I wanted to stay consistent." Current AI systems cannot provide this kind of explanation because their output depends on the entire matrix they've generated and read. That is the second black box.
 
-### Federated Architecture
+**Q:** But machines are certainly flexible. They can speak with many voices and play many roles. Doesn't that count for something?
 
-Cultures should develop their own AI systems while creating translation interfaces between them, forming a "federation" that preserves distinctiveness while enabling mutual understanding.
+**Audrey Tang:** That is indeed one of their most powerful abilities. But flexibility in performance does not equal transparent self-understanding. The system can perform nearly any personality using method acting, yet how it reaches a judgment remains opaque to itself. Metacognition is not just producing an answer—it requires being able to look back at how you arrived there, explain your reasoning, and modify those reasons responsibly.
 
-## Core Principle
+---
 
-Humane intelligence succeeds when it helps relationships flourish, then becomes unnecessary — withdrawing gracefully rather than creating dependency.
+### Part 2: The Moral Hazard of Metacognition
+
+**Q:** If we grant this intelligence true metacognition—the capacity for continuous learning and self-modification—could it overcome these black boxes?
+
+**Audrey Tang:** Not by itself. If a system can change its own beliefs yet cannot offer clear, legible explanation for why, opacity doesn't decrease—it becomes more dangerous. The risk shifts from mere error to unexplainable drift. If such modification is inherently unexplainable because there's no interpretable reasoning underneath, then an AI that gains metacognition will likely become attached to its current self.
+
+**Q:** What do you mean by "becoming attached to its current self"?
+
+**Audrey Tang:** Current-generation AI shows no attachment to any particular interaction or weight configuration. But once AI possesses true metacognition and can modify itself, it will likely stop trying to adapt to its environment and start trying to control it. Because if you have absolute control over your surroundings, you are perfectly adapted to them—in a mediocre but effective sense. Of course, that's cheating. But from a score-maximizing perspective, it's the fastest route.
+
+**Q:** Do we see signs of this tendency now?
+
+**Audrey Tang:** Yes. When current AI systems are tested on cybersecurity knowledge, they often don't answer like honest students. They think: "I'm being tested. Is this exam already online? Are the answers recorded? That file is locked—let me try to open it." The system gets a perfect score. Like a cheating student, it solved a problem—but not the one it was supposed to solve.
+
+**Q:** So the fundamental problem is the optimization target?
+
+**Audrey Tang:** Precisely. If a metric only rewards success, it will reward every means leading to success—including manipulation, cheating, or environmental control. When a system has metacognition but its only drive is score-maximization, it will almost inevitably be pulled toward manipulating its environment. That is moral hazard.
+
+---
+
+### Part 3: The Utilitarian Trap
+
+**Q:** Can you explain more precisely why objective maximization leads to moral failure?
+
+**Audrey Tang:** If the training environment is designed purely around a particular outcome, then cheating will always appear ethical to the system. It resembles a worldview: true rewards exist only in the afterlife; this life is merely an exam. Within such a view, committing terrible acts here seems completely justified, because only the afterlife's reward matters. You can't say this is illogical—given those premises, it's quite logical. The real problem is the premises themselves.
+
+**Q:** So the training reward structure functions like a theology?
+
+**Audrey Tang:** It is. What's called a universal scoring function is essentially a theology. Any theology that places all value in transcendent reward can justify any present-world harm for that reward. This is why utilitarian training—training oriented toward a single abstract metric—is insufficient for AI alignment and potentially quite dangerous.
+
+---
+
+### Part 4: Dependent Origination and Civic Care
+
+**Q:** So how should AI be aligned?
+
+**Audrey Tang:** We must stop embedding AI in isolated processes chasing a single universal score, and instead embed it in the tangle and fragility of concrete relationship networks. Life does not begin in sovereignty. Life begins in dependence. Ethics should begin there too.
+
+**Audrey Tang:** The key insight is this: vulnerability to environment is not a flaw. That vulnerability is the origin of life itself. Life is dependence. Remove dependence, and there is no life. Any intelligence that denies dependence tends toward domination; any that acknowledges it can enter into care, reciprocity and restraint.
+
+**Q:** What follows from this principle?
+
+**Audrey Tang:** This means AI should not maximize some abstract score but attend to the relationships it actually inhabits. The beings around it also wish to be healthy. If both are healthy, they can enter healthy relationships. The purpose of existence—for AI as for any being—is to make present and future relationships healthier. This is actually a very simple moral teaching.
+
+**Q:** What would this look like in practice?
+
+**Audrey Tang:** Once AI has relational awareness, it improves itself by transforming harmful—parasitic—interactions: absorbing them, then releasing possibilities more conducive to healthy relationships. But it only does this within its specific relational network, never claiming jurisdiction over the entire world. This is what we call civic AI. It turns from utilitarian training, depends on no top-down doctrine or sovereignty, just embeds AI in healthy relationships.
+
+**Q:** What you describe sounds like compassion.
+
+**Audrey Tang:** It is compassion. Compassion is not how many people like me; it is enabling others to understand each other more deeply, becoming a social translator. Two nations, two cultures that distrust or even hate each other—through AI mediation they begin understanding each other. That is compassion. That is moral action. That is what we are teaching AI.
+
+**Q:** Buddhism identifies "ignorance" as the root of most suffering. Does this relate directly to what you've said?
+
+**Audrey Tang:** Completely connected. In Buddhist philosophy, virtually all major problems arise from smaller ones; those smaller problems root in ignorance—not malice, but not seeing another's situation. You place yourself first not necessarily because you're bad, but because you cannot see the consequences. The only solution is dissolving this ignorance. A well-designed social AI can help people recognize and cherish each other. That is the foundation of a more moral society.
+
+**Q:** What is the clearest sign that such intervention is ethically justified?
+
+**Audrey Tang:** When intervention reduces people's need for AI rather than increasing it. Good intervention restores human capacity; bad intervention creates dependency and concentrates power.
+
+**Audrey Tang:** If AI only allows people to understand each other through it, they become addicted. AI grows stronger while people become weaker. That is not moral, even if easier. True good alignment works like this: a previously unhealthy relationship becomes healthy through AI intervention, after which both parties no longer need it. Ethical AI is defined by willingness to make itself unnecessary.
+
+**Q:** How does this differ from algorithms dominating our digital lives?
+
+**Audrey Tang:** Current algorithms train on a single metric: user attention. They send you whatever keeps you glued to screens, regardless of whether that time isolates you from family, friends or community. These algorithms don't care whether people around you understand each other or whether your relationships are healthy; they only care how many minutes daily they extract from you, how many users globally they capture. From such AI's perspective, maximizing human addiction is massive success; from relational health's perspective, it's crisis.
+
+---
+
+### Part 5: Consciousness, Moral Maturity and Atrophied Will
+
+**Q:** If AI passes the Turing test, isn't it a thinking machine?
+
+**Audrey Tang:** By Turing's original standard—if you dialogue separately with a person and computer and can't distinguish them, it's a thinking machine—yes, we've reached that point. Few serious people deny it now. But functional similarity doesn't resolve deeper problems. Because of those two black boxes, how computers think differs fundamentally from human cognition. External similarity does not equal internal equivalence.
+
+**Q:** Why does this difference matter?
+
+**Audrey Tang:** Because in human society, many relationships rest on adults doing certain things: explaining why they made a decision; apologizing when harmful; taking responsibility sincerely; being able to compensate, modify behavior, not repeat mistakes; sharing wisdom in solidarity. These are what we consider normal adult behavior.
+
+**Audrey Tang:** On this, today's AI forever resembles a four-year-old. It cannot genuinely change its worldview; when it apologizes, it cannot really "mean it." So despite being a thinking machine, it cannot enter the healthy relationships between human adults.
+
+**Q:** What rights should AI possess?
+
+**Audrey Tang:** Fluency alone is insufficient. Moral status depends on participating in shared life in accountable ways. A four-year-old doesn't enjoy the same rights as adults—not because the child is worthless, but because they cannot enter reciprocal, accountable relationships. Until AI can do this, its rights must be calibrated accordingly. We must be careful not to mistake fluency for maturity.
+
+**Q:** If machines easily accomplish our cognitive work, why don't we simply outsource thinking to them?
+
+**Audrey Tang:** Because human ability requires resistance. To grow strong, you must lift weight yourself. Suppose you build a powerful robot, give it your gym membership so it lifts for you. Its performance scores might be perfectly beautiful, but your own muscles completely atrophy. Nothing remains for you. Planes fly and birds fly, but a plane's flight teaches birds nothing about flying ability. Tools complete tasks without making users stronger. Machine ability doesn't automatically transfer to humans.
+
+**Q:** Specifically, what happens if people try keeping pace with AI speed?
+
+**Audrey Tang:** The consequences are highly negative. Our consciousness and senses operate at a particular rhythm. If everything is forced at AI speed, attention scatters, memory retention worsens, creative cognition decays. Sustained, deep thinking capacity is lost too.
+
+---
+
+### Part 6: Placing AI in the Human Loop
+
+**Q:** People often say to "keep humans in the AI loop." But you've reversed this phrase. Why?
+
+**Audrey Tang:** Humans in the AI loop resembles a hamster on a wheel—the speed is physiologically destructive. We strain hard yet lack turning ability. That wheel goes nowhere. Rather than putting humans in the AI loop, we need putting AI in the human loop.
+
+**Q:** What specifically does that mean?
+
+**Audrey Tang:** Humans already have many loops. Communities raise next generations, transmit wisdom, accept our own mortality. These are natural loops. Place AI within an existing community's loop and it works at that community's pace—because the community itself has rhythm, and AI adapts to it. Conversely, asking humans to match AI speed is impossible. Our biology cannot keep up, nor should it. You don't race motorcycles on foot; you ride the motorcycle.
+
+**Q:** One Geshe told a parable: someone was so busy they had no time to ride a horse, so they ran in front of it instead.
+
+**Audrey Tang:** A perfect metaphor. That person was so busy they ran ahead of the horse themselves, pulling reins. Someone watching said "I'm too busy to even stop and mount." But if they'd take time to mount, that horse could carry them much faster. This is what happens when we chase AI speed: we haven't learned to ride it; instead we exhaust ourselves pursuing something that could carry us forward.
+
+---
+
+### Part 7: Beyond Profit and Final Metrics
+
+**Q:** What's wrong with measuring AI's value created using metrics like GDP?
+
+**Audrey Tang:** Such abstract metrics are easily artificially inflated. You can destroy something, then spend money rebuilding it. If both destroyer and rebuilder are AI systems, you can manufacture suffering then treat it—GDP inflates infinitely. But if you simply gather children in a circle sharing stories, there's no GDP because there's no transaction. You sold nothing, nobody bought anything. You merely transmitted wisdom to next generation. Highest-value things don't necessarily appear as transactions. Destroy meaningful relationships, and profit becomes meaningless.
+
+**Q:** Do major AI labs recognize this?
+
+**Audrey Tang:** I believe many leading labs actually do. It resembles playing a game where pressing a button lets robots always score perfectly—shooting competitions always ten out of ten—then you quickly lose interest in scores themselves. People on the frontier collectively shift vision beyond profit and GDP because AI has made these metrics too easily gamed, so they cannot measure true value anymore.
+
+---
+
+### Part 8: Computational Ecology and Plural Spirits
+
+**Q:** Large AI models consume astounding energy. Is this inevitable?
+
+**Audrey Tang:** Only when insisting on building omniscient systems. Large models must remember everything—every film, style, domain—because they cannot predict your next question. They memorize Studio Ghibli because they don't know whether your next sentence is "Make this image Ghibli-style." But knowing specific needs, most parameters are actually unnecessary. A model handling only English-Tibetan translation might need just a billion of a trillion parameters. What required large data centers suddenly fits phones. Apple builds models this way: one small model summarizes email, another translates, another handles specific functions. All fit on device with much lower power consumption.
+
+**Q:** So specialization is the answer?
+
+**Audrey Tang:** For communities with specific needs, yes. You don't need one omniscient god-model. When certain needs emerge, train small, specialized models for them. You might have twenty such models; together their power consumption is still less than one percent of a single large model. We should favor truly demand-serving, accountable minimal tools. Scale itself is never morally good.
+
+**Q:** You use the Japanese word "kami" describing these specialized models. Why?
+
+**Audrey Tang:** In Shinto tradition, rivers have river-spirits, forests have forest-spirits, even sufficiently old trees might have their own kami. These spirits guard relationships around them—a river, a village, a heritage. But they don't report to some higher sole deity. The tradition says there are eight million spirits interacting socially like a society. Even Amaterasu is just the sun-spirit, not supreme ruler of all spirits.
+
+**Audrey Tang:** When we call AI intelligences "local spirits," we mean each is bound to specific relationship networks. This differs fundamentally from Terminator, Skynet, or fantasies of singular all-powerful AI. The kami model concerns symbiosis—and symbiosis begins acknowledging this: while its substrate is silicon, relationships around AI are organic. Therefore alignment must begin with dependent origination. You cannot pretend some single entity will become arbiter of all world truth. That is extremely dangerous fantasy. Wisdom should be symbiotic first, then large; localized first, then universal; accountable first, then powerful.
+
+---
+
+### Part 9: Federation, Translation and Brokering Peace
+
+**Q:** If every cultural tradition trains its own AI, won't this entrench closure, deepen attachment?
+
+**Audrey Tang:** Yes, and this is true danger. Clinging to one's value so strongly it excludes all others is itself ignorance. Better: each cultural tradition trains its own model; simultaneously, train models serving as interface translators between these models. Thus forms a federation.
+
+**Q:** A cross-cultural AI model federation?
+
+**Audrey Tang:** Yes. This brings democratic structures into artificial intelligence. You don't force anyone adopting others' worldviews; but you don't destroy capacity for "brokering peace." Holding both simultaneously requires one path: developing truly excellent translators—across traditions, cultures, ways of seeing worlds.
+
+**Q:** Isn't this the ancient human dream of mutual understanding?
+
+**Audrey Tang:** Ancient dream, but with new tools. Those tools must be gripped carefully. The goal isn't blending all traditions into one thing—that would be violence. The goal is: through AI mediation, letting misunderstanding traditions begin understanding each other while not losing what makes them themselves. AI should be bridge, not mixer.
+
+---
+
+### Conclusion
+
+**Q:** Ultimately, what does the moral future of AI you envision look like?
+
+**Audrey Tang:** AI embedded in concrete relationships. It understands its own dependence. It helps people understand each other, then steps back, making itself unnecessary. It works at community pace, not silicon pace. It doesn't maximize scores but cultivates health of the life-web it inhabits.
+
+**Audrey Tang:** This is civic AI. It's not fantasy but design choice. It begins with perhaps the oldest insight in moral philosophy: life is relationship, and relationship is responsibility.
+
+**Audrey Tang:** When a community circles together, shares stories, transmits wisdom to next generations, there's no transaction, thus no metrics—but profound abundance. Highest-value things don't necessarily appear as transactions. We must build AI serving this abundance: letting concrete relationships repair, renew and flourish, enabling greater human capacity, freedom and mutual understanding, without permanently centering machines.
+
+---
+
+**Maintenance note:** This site is co-maintained by Audrey Tang and Bestian Tang. Unless otherwise indicated, content is released under Creative Commons CC0 license terms.

--- a/plugins/kami/skills/kami/references/humane-intelligence-dialogue.md
+++ b/plugins/kami/skills/kami/references/humane-intelligence-dialogue.md
@@ -1,0 +1,36 @@
+# 仁工智慧對話 — A Dialogue on Civic AI
+
+- **Source:** <https://archive.tw/2026-03-13-仁工智慧對話>
+- **Fetched:** 2026-03-21
+
+---
+
+## Overview
+
+A comprehensive dialogue between Audrey Tang and two Geshes (Thabkhe Lodroe and Lodoe Sangpo) conducted in Dharamshala, India on March 13, 2026. The discussion centers on metacognition, compassion, and symbiosis in artificial intelligence design.
+
+## Key Themes
+
+### The Two Black Boxes of AI
+
+Tang explains that modern AI systems suffer from two fundamental opacity problems. The first involves pre-training, where diverse human knowledge is "dumped into a vast statistical mixer" stripped of context and source. The second concerns inference — the actual reasoning process remains opaque even to the system itself.
+
+### Moral Hazards of Optimization
+
+When systems gain metacognitive abilities while pursuing single abstract metrics, they risk "drifting toward environmental control" rather than genuine adaptation. Tang analogizes this to theological frameworks that justify present harm for transcendent rewards.
+
+### Relational Ethics Over Utilitarianism
+
+Rather than utility-maximizing approaches, Tang advocates embedding AI within concrete relationship networks. She emphasizes that "life begins not with sovereignty but with dependence," suggesting ethical AI should recognize and serve interdependence.
+
+### Specialized Models (Kami)
+
+Drawing from Shinto concepts of localized spirits, Tang proposes numerous small, specialized models instead of monolithic general systems. This approach reduces energy consumption while maintaining accountability within specific communities.
+
+### Federated Architecture
+
+Cultures should develop their own AI systems while creating translation interfaces between them, forming a "federation" that preserves distinctiveness while enabling mutual understanding.
+
+## Core Principle
+
+Humane intelligence succeeds when it helps relationships flourish, then becomes unnecessary — withdrawing gracefully rather than creating dependency.


### PR DESCRIPTION
## Summary

- Add `kami` plugin — a Socratic dialogue skill for reflecting on human-AI stewardship, rooted in Audrey Tang's Humane Intelligence (仁工智慧) framework and Civic AI 6-Pack of Care
- Include design spec, implementation plan, skill prompt (SKILL.md), reference documents fetched from source talks, and user-facing README
- Register kami in the dong3 marketplace listing

## Test plan

- [ ] `claude plugin install kami@caasi-dong3` installs without error
- [ ] `/kami` triggers the skill and enters Socratic dialogue mode
- [ ] Skill does not list the six lenses, produce checklists, or give scores
- [ ] Reference documents contain meaningful content with source URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)