### PR TITLE
feat(compose): update compose plugin to v0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,8 +18,8 @@
     {
       "name": "compose",
       "source": "./plugins/compose",
-      "description": "Describe multi-step agent workflows using an Arrow-style DSL (>>>, ***, &&&, |||, ?, loop) and validate them structurally",
-      "version": "0.7.0"
+      "description": "Describe multi-step agent workflows using an Arrow-style DSL (>>>, ***, &&&, |||, ?, loop, \\, let...in, (), ;) and validate them structurally",
+      "version": "0.10.0"
     },
     {
       "name": "kami",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ plugins/<name>/
 
 ## Plugin Details
 
-**chat-subagent (v0.3.2):** `chat.sh` is a pure bash/curl wrapper for OpenAI-compatible APIs. `thinking-filter.jq` strips reasoning blocks. `probes/` contains 19 diagnostic questions (reasoning, instruction-following, counting, coding). Test the jq filter with `test-thinking-filter.sh`.
+**chat-subagent (v0.4.0):** `chat.sh` is a pure bash/curl wrapper for OpenAI-compatible APIs. `thinking-filter.jq` strips reasoning blocks. `probes/` contains 19 diagnostic questions (reasoning, instruction-following, counting, coding). Test the jq filter with `test-thinking-filter.sh`.
 
 **compose (v0.10.0):** Uses an OCaml binary (`ocaml-compose-dsl`) for DSL validation. Install via `scripts/install.sh` (downloads to `~/.local/bin/`). Validate `.arr` files with `ocaml-compose-dsl pipeline.arr` or Markdown files with `ocaml-compose-dsl --literate doc.md`. Arrow combinators: `>>>` (sequential), `|||` (branch), `***` (parallel), `&&&` (fanout), `?` (question/branch), `loop()` (feedback). Abstraction: `\x -> expr` (lambda), `let x = expr in body` (let binding). Other syntax: `()` (unit), `;` (statement separator). Grammar spec in `references/dsl-grammar.md`, 21 examples in `examples/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ plugins/<name>/
 
 ## Plugin Details
 
-**chat-subagent (v0.4.0):** `chat.sh` is a pure bash/curl wrapper for OpenAI-compatible APIs. `thinking-filter.jq` strips reasoning blocks. `probes/` contains 19 diagnostic questions (reasoning, instruction-following, counting, coding). Test the jq filter with `test-thinking-filter.sh`.
+**chat-subagent (v0.3.2):** `chat.sh` is a pure bash/curl wrapper for OpenAI-compatible APIs. `thinking-filter.jq` strips reasoning blocks. `probes/` contains 19 diagnostic questions (reasoning, instruction-following, counting, coding). Test the jq filter with `test-thinking-filter.sh`.
 
 **compose (v0.10.0):** Uses an OCaml binary (`ocaml-compose-dsl`) for DSL validation. Install via `scripts/install.sh` (downloads to `~/.local/bin/`). Validate `.arr` files with `ocaml-compose-dsl pipeline.arr` or Markdown files with `ocaml-compose-dsl --literate doc.md`. Arrow combinators: `>>>` (sequential), `|||` (branch), `***` (parallel), `&&&` (fanout), `?` (question/branch), `loop()` (feedback). Abstraction: `\x -> expr` (lambda), `let x = expr in body` (let binding). Other syntax: `()` (unit), `;` (statement separator). Grammar spec in `references/dsl-grammar.md`, 21 examples in `examples/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ plugins/<name>/
 
 **chat-subagent (v0.3.2):** `chat.sh` is a pure bash/curl wrapper for OpenAI-compatible APIs. `thinking-filter.jq` strips reasoning blocks. `probes/` contains 19 diagnostic questions (reasoning, instruction-following, counting, coding). Test the jq filter with `test-thinking-filter.sh`.
 
-**compose (v0.6.1):** Uses an OCaml binary (`ocaml-compose-dsl`) for DSL validation. Install via `scripts/install.sh` (downloads to `~/.local/bin/`). Validate `.arr` files with `ocaml-compose-dsl pipeline.arr`. Arrow combinators: `>>>` (sequential), `|||` (branch), `***` (parallel), `&&&` (fanout), `?` (question/branch), `loop()` (feedback). Grammar spec in `references/dsl-grammar.md`, 16 examples in `examples/`.
+**compose (v0.10.0):** Uses an OCaml binary (`ocaml-compose-dsl`) for DSL validation. Install via `scripts/install.sh` (downloads to `~/.local/bin/`). Validate `.arr` files with `ocaml-compose-dsl pipeline.arr` or Markdown files with `ocaml-compose-dsl --literate doc.md`. Arrow combinators: `>>>` (sequential), `|||` (branch), `***` (parallel), `&&&` (fanout), `?` (question/branch), `loop()` (feedback). Abstraction: `\x -> expr` (lambda), `let x = expr in body` (let binding). Other syntax: `()` (unit), `;` (statement separator). Grammar spec in `references/dsl-grammar.md`, 21 examples in `examples/`.
 
 **kami (v0.1.0):** Pure dialogue, no runtime dependencies. Grounded in Audrey Tang's 仁工智慧 framework and the Civic AI 6-Pack of Care.
 

--- a/docs/superpowers/plans/2026-03-29-compose-v0100-update.md
+++ b/docs/superpowers/plans/2026-03-29-compose-v0100-update.md
@@ -1,0 +1,789 @@
+# Compose Skill v0.10.0 Update — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the compose skill with upstream `ocaml-compose-dsl` v0.10.0 — adding lambda, let...in, unit type, semicolon statements, and literate mode to all documentation, grammar reference, and examples.
+
+**Architecture:** Documentation-only update. No runtime code changes. The upstream README EBNF is the source of truth for grammar. SKILL.md stays concise as the LLM entry point; detailed grammar lives in `references/dsl-grammar.md`. New `.arr` examples demonstrate new features; selected existing examples get rewritten with let/lambda where it improves clarity.
+
+**Tech Stack:** `ocaml-compose-dsl` binary (v0.10.0) for validation, `gh` CLI for fetching upstream README.
+
+**Spec:** `docs/superpowers/specs/2026-03-29-compose-v0100-update-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `plugins/compose/skills/compose/references/dsl-grammar.md` | Full EBNF grammar reference (rewrite from upstream) |
+| Modify | `plugins/compose/skills/compose/SKILL.md` | LLM entry point — version, combinator table, new sections, patterns |
+| Create | `plugins/compose/skills/compose/examples/lambda.arr` | Lambda expression examples |
+| Create | `plugins/compose/skills/compose/examples/let-binding.arr` | Let...in binding examples |
+| Create | `plugins/compose/skills/compose/examples/unit-type.arr` | Unit value and type examples |
+| Create | `plugins/compose/skills/compose/examples/multi-statement.arr` | Semicolon statement separator examples |
+| Modify | `plugins/compose/skills/compose/examples/frontend-project.arr` | Extract repeated review-loop pattern with let/lambda |
+| Modify | `plugins/compose/skills/compose/examples/ci-pipeline.arr` | Name build pipeline with let |
+| Modify | `plugins/compose/skills/compose/examples/test-fix-loop.arr` | Parameterize loop body with lambda |
+| Modify | `plugins/compose/skills/compose/examples/update-skill-from-upstream.arr` | Rewrite with let/lambda, reflect actual session workflow |
+| Modify | `plugins/compose/skills/compose/README.md` | User-facing docs — features, combinator table, examples |
+| Modify | `.claude-plugin/marketplace.json` | Version bump `0.7.0` → `0.10.0` |
+| Modify | `CLAUDE.md` | Compose description update — version, combinators |
+
+---
+
+### Task 0: Install ocaml-compose-dsl v0.10.0
+
+The binary is not currently installed on this machine. All subsequent validation steps depend on it.
+
+**Files:**
+- Run: `plugins/compose/skills/compose/scripts/install.sh`
+
+- [ ] **Step 1: Run the install script**
+
+```bash
+bash plugins/compose/skills/compose/scripts/install.sh
+```
+
+Expected: downloads `ocaml-compose-dsl-macos-x86_64` to `~/.local/bin/ocaml-compose-dsl`.
+
+- [ ] **Step 2: Verify version**
+
+```bash
+~/.local/bin/ocaml-compose-dsl --version
+```
+
+Expected: output contains `0.10.0`.
+
+- [ ] **Step 3: Ensure binary is in PATH**
+
+If `which ocaml-compose-dsl` fails, add `~/.local/bin` to PATH for this session:
+
+```bash
+export PATH="${HOME}/.local/bin:${PATH}"
+```
+
+---
+
+### Task 1: Rewrite dsl-grammar.md from upstream EBNF
+
+This is the foundation — all other files reference the grammar.
+
+**Files:**
+- Modify: `plugins/compose/skills/compose/references/dsl-grammar.md`
+
+- [ ] **Step 1: Fetch upstream README for the complete EBNF**
+
+```bash
+gh api repos/caasi/ocaml-compose-dsl/contents/README.md --jq '.content' | base64 --decode > /tmp/upstream-readme.md
+```
+
+- [ ] **Step 2: Rewrite dsl-grammar.md**
+
+Replace the entire file. Structure:
+
+1. **Title:** `# Arrow DSL Grammar Reference`
+2. **EBNF section:** Copy the complete grammar from the upstream README verbatim. This includes `program`, `stmt`, `let_expr`, `lambda`, `pipeline`, `seq_expr`, `alt_expr`, `par_expr`, `typed_term`, `type_expr`, `type_name`, `term`, `call_args`, `call_arg`, `arg_key`, `value`, `ident`, `reserved`, `ident_start`, `ident_char`, `string`, `number`, `comment`.
+3. **Prose after EBNF:** Keep the existing explanatory paragraphs (right-associativity, UTF-8 identifiers, typed_term binding level) but update them to reference new productions — `program` as top-level, `stmt` containing `let_expr | pipeline`, semicolons between statements, `reserved` word exclusion, `()` as type name, `call_arg` with positional + named mixing.
+4. **Combinators table:** Expand the existing table. Add rows for:
+   - `\` (lambda): `Arrow a b` (parameterized workflow fragment)
+   - `let...in`: named binding (abstraction, not a combinator per se — note this)
+   - `()` (unit): unit value / type
+   - `;` (semicolon): statement separator — multiple independent pipelines in one program
+5. **Node Design section:** Keep as-is.
+6. **Examples section:** Keep all existing examples. Add new subsections:
+   - **Lambda Expressions** — `\name -> hello(to: name) >>> respond` and multi-param
+   - **Let Bindings** — `let review = ... in ...` and nested lets
+   - **Unit** — `()` standalone, `() >>> start_server :: () -> Server`, `f()` semantics
+   - **Multi-Statement** — `planning >>> commit; implementation >>> branch >>> commit`
+   - **Literate Arrow Documents** — explain `arrow`/`arr` code fence, `.md` convention
+   - **Mixed Call Arguments** — named + positional in the same call: `push(remote: origin, v)` where `v` is a positional pipeline expression
+7. **Structural Rules section:** Keep existing content. Add: semicolons not valid inside parentheses.
+8. **Warnings section:** Keep existing content as-is.
+
+- [ ] **Step 3: Validate the grammar reference with literate mode**
+
+```bash
+ocaml-compose-dsl --literate plugins/compose/skills/compose/references/dsl-grammar.md
+```
+
+Expected: exit 0 (all arrow blocks in the file parse cleanly). If any blocks fail, fix the syntax and re-validate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/compose/skills/compose/references/dsl-grammar.md
+git commit -m "docs(compose): rewrite dsl-grammar.md to match upstream v0.10.0 EBNF"
+```
+
+---
+
+### Task 2: Update SKILL.md
+
+**Files:**
+- Modify: `plugins/compose/skills/compose/SKILL.md`
+
+- [ ] **Step 1: Update version check**
+
+Change line 18 from:
+
+```
+This skill requires **v0.7.0** or later.
+```
+
+to:
+
+```
+This skill requires **v0.10.0** or later.
+```
+
+Also update the comparison text on line 24 from `0.7.0` to `0.10.0`.
+
+- [ ] **Step 2: Update Arrow Combinators table**
+
+In the existing table (lines 30-39):
+- Rename `()` → `(expr)` in the Grouping row (row with "Precedence control")
+- Add new rows after the existing `()` Grouping row:
+
+| `\x -> expr` | Lambda — parameterized workflow fragment | Abstraction (not a tool call) |
+| `let x = expr in body` | Let binding — name a workflow fragment | Abstraction (not a tool call) |
+| `()` | Unit — no-input value or trigger | Standalone value |
+| `;` | Statement separator — multiple independent pipelines | Separate programs |
+
+- [ ] **Step 3: Add Abstraction section**
+
+Insert after the Type Annotations section (after line 66), before "## Workflow":
+
+```markdown
+### Abstraction
+
+Lambda and let bindings are tools for organizing complex workflows — naming reusable fragments and parameterizing patterns. They are part of the DSL, not syntactic sugar that disappears.
+
+**Lambda** creates parameterized workflow fragments:
+
+\```
+\name -> hello(to: name) >>> respond
+\trigger, fix -> loop(trigger >>> (pass ||| fix))
+\```
+
+**Let** names a workflow fragment for reuse:
+
+\```
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+\```
+
+- `let` requires `in` to delimit scope
+- `let...in` works inside parentheses: `(let x = a in x)`
+- Named and positional arguments can be freely mixed: `push(remote: origin, v)` where `v` is a positional expression
+- Reserved words: `let`, `loop`, `in` cannot be used as identifiers
+```
+
+- [ ] **Step 4: Add Statements section**
+
+Insert after the Abstraction section:
+
+```markdown
+### Statements
+
+A program can contain multiple independent pipelines separated by `;`:
+
+\```
+planning :: Doc -> Commit
+  >>> commit(branch: main);
+
+implementation :: Code -> Commit
+  >>> branch(pattern: "feature/*") :: Code -> Branch
+  >>> commit :: Branch -> Commit
+\```
+
+- Trailing semicolon is optional
+- Semicolons are not allowed inside parentheses
+```
+
+- [ ] **Step 5: Add Unit section**
+
+Insert after the Statements section:
+
+```markdown
+### Unit
+
+`()` is a value representing "no input" or "trigger":
+
+\```
+() >>> start_server :: () -> Server
+\```
+
+- `()` is also valid as a type name in annotations: `:: () -> Server`, `:: Input -> ()`
+- `f()` passes Unit as a positional argument — it is not an empty argument list
+```
+
+- [ ] **Step 6: Update Type Annotations section**
+
+In the existing Type Annotations section (around line 57), add a note that `()` is a valid type name:
+
+Add after the existing annotation example:
+
+```
+Type names can be identifiers or `()` (unit): `:: () -> Server`, `:: Input -> ()`.
+```
+
+- [ ] **Step 7: Add literate mode to Workflow section**
+
+In the "Validate Structure" subsection (around line 87), add after the existing `ocaml-compose-dsl pipeline.arr` example:
+
+```markdown
+For Markdown files with embedded arrow blocks (fenced with `arrow` or `arr`):
+
+\```bash
+ocaml-compose-dsl --literate README.md
+\```
+
+Any Markdown file can be a literate Arrow document. Use `arrow` or `arr` as the code fence language tag.
+```
+
+- [ ] **Step 8: Add let/lambda pattern to Common Patterns**
+
+Add a new pattern subsection after existing patterns (around line 170):
+
+```markdown
+### Reusable Review Loop
+
+\```
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+\```
+```
+
+- [ ] **Step 9: Update Examples list in Additional Resources**
+
+Add entries for the four new `.arr` files in the examples list (around line 206):
+
+```markdown
+- **`examples/lambda.arr`** — Lambda expressions: parameterized workflow fragments, multi-param, positional arguments
+- **`examples/let-binding.arr`** — Let bindings: named fragments, nested lets, let inside parentheses, multi-phase composition
+- **`examples/unit-type.arr`** — Unit value and type: `()` standalone, in type annotations, `f()` semantics
+- **`examples/multi-statement.arr`** — Semicolon statement separator: independent pipelines, trailing semicolon
+```
+
+- [ ] **Step 10: Validate SKILL.md with literate mode**
+
+```bash
+ocaml-compose-dsl --literate plugins/compose/skills/compose/SKILL.md
+```
+
+Expected: exit 0. If any arrow blocks fail, fix and re-validate. Note: only blocks fenced with `arrow` or `arr` are checked — standard ``` blocks are ignored.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add plugins/compose/skills/compose/SKILL.md
+git commit -m "docs(compose): update SKILL.md for v0.10.0 — abstraction, statements, unit, literate mode"
+```
+
+---
+
+### Task 3: Create new example files
+
+**Files:**
+- Create: `plugins/compose/skills/compose/examples/lambda.arr`
+- Create: `plugins/compose/skills/compose/examples/let-binding.arr`
+- Create: `plugins/compose/skills/compose/examples/unit-type.arr`
+- Create: `plugins/compose/skills/compose/examples/multi-statement.arr`
+
+- [ ] **Step 1: Create lambda.arr**
+
+```
+-- Lambda expressions: parameterized workflow fragments
+
+-- Basic lambda — single parameter
+\name -> hello(to: name) >>> respond
+
+-- Multi-param lambda — reusable review pattern
+; \trigger, fix -> loop(trigger >>> (pass ||| fix))
+
+-- Lambda as positional argument passed to a node
+; let v = some_pipeline in
+  push(remote: origin, v)
+
+-- Lambda with type annotations
+; \url -> fetch(url: url) :: URL -> HTML
+  >>> parse :: HTML -> Data
+```
+
+- [ ] **Step 2: Validate lambda.arr**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/lambda.arr
+```
+
+Expected: exit 0 with AST output. If it fails, fix syntax and retry.
+
+- [ ] **Step 3: Create let-binding.arr**
+
+```
+-- Let bindings: name and reuse workflow fragments
+
+-- Basic let binding
+let greet = \name -> hello(to: name) >>> respond in
+greet(alice) >>> greet(bob)
+
+-- Nested lets — multi-phase workflow
+; let review = \trigger, fix ->
+    loop(trigger >>> (pass ||| fix))
+  in
+  let phase1 = gather >>> review(check?, rework) in
+  let phase2 = build >>> review(test?, fix) in
+  phase1 >>> phase2
+
+-- Let inside parentheses
+; (let x = fetch(url: primary) in x)
+  ||| fetch(url: mirror)
+
+-- Let binding a value passed as positional arg
+; let v = read(source: "config.yaml") >>> validate in
+  deploy(env: staging, v)
+```
+
+- [ ] **Step 4: Validate let-binding.arr**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/let-binding.arr
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Create unit-type.arr**
+
+```
+-- Unit value and type
+
+-- Unit as a trigger — no meaningful input
+() >>> start_server :: () -> Server
+
+-- Unit in type annotations — both input and output positions
+; healthcheck :: () -> Status
+
+-- f() passes Unit as positional argument (not empty args)
+; noop() >>> continue
+
+-- Unit with question operator
+; ()? >>> (ready ||| wait)
+```
+
+- [ ] **Step 6: Validate unit-type.arr**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/unit-type.arr
+```
+
+Expected: exit 0.
+
+- [ ] **Step 7: Create multi-statement.arr**
+
+```
+-- Semicolon statement separator: independent pipelines in one file
+
+-- Planning and implementation as separate concerns
+planning :: Doc -> Commit
+  >>> commit(branch: main);
+
+implementation :: Code -> Commit
+  >>> branch(pattern: "feature/*") :: Code -> Branch
+  >>> commit :: Branch -> Commit;
+
+-- Trailing semicolon is optional on the last statement
+deploy(env: staging) >>> verify >>> promote(env: production)
+```
+
+- [ ] **Step 8: Validate multi-statement.arr**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/multi-statement.arr
+```
+
+Expected: exit 0.
+
+- [ ] **Step 9: Commit all new examples**
+
+```bash
+git add plugins/compose/skills/compose/examples/lambda.arr \
+        plugins/compose/skills/compose/examples/let-binding.arr \
+        plugins/compose/skills/compose/examples/unit-type.arr \
+        plugins/compose/skills/compose/examples/multi-statement.arr
+git commit -m "feat(compose): add example files for lambda, let-binding, unit-type, multi-statement"
+```
+
+---
+
+### Task 4: Update existing examples — frontend-project.arr
+
+The review-loop pattern `loop(提案? >>> (通過 ||| 修正))` repeats 6 times. Extract with let/lambda.
+
+**Files:**
+- Modify: `plugins/compose/skills/compose/examples/frontend-project.arr`
+
+- [ ] **Step 1: Add let binding at the top of the file**
+
+After the header comments (line 2), insert:
+
+```
+let 審核 = \提案, 修正 ->
+  loop(提案? >>> (通過 ||| 修正))
+in
+```
+
+- [ ] **Step 2: Replace review-loop instances where the pattern fits**
+
+The `審核` lambda fits loops shaped `loop(提案? >>> (通過 ||| 修正))`. Not all 6 review loops in the file match — some have multi-step chains before `?`, non-trivial pass sides, or different structures.
+
+The 6 candidate instances:
+1. Lines 41-45 (內部審查)
+2. Lines 46-49 (客戶簽核 DocuSign)
+3. Lines 59-63 (客戶風格確認)
+4. Lines 119-123 (客戶最終簽核)
+5. Lines 183-188 (PR Code Review) — uses `"approved"?` and `GitHub(任務: merge)` on pass side
+6. Lines 226-230 (客戶驗收) — has multi-step fix pipeline
+
+For each, check:
+- Does the pass side just say `通過`? If it does something else (e.g., `GitHub(任務: merge)`), the `審核` pattern does not fit — leave the original `loop`.
+- Is there a multi-step chain before `?` that doesn't decompose into a single expression? If so, leave it.
+- Only replace instances where the pattern matches cleanly. Expect roughly 3-4 of 6 to fit.
+
+- [ ] **Step 3: Validate**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/frontend-project.arr
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/compose/skills/compose/examples/frontend-project.arr
+git commit -m "refactor(compose): extract review-loop pattern with let/lambda in frontend-project.arr"
+```
+
+---
+
+### Task 5: Update existing examples — ci-pipeline.arr and test-fix-loop.arr
+
+**Files:**
+- Modify: `plugins/compose/skills/compose/examples/ci-pipeline.arr`
+- Modify: `plugins/compose/skills/compose/examples/test-fix-loop.arr`
+
+- [ ] **Step 1: Update ci-pipeline.arr — name the CI pipeline with let**
+
+Replace the entire file content with:
+
+```
+-- Workflow: lint + test, gate, build for multiple platforms, upload
+let ci =
+  (lint &&& test)
+  >>> gate(require: [pass, pass])
+in
+ci
+  >>> (build_linux(profile: static) *** build_macos(profile: release))
+  >>> upload(tag: "v0.1.0")       -- ref: Bash("gh release create")
+```
+
+- [ ] **Step 2: Validate ci-pipeline.arr**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/ci-pipeline.arr
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Update test-fix-loop.arr — parameterize with lambda**
+
+Replace the entire file content with:
+
+```
+-- Workflow: iteratively fix code until tests pass
+-- Parameterized with lambda so the loop can be reused for different targets/suites
+
+let test_fix = \target, suite ->
+  loop(
+    edit(target: target, change: fix)     -- ref: Edit
+      >>> test(suite: suite)              -- ref: Bash("npm test")
+      >>> "all tests pass"?
+      >>> (done ||| retry)               -- exit loop on pass, retry on fail
+  )
+in
+test_fix(code, relevant)
+```
+
+- [ ] **Step 4: Validate test-fix-loop.arr**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/test-fix-loop.arr
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/compose/skills/compose/examples/ci-pipeline.arr \
+        plugins/compose/skills/compose/examples/test-fix-loop.arr
+git commit -m "refactor(compose): introduce let/lambda in ci-pipeline and test-fix-loop examples"
+```
+
+---
+
+### Task 6: Rewrite update-skill-from-upstream.arr
+
+Rewrite to reflect the actual workflow used in this update session and demonstrate let/lambda and semicolons.
+
+**Files:**
+- Modify: `plugins/compose/skills/compose/examples/update-skill-from-upstream.arr`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire file. The new version should:
+
+1. Define a `fetch_upstream` lambda abstracting the repeated fetch+extract pattern
+2. Use `let` to name each phase
+3. Add `fetch_prs` in Phase 1 (reflecting actual use of `gh pr view`)
+4. Add `update(target: "CLAUDE.md")` in Phase 3
+5. Split Phase 4 into "update old examples with new syntax" and "add new examples" more clearly
+6. Add `--literate` validation in Phase 5
+7. Update minimum version to `v0.10.0` in Phase 7
+8. Use `;` to separate phases as independent statements where appropriate
+
+Structure:
+
+```
+-- Workflow: check upstream binary repo and align compose skill to match
+-- Triggers: new release of ocaml-compose-dsl, grammar changes, new features
+-- Covers: docs, examples, metadata (marketplace.json), review cycle
+-- Demonstrates: let/lambda abstraction, semicolons, unit
+
+let fetch_upstream = \repo, fields ->
+  fetch(repo: repo)                      -- ref: Bash("gh api repos/.../releases/latest")
+  >>> extract(fields: fields)
+in
+
+let gather =
+  (fetch_upstream("caasi/ocaml-compose-dsl", [tag_name, body, assets])
+    &&&
+    fetch_upstream("caasi/ocaml-compose-dsl", [grammar, examples, usage])
+    &&&
+    fetch_prs(repo: "caasi/ocaml-compose-dsl")  -- ref: Bash("gh pr view N --json body")
+    &&&
+    read(source: "skills/compose/SKILL.md")
+    &&&
+    read(source: "skills/compose/references/dsl-grammar.md")
+    &&&
+    read(source: "skills/compose/README.md"))
+in
+
+let analyze =
+  diff(upstream: release_info, local: skill_files)
+  >>> plan(changes: required_updates)
+in
+
+let update_docs =
+  update(target: "references/dsl-grammar.md", source: upstream_ebnf)
+  *** update(target: "SKILL.md", sections: [version, combinators, abstraction, statements, unit, workflow, patterns])
+  *** update(target: "README.md", sections: [features, combinators, examples])
+  *** update(target: "CLAUDE.md", sections: [compose_description, version])
+in
+
+let update_examples =
+  (update_examples(dir: "examples/", action: introduce_let_lambda)
+    *** add_examples(dir: "examples/", for: [lambda, let_binding, unit_type, multi_statement]))
+  >>> update(target: "SKILL.md", section: examples_list)
+in
+
+let validate =
+  collect_arr_files(from: "skills/compose/examples/")
+  >>> validate_all(checker: "ocaml-compose-dsl")
+  >>> validate_literate(files: ["SKILL.md", "references/dsl-grammar.md", "README.md"])
+in
+
+let bump_version =
+  update(target: ".claude-plugin/marketplace.json", fields: [version, description])
+in
+
+let verify =
+  check_version(binary: "ocaml-compose-dsl", minimum: "0.10.0")
+in
+
+gather >>> analyze >>> update_docs >>> update_examples >>> validate >>> bump_version >>> verify
+```
+
+- [ ] **Step 2: Validate**
+
+```bash
+ocaml-compose-dsl plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
+git commit -m "refactor(compose): rewrite update-skill-from-upstream.arr with let/lambda"
+```
+
+---
+
+### Task 7: Update README.md
+
+**Files:**
+- Modify: `plugins/compose/skills/compose/README.md`
+
+- [ ] **Step 1: Update "What it does" section**
+
+Add to the bullet list (after line 4):
+
+```markdown
+- Supports abstraction with lambda (`\x -> expr`) and let bindings (`let x = expr in body`) for naming and reusing workflow fragments
+- Validates arrow blocks embedded in Markdown files via literate mode (`--literate`)
+- Supports multiple independent pipelines in one file via semicolon `;` separator
+```
+
+- [ ] **Step 2: Update Arrow Combinators table**
+
+Add rows to the existing table (after line 21):
+
+| `\x -> expr` | Lambda — parameterized fragment | — |
+| `let x = expr in body` | Let binding — named fragment | — |
+| `()` | Unit — no-input value | — |
+| `;` | Statement separator | — |
+
+Rename existing `()` Grouping row to `(expr)`.
+
+- [ ] **Step 3: Add lambda/let example**
+
+Add after the existing examples (around line 42):
+
+```markdown
+\```
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+\```
+```
+
+- [ ] **Step 4: Update "More examples" text**
+
+Update the examples directory description to mention the new example count (21 examples: 17 existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/compose/skills/compose/README.md
+git commit -m "docs(compose): update README.md for v0.10.0 features"
+```
+
+---
+
+### Task 8: Update CLAUDE.md and marketplace.json
+
+**Files:**
+- Modify: `CLAUDE.md` (repo root)
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Update CLAUDE.md compose description**
+
+Replace line 36. Change:
+
+```
+**compose (v0.6.1):** Uses an OCaml binary (`ocaml-compose-dsl`) for DSL validation. Install via `scripts/install.sh` (downloads to `~/.local/bin/`). Validate `.arr` files with `ocaml-compose-dsl pipeline.arr`. Arrow combinators: `>>>` (sequential), `|||` (branch), `***` (parallel), `&&&` (fanout), `?` (question/branch), `loop()` (feedback). Grammar spec in `references/dsl-grammar.md`, 16 examples in `examples/`.
+```
+
+to:
+
+```
+**compose (v0.10.0):** Uses an OCaml binary (`ocaml-compose-dsl`) for DSL validation. Install via `scripts/install.sh` (downloads to `~/.local/bin/`). Validate `.arr` files with `ocaml-compose-dsl pipeline.arr` or Markdown files with `ocaml-compose-dsl --literate doc.md`. Arrow combinators: `>>>` (sequential), `|||` (branch), `***` (parallel), `&&&` (fanout), `?` (question/branch), `loop()` (feedback). Abstraction: `\x -> expr` (lambda), `let x = expr in body` (let binding). Other syntax: `()` (unit), `;` (statement separator). Grammar spec in `references/dsl-grammar.md`, 21 examples in `examples/`.
+```
+
+- [ ] **Step 2: Update marketplace.json**
+
+Change the compose version on line 20:
+
+```json
+"version": "0.7.0"
+```
+
+to:
+
+```json
+"version": "0.10.0"
+```
+
+Also update the compose description on line 19 to include new combinators:
+
+```json
+"description": "Describe multi-step agent workflows using an Arrow-style DSL (>>>, ***, &&&, |||, ?, loop, \\, let...in, (), ;) and validate them structurally"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md .claude-plugin/marketplace.json
+git commit -m "chore(compose): bump version to v0.10.0 in CLAUDE.md and marketplace.json"
+```
+
+---
+
+### Task 9: Final validation
+
+Run all `.arr` examples through the checker and literate-validate all Markdown files with arrow blocks.
+
+**Files:**
+- None modified — validation only
+
+- [ ] **Step 1: Validate all .arr example files**
+
+```bash
+for f in plugins/compose/skills/compose/examples/*.arr; do
+  echo "--- $f ---"
+  ocaml-compose-dsl "$f" > /dev/null && echo "OK" || echo "FAIL: $f"
+done
+```
+
+Expected: all files print `OK`.
+
+- [ ] **Step 2: Validate Markdown files with literate mode**
+
+```bash
+ocaml-compose-dsl --literate plugins/compose/skills/compose/SKILL.md && echo "SKILL.md OK"
+ocaml-compose-dsl --literate plugins/compose/skills/compose/references/dsl-grammar.md && echo "dsl-grammar.md OK"
+ocaml-compose-dsl --literate plugins/compose/skills/compose/README.md && echo "README.md OK"
+```
+
+Expected: all three print `OK`. Note: only code blocks fenced with `arrow` or `arr` are checked. Standard triple-backtick blocks without a language tag or with other language tags (e.g., `bash`, `ebnf`) are ignored.
+
+- [ ] **Step 3: Fix any failures and re-validate**
+
+If any file fails, fix the syntax error and re-run the validation. Commit fixes with:
+
+```bash
+git add <fixed-files>
+git commit -m "fix(compose): fix validation errors in <file>"
+```
+
+- [ ] **Step 4: Verify final file count**
+
+```bash
+ls plugins/compose/skills/compose/examples/*.arr | wc -l
+```
+
+Expected: 21 files (17 existing + 4 new).

--- a/docs/superpowers/plans/2026-03-29-compose-v0100-update.md
+++ b/docs/superpowers/plans/2026-03-29-compose-v0100-update.md
@@ -783,7 +783,7 @@ git commit -m "fix(compose): fix validation errors in <file>"
 - [ ] **Step 4: Verify final file count**
 
 ```bash
-ls plugins/compose/skills/compose/examples/*.arr | wc -l
+ls plugins/compose/skills/compose/examples/*.arr | wc --lines
 ```
 
 Expected: 21 files (17 existing + 4 new).

--- a/docs/superpowers/specs/2026-03-29-compose-v0100-update-design.md
+++ b/docs/superpowers/specs/2026-03-29-compose-v0100-update-design.md
@@ -59,10 +59,11 @@ plugins/compose/skills/compose/
 
 #### Core Concepts — Arrow Combinators Table
 
-Add to existing table:
+Update existing table: rename `()` row from "Grouping" to `(expr)` for clarity, then add new rows:
 
 | Syntax | Meaning |
 |--------|---------|
+| `(expr)` | Grouping — precedence control (rename from `()`) |
 | `\x -> expr` | Lambda — parameterized workflow fragment |
 | `let x = expr in body` | Let binding — name a workflow fragment |
 | `()` | Unit — no-input value or trigger |
@@ -129,30 +130,23 @@ Update the list to include the four new `.arr` files.
 
 ### 3. references/dsl-grammar.md — Full Rewrite
 
-Replace the entire file with the upstream EBNF grammar, adapted for the compose skill context:
+Replace the entire file. The **complete** EBNF is sourced from the upstream README at implementation time (fetch via `gh api repos/caasi/ocaml-compose-dsl/contents/README.md`). Key new productions compared to the current dsl-grammar.md:
 
 ```ebnf
 program     = { ";" } , [ stmt , { ";" , { ";" } , stmt } , { ";" } ] ;
 stmt        = let_expr | pipeline ;
 let_expr    = "let" , ident , "=" , seq_expr , "in" , stmt ;
 lambda      = "\" , ident , { "," , ident } , "->" , seq_expr ;
-pipeline    = seq_expr ;
-seq_expr    = alt_expr , ">>>" , seq_expr | lambda | alt_expr ;
-alt_expr    = par_expr , "|||" , alt_expr | par_expr ;
-par_expr    = typed_term , ( "***" | "&&&" ) , par_expr | typed_term ;
-typed_term  = term , [ "::" , type_expr ] ;
-type_expr   = type_name , "->" , type_name ;
 type_name   = ident | "(" , ")" ;
-term        = ident , [ "(" , [ call_args ] , ")" ] , [ "?" ]
-            | string , [ "?" ]
-            | "(" , ")" , [ "?" ]
-            | "loop" , "(" , seq_expr , ")"
-            | "(" , stmt , ")" ;
+term        = ... | "(" , ")" , [ "?" ] | "(" , stmt , ")" ;
 call_args   = call_arg , { "," , call_arg } ;
 call_arg    = arg_key , ":" , value | seq_expr ;
 arg_key     = ident | "in" ;
-...
+ident       = ident_start , { ident_char } - reserved ;
+reserved    = "let" | "loop" | "in" ;
 ```
+
+The remaining productions (`seq_expr`, `alt_expr`, `par_expr`, `typed_term`, `value`, `number`, `string`, `ident_start`, `ident_char`, `comment`) are copied verbatim from the upstream README. The implementer must fetch the full upstream EBNF — this excerpt highlights only what changed.
 
 Plus: combinator table (including `;`, `\`, `let...in`, `()`), node design section, examples, structural rules, warnings.
 

--- a/docs/superpowers/specs/2026-03-29-compose-v0100-update-design.md
+++ b/docs/superpowers/specs/2026-03-29-compose-v0100-update-design.md
@@ -1,0 +1,236 @@
+# Compose Skill v0.10.0 Update — Design Spec
+
+## Context
+
+The upstream `ocaml-compose-dsl` binary has reached v0.10.0, while the compose skill in dong3 is at v0.7.0. Three upstream releases (v0.8.0, v0.9.0, v0.10.0) have accumulated significant new features. This update aligns the compose skill with the upstream binary.
+
+### Upstream Changelog (v0.7.0 → v0.10.0)
+
+**v0.8.0 (2026-03-26):**
+- Lambda expressions (`\name -> expr`) with beta reduction
+- String literals as first-class expressions
+- Mixed positional/named call arguments (`call_arg = arg_key ":" value | seq_expr`)
+- Literate mode (`--literate` flag) for checking `arrow`/`arr` code blocks in Markdown
+
+**v0.9.0 (PR #29):**
+- **BREAKING:** `let` bindings require explicit `in` keyword (`let x = expr in body`)
+- Parenthesized groups accept `let...in` (`(let x = a in x)`)
+- Migration hint error for old `let` syntax (without `in`)
+
+**v0.10.0 (PRs #30, #31, #32):**
+- Unit value expression and type: `()` as value, `()` as type name in annotations
+- `f()` produces `[Positional Unit]` (not empty args)
+- Semicolon `;` statement separator: `a >>> b; c >>> d`
+- `program = expr list` — multiple independent pipelines in one file
+- `let`, `loop`, `in` are now reserved words (excluded from `ident`)
+- Parser rewritten with Menhir + sedlex (better error messages, no user-facing syntax change)
+
+## Approach
+
+**Upstream sync:** use the upstream README's EBNF as source of truth. Rewrite `dsl-grammar.md` to match. Expand SKILL.md with new sections but keep it concise — detailed grammar stays in `references/`. Skill version jumps to v0.10.0 to align with upstream binary.
+
+If SKILL.md grows too large, offload detail into `references/` and let the LLM discover it.
+
+## Design
+
+### 1. File Structure
+
+```
+plugins/compose/skills/compose/
+  SKILL.md                              # Entry point — concise, core concepts + workflow
+  README.md                             # User-facing docs
+  references/
+    dsl-grammar.md                      # Full EBNF + combinator table (rewrite from upstream)
+  examples/
+    (existing .arr files)               # Some updated to use let/lambda where appropriate
+    lambda.arr                          # NEW
+    let-binding.arr                     # NEW
+    unit-type.arr                       # NEW
+    multi-statement.arr                 # NEW
+  scripts/
+    install.sh                          # No change (already fetches latest)
+```
+
+### 2. SKILL.md Changes
+
+#### Prerequisites / Version Check
+
+- Change minimum version from `v0.7.0` to `v0.10.0`
+
+#### Core Concepts — Arrow Combinators Table
+
+Add to existing table:
+
+| Syntax | Meaning |
+|--------|---------|
+| `\x -> expr` | Lambda — parameterized workflow fragment |
+| `let x = expr in body` | Let binding — name a workflow fragment |
+| `()` | Unit — no-input value or trigger |
+| `;` | Statement separator — multiple independent pipelines |
+
+#### Core Concepts — New Section: Abstraction
+
+Position: after Type Annotations, before Workflow.
+
+Content covers lambda and let as **abstraction tools for organizing complex workflows** — not as reduction targets. Key points:
+
+- Lambda: `\name -> hello(to: name) >>> respond` — parameterized workflow fragment
+- Multi-param lambda: `\trigger, fix -> loop(trigger >>> (pass ||| fix))`
+- Let: `let review = ... in phase1 >>> phase2` — name and reuse workflow fragments
+- `let` requires `in` to delimit scope
+- `let...in` works inside parentheses: `(let x = a in x)`
+- Reserved words: `let`, `loop`, `in` cannot be used as identifiers
+- Named and positional arguments can be freely mixed in calls
+
+Example:
+
+```
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+```
+
+#### Core Concepts — New Section: Statements
+
+- `;` separates independent pipelines: `planning >>> commit; implementation >>> branch >>> commit`
+- Trailing semicolon is optional
+- Semicolons are not allowed inside parentheses
+
+#### Core Concepts — New Section: Unit
+
+- `()` as a value expression: represents "no input" or "trigger"
+- `()` as a type name in annotations: `:: () -> Server`, `:: Input -> ()`
+- `f()` produces `[Positional Unit]`, not an empty argument list
+
+#### Type Annotations
+
+Add that `()` is a valid type name alongside identifiers.
+
+#### Workflow — Validate Structure
+
+Add literate mode after existing file validation:
+
+```bash
+ocaml-compose-dsl --literate README.md
+```
+
+Explain: use `arrow` or `arr` as the code fence language tag. Any Markdown file can be a literate Arrow document.
+
+#### Common Patterns
+
+Add 1-2 patterns using let/lambda (e.g., the `review` abstraction above).
+
+#### Additional Resources — Examples
+
+Update the list to include the four new `.arr` files.
+
+### 3. references/dsl-grammar.md — Full Rewrite
+
+Replace the entire file with the upstream EBNF grammar, adapted for the compose skill context:
+
+```ebnf
+program     = { ";" } , [ stmt , { ";" , { ";" } , stmt } , { ";" } ] ;
+stmt        = let_expr | pipeline ;
+let_expr    = "let" , ident , "=" , seq_expr , "in" , stmt ;
+lambda      = "\" , ident , { "," , ident } , "->" , seq_expr ;
+pipeline    = seq_expr ;
+seq_expr    = alt_expr , ">>>" , seq_expr | lambda | alt_expr ;
+alt_expr    = par_expr , "|||" , alt_expr | par_expr ;
+par_expr    = typed_term , ( "***" | "&&&" ) , par_expr | typed_term ;
+typed_term  = term , [ "::" , type_expr ] ;
+type_expr   = type_name , "->" , type_name ;
+type_name   = ident | "(" , ")" ;
+term        = ident , [ "(" , [ call_args ] , ")" ] , [ "?" ]
+            | string , [ "?" ]
+            | "(" , ")" , [ "?" ]
+            | "loop" , "(" , seq_expr , ")"
+            | "(" , stmt , ")" ;
+call_args   = call_arg , { "," , call_arg } ;
+call_arg    = arg_key , ":" , value | seq_expr ;
+arg_key     = ident | "in" ;
+...
+```
+
+Plus: combinator table (including `;`, `\`, `let...in`, `()`), node design section, examples, structural rules, warnings.
+
+### 4. New Example Files
+
+**`lambda.arr`:**
+- Basic lambda: `\name -> hello(to: name) >>> respond`
+- Multi-param: `\trigger, fix -> loop(trigger >>> (pass ||| fix))`
+- As positional arg: `let v = some_pipeline in push(remote: origin, v)`
+
+**`let-binding.arr`:**
+- Named workflow fragments with `let...in`
+- Nested lets
+- `let` inside parentheses: `(let x = a in x)`
+- Multi-phase workflow composition using let
+
+**`unit-type.arr`:**
+- `()` as standalone value
+- `() >>> start_server :: () -> Server`
+- `f()` semantics
+- `()` in type annotations
+
+**`multi-statement.arr`:**
+- `;`-separated independent pipelines
+- Trailing semicolon
+- Real-world example: planning + implementation as separate statements
+
+### 5. Existing Example Updates
+
+**Candidates for let/lambda introduction:**
+
+- **`frontend-project.arr`** (230 lines) — repeated pipeline fragments → extract with let/lambda
+- **`ci-pipeline.arr`** — build steps → name with let
+- **`test-fix-loop.arr`** — loop body → parameterize with lambda
+- **`update-skill-from-upstream.arr`** — reorganize with let, reflect actual session workflow (see section 7)
+
+**Leave unchanged:**
+- `data-pipeline.arr`, `resilient-fetch.arr`, `numeric-literals.arr`, `unicode-identifiers.arr`, `mixed-par-fanout.arr`, `question-operator.arr`, `type-annotations.arr` — these demonstrate basic syntax and work as foundation examples
+- OSINT examples — domain-specific, no benefit from abstraction
+
+### 6. Version Bumps and Metadata
+
+| File | Field | Old | New |
+|------|-------|-----|-----|
+| `marketplace.json` | compose version | `0.7.0` | `0.10.0` |
+| `SKILL.md` | Version Check text | `v0.7.0` | `v0.10.0` |
+
+`plugin.json` has no version field — no change. `install.sh` already fetches latest — no change.
+
+### 7. update-skill-from-upstream.arr Rewrite
+
+Rewrite to reflect what we actually did in this session, using let/lambda to organize phases:
+
+**New elements:**
+- `let fetch_upstream = \repo -> ...` — abstract the fetch+extract pattern (used twice)
+- `let` to name each phase
+- Phase 1: add `fetch_prs` (we used `gh pr view` to understand new features)
+- Phase 3: add `update(target: "CLAUDE.md")` — repo root CLAUDE.md also needs updating
+- Phase 4: clearer split between "update old examples with new syntax" and "add new examples"
+- Phase 5: add `--literate` validation for SKILL.md/README arrow blocks
+- Phase 6: minimum version → `v0.10.0`
+- Potentially use `;` to separate independent phases
+
+### 8. README.md Updates
+
+- "What it does" — add lambda/let abstraction, literate mode, multi-statement
+- Arrow Combinators table — add `\`, `let...in`, `()`, `;`
+- Examples — add a short demo of lambda/let
+- Install section — no change
+
+### 9. CLAUDE.md (repo root) Updates
+
+- Compose description: add `let...in`, `\` (lambda), `;`, `()` to the Arrow combinators list
+- Version reference: `v0.10.0`
+
+## Out of Scope
+
+- Changes to `install.sh` (already fetches latest)
+- Changes to `plugin.json` (no version field)
+- New OSINT examples
+- Type checker implementation (upstream has none, annotations remain documentation-only)

--- a/plugins/compose/skills/compose/README.md
+++ b/plugins/compose/skills/compose/README.md
@@ -8,6 +8,9 @@ A Claude Code skill for describing multi-step agent workflows using an Arrow-sty
 - Validates pipeline structure with a pre-built binary checker (parse errors, unbalanced branches) and emits warnings (`?` without `|||`)
 - Saves successful pipelines as `.arr` files for reuse across conversations
 - Provides common patterns: sequential, parallel, branch/fallback, and feedback loops
+- Supports abstraction with lambda (`\x -> expr`) and let bindings (`let x = expr in body`) for naming and reusing workflow fragments
+- Validates arrow blocks embedded in Markdown files via literate mode (`--literate`)
+- Supports multiple independent pipelines in one file via semicolon `;` separator
 
 ## Arrow Combinators
 
@@ -19,6 +22,10 @@ A Claude Code skill for describing multi-step agent workflows using an Arrow-sty
 | `&&&` | Fanout — run both on same input | infixr 3 |
 | `loop()` | Feedback — repeat body iteratively | — |
 | `?` | Question — marks step as producing Either | — |
+| `\x -> expr` | Lambda — parameterized fragment | — |
+| `let x = expr in body` | Let binding — named fragment | — |
+| `()` | Unit — no-input value | — |
+| `;` | Statement separator | — |
 
 ## Examples
 
@@ -43,7 +50,16 @@ read(source: "data.csv")
   >>> 出力
 ```
 
-More examples in `examples/` — including a meta-workflow that describes how this skill updates itself from the upstream repo.
+```
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+```
+
+21 examples in `examples/` — including a meta-workflow that describes how this skill updates itself from the upstream repo.
 
 ## Install
 

--- a/plugins/compose/skills/compose/README.md
+++ b/plugins/compose/skills/compose/README.md
@@ -51,7 +51,7 @@ read(source: "data.csv")
   >>> 出力
 ```
 
-```
+```arrow
 let review = \trigger, fix ->
   loop(trigger >>> (pass ||| fix))
 in

--- a/plugins/compose/skills/compose/README.md
+++ b/plugins/compose/skills/compose/README.md
@@ -22,6 +22,7 @@ A Claude Code skill for describing multi-step agent workflows using an Arrow-sty
 | `&&&` | Fanout — run both on same input | infixr 3 |
 | `loop()` | Feedback — repeat body iteratively | — |
 | `?` | Question — marks step as producing Either | — |
+| `(expr)` | Grouping | — |
 | `\x -> expr` | Lambda — parameterized fragment | — |
 | `let x = expr in body` | Let binding — named fragment | — |
 | `()` | Unit — no-input value | — |

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -100,7 +100,7 @@ phase1 >>> phase2
 
 A program can contain multiple independent pipelines separated by `;`:
 
-```
+```arrow
 planning :: Doc -> Commit
   >>> commit(branch: main);
 
@@ -116,7 +116,7 @@ implementation :: Code -> Commit
 
 `()` is a value representing "no input" or "trigger":
 
-```
+```arrow
 () >>> start_server :: () -> Server
 ```
 
@@ -269,7 +269,7 @@ Error positions report codepoint-level columns, not byte offsets, so diagnostics
 
 ### Reusable Review Loop
 
-```
+```arrow
 let review = \trigger, fix ->
   loop(trigger >>> (pass ||| fix))
 in

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -307,7 +307,7 @@ The following OSINT examples are illustrative and should be used only in lawful,
 - **`examples/osint-geolocation.arr`** — Geolocate facilities from broadcast footage by cross-referencing with satellite imagery
 - **`examples/osint-media-monitoring.arr`** — Monitor state media for military unit designations and map to known bases
 - **`examples/osint-infrastructure-change.arr`** — Temporal satellite imagery comparison to detect new military construction
-- **`examples/frontend-project.arr`** — Full product lifecycle: discovery → outsourced design → handoff → in-house implementation → delivery. Stress-tests all combinators at 230 lines
+- **`examples/frontend-project.arr`** — Full product lifecycle: discovery → outsourced design → handoff → in-house implementation → delivery. Stress-tests all combinators at 225 lines
 
 Use these as starting points: copy, modify node names/arguments, and validate with `ocaml-compose-dsl`.
 

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -75,14 +75,14 @@ Lambda and let bindings are tools for organizing complex workflows — naming re
 
 **Lambda** creates parameterized workflow fragments:
 
-```
+```arrow
 \name -> hello(to: name) >>> respond
 \trigger, fix -> loop(trigger >>> (pass ||| fix))
 ```
 
 **Let** names a workflow fragment for reuse:
 
-```
+```arrow
 let review = \trigger, fix ->
   loop(trigger >>> (pass ||| fix))
 in

--- a/plugins/compose/skills/compose/SKILL.md
+++ b/plugins/compose/skills/compose/SKILL.md
@@ -15,13 +15,13 @@ Ensure `~/.local/bin` is in `PATH`.
 
 ### Version Check
 
-This skill requires **v0.7.0** or later. After confirming the binary exists, verify the version:
+This skill requires **v0.10.0** or later. After confirming the binary exists, verify the version:
 
 ```bash
 ocaml-compose-dsl --version
 ```
 
-If the output is lower than `0.7.0` or the `--version` flag is not recognized, the binary is outdated. Offer to re-run `scripts/install.sh` to upgrade to the latest release.
+If the output is lower than `0.10.0` or the `--version` flag is not recognized, the binary is outdated. Offer to re-run `scripts/install.sh` to upgrade to the latest release.
 
 ## Core Concepts
 
@@ -35,7 +35,11 @@ If the output is lower than `0.7.0` or the `--version` flag is not recognized, t
 | `&&&` | Fanout — run both on same input (infixr 3) | Multiple tool calls, same input |
 | `loop()` | Feedback — repeat body iteratively | Retry / iterative refinement |
 | `?` | Question — marks step as producing Either | Branching via `\|\|\|` |
-| `()` | Grouping | Precedence control |
+| `(expr)` | Grouping | Precedence control |
+| `\x -> expr` | Lambda — parameterized workflow fragment | Abstraction (not a tool call) |
+| `let x = expr in body` | Let binding — name a workflow fragment | Abstraction (not a tool call) |
+| `()` | Unit — no-input value or trigger | Standalone value |
+| `;` | Statement separator — multiple independent pipelines | Separate programs |
 
 All operators are **right-associative**. `***` and `&&&` bind tighter than `|||`, which binds tighter than `>>>`.
 
@@ -62,6 +66,62 @@ fetch(url: "https://example.com") :: URL -> HTML
 ```
 
 Annotations document intended data flow for humans and agents reading the pipeline. The checker parses them but performs no type checking.
+
+Type names can be identifiers or `()` (unit): `:: () -> Server`, `:: Input -> ()`.
+
+### Abstraction
+
+Lambda and let bindings are tools for organizing complex workflows — naming reusable fragments and parameterizing patterns. They are part of the DSL, not syntactic sugar that disappears.
+
+**Lambda** creates parameterized workflow fragments:
+
+```
+\name -> hello(to: name) >>> respond
+\trigger, fix -> loop(trigger >>> (pass ||| fix))
+```
+
+**Let** names a workflow fragment for reuse:
+
+```
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+```
+
+- `let` requires `in` to delimit scope
+- `let...in` works inside parentheses: `(let x = a in x)`
+- Named and positional arguments can be freely mixed: `push(remote: origin, v)` where `v` is a positional expression
+- Reserved words: `let`, `loop`, `in` cannot be used as identifiers
+
+### Statements
+
+A program can contain multiple independent pipelines separated by `;`:
+
+```
+planning :: Doc -> Commit
+  >>> commit(branch: main);
+
+implementation :: Code -> Commit
+  >>> branch(pattern: "feature/*") :: Code -> Branch
+  >>> commit :: Branch -> Commit
+```
+
+- Trailing semicolon is optional
+- Semicolons are not allowed inside parentheses
+
+### Unit
+
+`()` is a value representing "no input" or "trigger":
+
+```
+() >>> start_server :: () -> Server
+```
+
+- `()` is also valid as a type name in annotations: `:: () -> Server`, `:: Input -> ()`
+- `f()` passes Unit as a positional argument — it is not an empty argument list
 
 For detailed grammar (EBNF), combinators, and examples, consult **`references/dsl-grammar.md`**.
 
@@ -91,6 +151,14 @@ Or from a file:
 ```bash
 ocaml-compose-dsl pipeline.arr
 ```
+
+For Markdown files with embedded arrow blocks (fenced with `arrow` or `arr`):
+
+```bash
+ocaml-compose-dsl --literate README.md
+```
+
+Any Markdown file can be a literate Arrow document. Use `arrow` or `arr` as the code fence language tag.
 
 The binary exits `0` with AST output (OCaml constructor format) on valid input, `1` with error messages (with `line:col` positions) on structural problems. Warnings go to stderr without affecting exit code. Fix any structural errors before proceeding.
 
@@ -199,6 +267,17 @@ Node names, argument keys, and unit suffixes support full UTF-8 identifiers, inc
 
 Error positions report codepoint-level columns, not byte offsets, so diagnostics stay accurate for multibyte characters.
 
+### Reusable Review Loop
+
+```
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+```
+
 ## Additional Resources
 
 ### Examples
@@ -215,6 +294,10 @@ The `examples/` directory contains ready-to-use `.arr` files demonstrating commo
 - **`examples/unicode-identifiers.arr`** — Unicode node names, argument keys, and unit suffixes with non-Latin scripts
 - **`examples/question-operator.arr`** — Question operator `?`: marking steps as producing Either for `|||` branching
 - **`examples/type-annotations.arr`** — Type annotation syntax (`:: Ident -> Ident`) on sequential, parallel, fanout, loop, and question terms
+- **`examples/lambda.arr`** — Lambda expressions: parameterized workflow fragments, multi-param, positional arguments
+- **`examples/let-binding.arr`** — Let bindings: named fragments, nested lets, let inside parentheses, multi-phase composition
+- **`examples/unit-type.arr`** — Unit value and type: `()` standalone, in type annotations, `f()` semantics
+- **`examples/multi-statement.arr`** — Semicolon statement separator: independent pipelines, trailing semicolon
 
 The following OSINT examples are illustrative and should be used only in lawful, ToS-compliant, and privacy-respecting contexts. Person-targeting examples model defensive workflows (tracing dox attackers) and include de-identification, public methodology disclosure, and legal reporting steps.
 

--- a/plugins/compose/skills/compose/examples/ci-pipeline.arr
+++ b/plugins/compose/skills/compose/examples/ci-pipeline.arr
@@ -1,5 +1,8 @@
--- Workflow: lint + test in parallel (fanout), gate, build for multiple platforms, upload
-(lint &&& test)
+-- Workflow: lint + test, gate, build for multiple platforms, upload
+let ci =
+  (lint &&& test)
   >>> gate(require: [pass, pass])
+in
+ci
   >>> (build_linux(profile: static) *** build_macos(profile: release))
   >>> upload(tag: "v0.1.0")       -- ref: Bash("gh release create")

--- a/plugins/compose/skills/compose/examples/frontend-project.arr
+++ b/plugins/compose/skills/compose/examples/frontend-project.arr
@@ -1,6 +1,10 @@
 -- Frontend project: client request to production delivery
 -- 外包設計 + 內部開發的完整產品流程
 
+let 審核 = \提案, 修正 ->
+  loop(提案? >>> (通過 ||| 修正))
+in
+
 -- Phase 1: Discovery
 (
   Google_Meet(對象: 利害關係人, 目的: 需求訪談) :: 專案 -> 訪談紀錄
@@ -38,15 +42,8 @@
 )
 >>> Claude(任務: 需求規格書草稿) :: Discovery產出 -> 規格草稿
 >>> Notion(文件: 需求規格書定稿) :: 規格草稿 -> 規格書
->>> loop(
-  Google_Meet(目的: 內部審查會議) :: 規格書 -> 審查紀錄
-  >>> 內部審查? :: 審查紀錄 -> Either
-  >>> (通過 :: Either -> 規格書 ||| (Claude(任務: 修正需求規格書) :: Either -> 修正稿 >>> Notion(文件: 需求規格書更新) :: 修正稿 -> 規格書))
-)
->>> loop(
-  DocuSign(對象: 客戶, 文件: 需求規格書)? :: 規格書 -> Either
-  >>> (通過 :: Either -> 規格書 ||| (Claude(任務: 依客戶意見修正) :: Either -> 修正稿 >>> Notion(文件: 需求規格書更新) :: 修正稿 -> 規格書))
-)
+>>> 審核(Google_Meet(目的: 內部審查會議) >>> 內部審查, Claude(任務: 修正需求規格書) >>> Notion(文件: 需求規格書更新))
+>>> 審核(DocuSign(對象: 客戶, 文件: 需求規格書), Claude(任務: 依客戶意見修正) >>> Notion(文件: 需求規格書更新))
 
 -- Phase 2: Design (outsourced)
 >>> (
@@ -56,11 +53,7 @@
   Figma(任務: 品牌風格探索, 面向: 色彩) :: 靈感素材 -> 色彩方案 &&& Figma(任務: 品牌風格探索, 面向: 字型) :: 靈感素材 -> 字型方案
 )
 >>> Miro(任務: Moodboard彙整) :: 風格素材 -> Moodboard
->>> loop(
-  Loom(任務: 風格方向提案) :: Moodboard -> 提案影片
-  >>> 客戶風格確認? :: 提案影片 -> Either
-  >>> (通過 :: Either -> 風格定稿 ||| Figma(任務: 風格方向修正) :: Either -> Moodboard)
-)
+>>> 審核(Loom(任務: 風格方向提案) >>> 客戶風格確認, Figma(任務: 風格方向修正))
 >>> (
   Figma(任務: Wireframe, 裝置: mobile) :: 風格定稿 -> 線框稿 >>> Figma(任務: 互動流程, 裝置: mobile) :: 線框稿 -> 互動稿
   &&&
@@ -116,11 +109,7 @@
 >>> Figma(任務: 設計修正, 輪次: 1) :: 改善建議 -> 修正稿
 >>> Maze(任務: 修正後驗證測試) :: 修正稿 -> 驗證結果
 >>> Figma(任務: 設計修正, 輪次: 2) :: 驗證結果 -> 設計完稿
->>> loop(
-  Loom(任務: 最終設計簡報) :: 設計完稿 -> 簡報影片
-  >>> 客戶最終簽核? :: 簡報影片 -> Either
-  >>> (通過 :: Either -> 設計定版 ||| Figma(任務: 設計修正_依客戶意見) :: Either -> 設計完稿)
-)
+>>> 審核(Loom(任務: 最終設計簡報) >>> 客戶最終簽核, Figma(任務: 設計修正_依客戶意見))
 
 -- Phase 3: Handoff
 >>> Figma(任務: Dev_Mode啟用) :: 設計定版 -> DevMode稿

--- a/plugins/compose/skills/compose/examples/lambda.arr
+++ b/plugins/compose/skills/compose/examples/lambda.arr
@@ -1,0 +1,19 @@
+-- Lambda expressions: parameterized workflow fragments
+
+-- Basic lambda — single parameter, bound and applied
+let greet = \name -> hello(to: name) >>> respond in
+greet(world)
+
+-- Multi-param lambda — reusable review pattern
+; let review = \trigger, fix -> loop(trigger >>> (pass ||| fix)) in
+  review(check?, rework)
+
+-- Lambda as positional argument passed to a node
+; let v = some_pipeline in
+  push(remote: origin, v)
+
+-- Lambda with type annotations
+; let process = \url -> fetch(url: url) :: URL -> HTML
+    >>> parse :: HTML -> Data
+  in
+  process(target)

--- a/plugins/compose/skills/compose/examples/lambda.arr
+++ b/plugins/compose/skills/compose/examples/lambda.arr
@@ -8,7 +8,7 @@ greet(world)
 ; let review = \trigger, fix -> loop(trigger >>> (pass ||| fix)) in
   review(check?, rework)
 
--- Lambda as positional argument passed to a node
+-- Let-bound pipeline as positional argument passed to a node
 ; let v = some_pipeline in
   push(remote: origin, v)
 

--- a/plugins/compose/skills/compose/examples/let-binding.arr
+++ b/plugins/compose/skills/compose/examples/let-binding.arr
@@ -1,0 +1,21 @@
+-- Let bindings: name and reuse workflow fragments
+
+-- Basic let binding
+let greet = \name -> hello(to: name) >>> respond in
+greet(alice) >>> greet(bob)
+
+-- Nested lets — multi-phase workflow
+; let review = \trigger, fix ->
+    loop(trigger >>> (pass ||| fix))
+  in
+  let phase1 = gather >>> review(check?, rework) in
+  let phase2 = build >>> review(test?, fix) in
+  phase1 >>> phase2
+
+-- Let inside parentheses
+; (let x = fetch(url: primary) in x)
+  ||| fetch(url: mirror)
+
+-- Let binding a value passed as positional arg
+; let v = read(source: "config.yaml") >>> validate in
+  deploy(env: staging, v)

--- a/plugins/compose/skills/compose/examples/multi-statement.arr
+++ b/plugins/compose/skills/compose/examples/multi-statement.arr
@@ -1,0 +1,12 @@
+-- Semicolon statement separator: independent pipelines in one file
+
+-- Planning and implementation as separate concerns
+planning :: Doc -> Commit
+  >>> commit(branch: main);
+
+implementation :: Code -> Commit
+  >>> branch(pattern: "feature/*") :: Code -> Branch
+  >>> commit :: Branch -> Commit;
+
+-- Trailing semicolon is optional on the last statement
+deploy(env: staging) >>> verify >>> promote(env: production)

--- a/plugins/compose/skills/compose/examples/test-fix-loop.arr
+++ b/plugins/compose/skills/compose/examples/test-fix-loop.arr
@@ -1,7 +1,12 @@
 -- Workflow: iteratively fix code until tests pass
-loop(
-  edit(target: code, change: fix)     -- ref: Edit
-    >>> test(suite: relevant)         -- ref: Bash("npm test")
-    >>> "all tests pass"?
-    >>> (done ||| retry)              -- exit loop on pass, retry on fail
-)
+-- Parameterized with lambda so the loop can be reused for different targets/suites
+
+let test_fix = \target, suite ->
+  loop(
+    edit(target: target, change: fix)     -- ref: Edit
+      >>> test(suite: suite)              -- ref: Bash("npm test")
+      >>> "all tests pass"?
+      >>> (done ||| retry)               -- exit loop on pass, retry on fail
+  )
+in
+test_fix(code, relevant)

--- a/plugins/compose/skills/compose/examples/unit-type.arr
+++ b/plugins/compose/skills/compose/examples/unit-type.arr
@@ -1,0 +1,13 @@
+-- Unit value and type
+
+-- Unit as a trigger — no meaningful input
+() >>> start_server :: () -> Server
+
+-- Unit in type annotations — both input and output positions
+; healthcheck :: () -> Status
+
+-- f() passes Unit as positional argument (not empty args)
+; noop() >>> continue
+
+-- Unit with question operator
+; ()? >>> (ready ||| wait)

--- a/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
+++ b/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
@@ -59,4 +59,8 @@ let verify =
   check_version(binary: "ocaml-compose-dsl", minimum: "0.10.0")
 in
 
+-- Main pipeline
 gather >>> analyze >>> update_docs >>> update_examples >>> validate >>> bump_version >>> verify
+
+-- Separate statement: signal completion with unit trigger
+; () >>> notify(channel: "compose-updates", status: done)

--- a/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
+++ b/plugins/compose/skills/compose/examples/update-skill-from-upstream.arr
@@ -1,53 +1,62 @@
 -- Workflow: check upstream binary repo and align compose skill to match
 -- Triggers: new release of ocaml-compose-dsl, grammar changes, new features
--- Covers: docs, examples, metadata (marketplace.json, plugin.json), review cycle
+-- Covers: docs, examples, metadata (marketplace.json), review cycle
+-- Demonstrates: let/lambda abstraction, semicolons, unit
 
--- Phase 1: gather current state from upstream and local skill
--- Note: >>> binds looser than &&&, so each seq chain needs explicit grouping
-(
-  (fetch_release(repo: "caasi/ocaml-compose-dsl") -- ref: Bash("gh api repos/.../releases/latest")
-    >>> extract(fields: [tag_name, body, assets])) -- release version, changelog, binary assets
-  &&&
-  (fetch_readme(repo: "caasi/ocaml-compose-dsl")  -- ref: Bash("gh api repos/.../contents/README.md")
-    >>> extract(fields: [grammar, examples, usage])) -- new EBNF, examples, CLI flags
-  &&&
-  read(source: "skills/compose/SKILL.md")          -- ref: Read
-  &&&
-  read(source: "skills/compose/references/dsl-grammar.md") -- ref: Read
-  &&&
-  read(source: "skills/compose/README.md")         -- ref: Read
-)
-  -- Phase 2: diff upstream vs local, produce change list
-  >>> diff(upstream: release_info, local: skill_files) -- ref: Agent("compare grammar, combinators, CLI flags, examples")
-  >>> plan(changes: required_updates)                  -- ref: Agent("list what needs updating")
+let fetch_release = \repo ->
+  fetch(repo: repo)                      -- ref: Bash("gh api repos/.../releases/latest")
+  >>> extract(fields: [tag_name, body, assets])
+in
 
-  -- Phase 3: apply doc and grammar updates in parallel
-  >>> (
-    update(target: "references/dsl-grammar.md", sections: [ebnf, combinators, examples, warnings]) -- ref: Edit
-    ***
-    update(target: "SKILL.md", sections: [version, combinators, workflow, patterns, warnings])      -- ref: Edit
-    ***
-    update(target: "README.md", sections: [combinators, loop_description])                          -- ref: Edit
-  )
+let fetch_readme = \repo ->
+  fetch(repo: repo)                      -- ref: Bash("gh api repos/.../contents/README.md")
+  >>> extract(fields: [grammar, examples, usage])
+in
 
-  -- Phase 4: update existing examples to new syntax + add new examples
-  >>> (
-    update_examples(dir: "examples/", action: migrate_syntax)  -- ref: Edit (e.g. replace evaluate with ? + |||)
-    ***
-    add_examples(dir: "examples/", for: new_features)          -- ref: Write (e.g. question-operator.arr)
-  )
-  >>> update(target: "SKILL.md", section: examples_list)       -- ref: Edit (add new entries, fix stale descriptions)
+let gather =
+  (fetch_release("caasi/ocaml-compose-dsl")
+    &&&
+    fetch_readme("caasi/ocaml-compose-dsl")
+    &&&
+    fetch_prs(repo: "caasi/ocaml-compose-dsl")  -- ref: Bash("gh pr view N --json body")
+    &&&
+    read(source: "skills/compose/SKILL.md")
+    &&&
+    read(source: "skills/compose/references/dsl-grammar.md")
+    &&&
+    read(source: "skills/compose/README.md"))
+in
 
-  -- Phase 5: validate all .arr files still parse
-  >>> collect_arr_files(from: "skills/compose/examples/")      -- ref: Glob("**/*.arr")
-  >>> validate_all(checker: "ocaml-compose-dsl")               -- ref: Bash("ocaml-compose-dsl *.arr")
+let analyze =
+  diff(upstream: release_info, local: skill_files)
+  >>> plan(changes: required_updates)
+in
 
-  -- Phase 6: bump version and descriptions in metadata
-  >>> (
-    update(target: ".claude-plugin/marketplace.json", fields: [version, description]) -- ref: Edit
-    ***
-    update(target: "plugins/compose/.claude-plugin/plugin.json", fields: [description]) -- ref: Edit
-  )
+let update_docs =
+  update(target: "references/dsl-grammar.md", source: upstream_ebnf)
+  *** update(target: "SKILL.md", sections: [version, combinators, abstraction, statements, unit, workflow, patterns])
+  *** update(target: "README.md", sections: [features, combinators, examples])
+  *** update(target: "CLAUDE.md", sections: [compose_description, version])
+in
 
-  -- Phase 7: verify binary version matches skill requirement
-  >>> check_version(binary: "ocaml-compose-dsl", minimum: "0.6.1") -- ref: Bash("ocaml-compose-dsl --version")
+let update_examples =
+  (update_examples(dir: "examples/", action: introduce_let_lambda)
+    *** add_examples(dir: "examples/", for: [lambda, let_binding, unit_type, multi_statement]))
+  >>> update(target: "SKILL.md", section: examples_list)
+in
+
+let validate =
+  collect_arr_files(from: "skills/compose/examples/")
+  >>> validate_all(checker: "ocaml-compose-dsl")
+  >>> validate_literate(files: ["SKILL.md", "references/dsl-grammar.md", "README.md"])
+in
+
+let bump_version =
+  update(target: ".claude-plugin/marketplace.json", fields: [version, description])
+in
+
+let verify =
+  check_version(binary: "ocaml-compose-dsl", minimum: "0.10.0")
+in
+
+gather >>> analyze >>> update_docs >>> update_examples >>> validate >>> bump_version >>> verify

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -69,7 +69,8 @@ ident_char  = ? any valid UTF-8 codepoint that is not ASCII whitespace,
 
 string   = '"' , { ? any valid UTF-8 codepoint except '"' ? } , '"' ;
 
-number     = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , [ ident_start , { ident_char } ] ;
+digit    = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+number   = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , [ ident_start , { ident_char } ] ;
 
 comment  = "--" , { any char - newline } ;
 ```

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -59,10 +59,10 @@ ident       = ident_start , { ident_char } - reserved ;
 reserved    = "let" | "loop" | "in" ;
 ident_start = ? any valid UTF-8 codepoint that is not an ASCII digit,
                 not ASCII whitespace, and not one of ( ) [ ] : , > * | & - " .
-                ! # $ % ^ + = { } < ; ' ` ~ / ? @ \ ? ;
+                ! # $ % ^ + = { } < ; ' ` ~ / QUESTION MARK @ \ ? ;
 ident_char  = ? any valid UTF-8 codepoint that is not ASCII whitespace,
                 and not one of ( ) [ ] : , > * | & " .
-                ! # $ % ^ + = { } < ; ' ` ~ / ? @ \ ? ;
+                ! # $ % ^ + = { } < ; ' ` ~ / QUESTION MARK @ \ ? ;
                 (* note: "-" is a valid ident_char, but the lexer stops
                    before "->" so that the arrow token is recognized
                    even without surrounding whitespace *)

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -3,34 +3,50 @@
 ## EBNF
 
 ```ebnf
+program     = { ";" } , [ stmt , { ";" , { ";" } , stmt } , { ";" } ] ;
+
+stmt        = let_expr | pipeline ;
+
+let_expr    = "let" , ident , "=" , seq_expr , "in" , stmt ;
+
+lambda  = "\" , ident , { "," , ident } , "->" , seq_expr ;
+                                                    (* body is seq_expr, not stmt;
+                                                       let_expr is only valid at stmt level
+                                                       or inside grouping parens *)
+
 pipeline = seq_expr ;
 
 seq_expr = alt_expr , ">>>" , seq_expr              (* sequential — infixr 1 *)
+         | lambda
          | alt_expr ;
 alt_expr = par_expr , "|||" , alt_expr              (* branch — infixr 2 *)
          | par_expr ;
-par_expr = typed_term , ( "***" | "&&&" ) , par_expr      (* parallel / fanout — infixr 3 *)
-         | typed_term ;
+par_expr    = typed_term , ( "***" | "&&&" ) , par_expr (* parallel / fanout — infixr 3 *)
+            | typed_term ;
 
-typed_term = term , [ "::" , type_expr ] ;             (* optional type annotation *)
+typed_term  = term , [ "::" , type_expr ] ;
 
-type_expr  = ident , "->" , ident ;
+type_expr   = type_name , "->" , type_name ;
+type_name   = ident | "(" , ")" ;
 
-question_term = string , "?"                       (* question — produces Either *)
-              | node , "?"
-              ;
-
-term     = node
+term     = ident , [ "(" , [ call_args ] , ")" ] , [ "?" ]
+                                                    (* ident with optional args and question *)
+         | string , [ "?" ]                        (* string literal, optionally question;
+                                                      AST represents both as Question(expr) *)
+         | "(" , ")" , [ "?" ]                     (* unit value, with optional question *)
          | "loop" , "(" , seq_expr , ")"            (* feedback loop *)
-         | "(" , seq_expr , ")"                    (* grouping *)
-         | question_term
+         | "(" , stmt , ")"                        (* grouping — allows let bindings
+                                                      but not semicolons inside parens *)
          ;
 
-node     = ident , [ "(" , [ args ] , ")" ] ;
-
-args     = arg , { "," , arg } ;
-
-arg      = ident , ":" , value ;
+call_args = call_arg , { "," , call_arg } ;
+                                                    (* empty call_args in f() produces
+                                                       [Positional Unit], not an empty list;
+                                                       zero-arg application is eliminated *)
+call_arg  = arg_key , ":" , value                   (* Named — per-arg disambiguation via key ":" *)
+          | seq_expr                                (* Positional — any expression *)
+          ;
+arg_key   = ident | "in" ;                          (* reserved words allowed as named arg keys *)
 
 value    = string
          | number
@@ -38,28 +54,37 @@ value    = string
          | "[" , [ value , { "," , value } ] , "]"
          ;
 
-ident       = ident_start , { ident_char } ;
+ident       = ident_start , { ident_char } - reserved ;
+                (* reserved words are excluded at the lexer level *)
+reserved    = "let" | "loop" | "in" ;
 ident_start = ? any valid UTF-8 codepoint that is not an ASCII digit,
                 not ASCII whitespace, and not one of ( ) [ ] : , > * | & - " .
                 ! # $ % ^ + = { } < ; ' ` ~ / ? @ \ ? ;
 ident_char  = ? any valid UTF-8 codepoint that is not ASCII whitespace,
                 and not one of ( ) [ ] : , > * | & " .
                 ! # $ % ^ + = { } < ; ' ` ~ / ? @ \ ? ;
+                (* note: "-" is a valid ident_char, but the lexer stops
+                   before "->" so that the arrow token is recognized
+                   even without surrounding whitespace *)
 
 string   = '"' , { ? any valid UTF-8 codepoint except '"' ? } , '"' ;
 
-digit    = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+number     = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , [ ident_start , { ident_char } ] ;
 
-number   = [ "-" ] , digit , { digit } , [ "." , digit , { digit } ] , [ ident_start , { ident_char } ] ;
-
-comment  = "--" , { ? any valid UTF-8 codepoint except newline ? } ;
+comment  = "--" , { any char - newline } ;
 ```
 
 All operators are right-associative (matching Haskell Arrow fixity). Comments can appear after any term and are attached to the preceding node as purpose descriptions or reference tool annotations.
 
 Identifiers and unit suffixes support full UTF-8 codepoints, including non-ASCII characters (CJK, Greek, accented Latin, etc.), so the DSL works naturally with non-Latin scripts. Error positions report codepoint-level columns, not byte offsets.
 
-`typed_term` sits at the `par_expr` level, but since `seq_expr` and `alt_expr` both bottom out through `par_expr → typed_term → term`, every term position in the grammar can carry a `:: Ident -> Ident` annotation. Annotations are documentation-only; the checker does not validate types.
+`typed_term` sits at the `par_expr` level, but since `seq_expr` and `alt_expr` both bottom out through `par_expr → typed_term → term`, every term position in the grammar can carry a `:: TypeName -> TypeName` annotation. Type names can be identifiers or `()` (unit). Annotations are documentation-only; the checker does not validate types.
+
+`program` is the top-level production. A program contains zero or more statements (`stmt`) separated by semicolons. Each statement is either a `let_expr` or a `pipeline`. Semicolons between statements are required; leading and trailing semicolons are optional.
+
+`reserved` words (`let`, `loop`, `in`) are excluded from `ident` at the lexer level — they cannot be used as node names. `in` is allowed as a named argument key via the `arg_key` production.
+
+`call_arg` supports both named (`key: value`) and positional (`seq_expr`) arguments in the same call. `f()` produces a single positional Unit argument — it is not an empty argument list.
 
 ## Combinators
 
@@ -73,21 +98,25 @@ Identifiers and unit suffixes support full UTF-8 codepoints, including non-ASCII
 | Question | `node?` / `"string"?` | — | `Arrow a (Either a a)` | Marks step as producing Either for `\|\|\|` |
 | Group | `(expr)` | — | Precedence grouping | No direct expansion |
 | Type Ann | `term :: A -> B` | — | Documentation annotation | No direct expansion |
+| Lambda | `\x -> expr` | — | `Arrow a b` | Parameterized workflow fragment |
+| Let | `let x = expr in body` | — | Named binding | Abstraction (not a combinator) |
+| Unit | `()` | — | Unit value / type | No-input value or trigger |
+| Semicolon | `;` | — | Statement separator | Multiple independent pipelines |
 
 `***` is right-associative: `a *** b *** c` types as `(A, (B, C))`.
 
 `***` and `&&&` share the same precedence. When mixed without grouping, the rightmost operator binds first:
 
-```
-a *** b &&& c        -- parses as: a *** (b &&& c)
-a &&& b *** c        -- parses as: a &&& (b *** c)
+```arrow
+a *** b &&& c;        -- parses as: a *** (b &&& c)
+a &&& b *** c         -- parses as: a &&& (b *** c)
 ```
 
 Use explicit parentheses when mixing them to make intent clear:
 
-```
-(a *** b) &&& c      -- parallel a,b then fanout with c
-a *** (b &&& c)      -- fanout b,c then parallel with a
+```arrow
+(a *** b) &&& c;      -- parallel a,b then fanout with c
+a *** (b &&& c)       -- fanout b,c then parallel with a
 ```
 
 ## Node Design
@@ -104,7 +133,7 @@ The agent expanding the pipeline decides which concrete tool to use based on the
 
 ### Sequential Pipeline
 
-```
+```arrow
 read(source: "data.csv")          -- read the data source
   >>> parse(format: csv)          -- structure raw data
   >>> filter(condition: "age > 18")
@@ -113,7 +142,7 @@ read(source: "data.csv")          -- read the data source
 
 ### Parallel Composition
 
-```
+```arrow
 read(source: "data.csv")
   >>> parse(format: csv)
   >>> (count *** collect(fields: [email]))  -- parallel: count & collect
@@ -122,7 +151,7 @@ read(source: "data.csv")
 
 ### Fanout
 
-```
+```arrow
 (lint &&& test)
   >>> gate(require: [pass, pass])
   >>> (build_linux(profile: static) *** build_macos(profile: release))
@@ -133,7 +162,7 @@ read(source: "data.csv")
 
 ### Branch / Fallback
 
-```
+```arrow
 (fetch(url: endpoint)             -- try remote first
   ||| load(from: cache, key: k))  -- fall back to cache
   >>> transform(mapping: schema_v2)
@@ -142,7 +171,7 @@ read(source: "data.csv")
 
 ### Feedback Loop
 
-```
+```arrow
 loop(
   generate(artifact: code, from: spec)  -- produce code from spec
     >>> verify(method: test_suite)       -- run tests
@@ -155,14 +184,14 @@ loop(
 
 `?` marks a step as producing Either, feeding into `|||` for branching:
 
-```
+```arrow
 fetch(url: primary)?
   >>> (process ||| (fetch(url: mirror) >>> process))
 ```
 
 `?` can also appear upstream in a `>>>` chain that feeds into `|||`:
 
-```
+```arrow
 loop(
   generate >>> verify >>> "all tests pass"?
   >>> (done ||| fix_and_retry)
@@ -177,7 +206,7 @@ The checker emits a warning (to stderr, exit code unaffected) if `?` appears wit
 
 Nodes and terms can carry optional type annotations using `::`:
 
-```
+```arrow
 fetch(url: "https://example.com") :: URL -> HTML
   >>> parse :: HTML -> Data
   >>> format(as: report) :: Data -> Report
@@ -185,11 +214,13 @@ fetch(url: "https://example.com") :: URL -> HTML
 
 Annotations document intended data flow for humans and agents. The checker parses them into the AST but performs **no type checking** — they are purely documentation.
 
+Type names can be identifiers or `()` (unit): `:: () -> Server`, `:: Input -> ()`.
+
 Type annotations bind at the `par_expr` level (tighter than all infix operators):
 
-```
+```arrow
 -- annotation attaches to the preceding term, not the whole chain
-read :: File -> CSV >>> parse :: CSV -> Data
+read :: File -> CSV >>> parse :: CSV -> Data;
 
 -- annotate grouped expressions
 (read >>> parse) :: File -> Data
@@ -199,7 +230,7 @@ read :: File -> CSV >>> parse :: CSV -> Data
 
 Numbers can be integers, floats, negative, or carry unit suffixes:
 
-```
+```arrow
 resize(width: 1920, height: 1080)     -- integers
   >>> compress(quality: 85)
   >>> dose(amount: 100mg)             -- unit suffix
@@ -208,7 +239,7 @@ resize(width: 1920, height: 1080)     -- integers
 
 Numbers appear wherever a value is expected — as arguments or inside lists:
 
-```
+```arrow
 mix(volumes: [100ml, 250ml, 50ml])
   >>> heat(temp: 72.5c, duration: 30min)
 ```
@@ -219,18 +250,18 @@ Note: leading-dot (`.5`) and trailing-dot (`5.`) forms are **not** valid — use
 
 Node names, argument keys, and unit suffixes can use non-Latin scripts:
 
-```
+```arrow
 読み込み(ソース: "データ.csv")
   >>> フィルタ(条件: "年齢 > 18")
   >>> 出力
 ```
 
-```
+```arrow
 加熱(溫度: 72.5℃, 時間: 30分鐘)
   >>> 冷卻(目標: 4℃)
 ```
 
-```
+```arrow
 dose(amount: 500ミリ秒)            -- unicode unit suffix
   >>> measure(area: 100m2)         -- digit within unit suffix
 ```
@@ -247,6 +278,122 @@ read(source: "data.csv")
   browser agent → fetch("/api/data.csv")
 ```
 
+### Lambda Expressions
+
+Lambda creates parameterized workflow fragments:
+
+```
+\name -> hello(to: name) >>> respond
+```
+
+Multi-parameter lambda:
+
+```
+\trigger, fix -> loop(trigger >>> (pass ||| fix))
+```
+
+Lambda with type annotations:
+
+```
+\url -> fetch(url: url) :: URL -> HTML
+  >>> parse :: HTML -> Data
+```
+
+Lambdas must be bound via `let` and applied to be valid programs — the examples above show the syntax construct. See [Let Bindings](#let-bindings) for complete usage.
+
+### Let Bindings
+
+`let` names a workflow fragment for reuse:
+
+```arrow
+let greet = \name -> hello(to: name) >>> respond in
+greet(alice) >>> greet(bob)
+```
+
+Nested lets — multi-phase workflow:
+
+```arrow
+let review = \trigger, fix ->
+  loop(trigger >>> (pass ||| fix))
+in
+let phase1 = gather >>> review(check?, rework) in
+let phase2 = build >>> review(test?, fix) in
+phase1 >>> phase2
+```
+
+Let inside parentheses:
+
+```arrow
+(let x = fetch(url: primary) in x)
+  ||| fetch(url: mirror)
+```
+
+### Unit
+
+`()` is a value representing "no input" or "trigger":
+
+```arrow
+() >>> start_server :: () -> Server
+```
+
+`()` is also valid as a type name in annotations:
+
+```arrow
+healthcheck :: () -> Status
+```
+
+`f()` passes Unit as a positional argument — it is not an empty argument list:
+
+```arrow
+noop() >>> continue
+```
+
+### Multi-Statement
+
+A program can contain multiple independent pipelines separated by `;`:
+
+```arrow
+planning :: Doc -> Commit
+  >>> commit(branch: main);
+
+implementation :: Code -> Commit
+  >>> branch(pattern: "feature/*") :: Code -> Branch
+  >>> commit :: Branch -> Commit
+```
+
+Trailing semicolon is optional on the last statement.
+
+### Literate Arrow Documents
+
+Arrow DSL is designed to work inside Markdown documents. Use fenced code blocks with the `arrow` (or `arr`) language tag to embed workflow definitions alongside prose. Any Markdown file can be a literate Arrow document. Both LF and CRLF line endings are supported.
+
+````markdown
+## Deployment
+
+Build artifacts must pass CI before release.
+
+```arrow
+build :: Source -> Artifact
+  >>> test :: Artifact -> Verified
+  >>> deploy(env: production) :: Verified -> Released
+```
+````
+
+Convention: `.arr` for standalone DSL files. For literate documents, use regular `.md` — the `arrow` code blocks speak for themselves.
+
+Validate with `ocaml-compose-dsl --literate doc.md`.
+
+### Mixed Call Arguments
+
+Named and positional arguments can be freely mixed in the same call:
+
+```arrow
+let v = some_pipeline in
+push(remote: origin, v)
+```
+
+Named arguments (`key: value`) provide static configuration; positional arguments pass pipeline expressions.
+
 ## Structural Rules
 
 The checker validates **syntax structure** only, and emits warnings:
@@ -254,6 +401,7 @@ The checker validates **syntax structure** only, and emits warnings:
 - Balanced parentheses
 - Valid operator usage and precedence
 - Well-formed node definitions
+- Semicolons separate top-level statements only — they are not valid inside parentheses
 
 The checker does NOT validate:
 

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -59,10 +59,10 @@ ident       = ident_start , { ident_char } - reserved ;
 reserved    = "let" | "loop" | "in" ;
 ident_start = ? any valid UTF-8 codepoint that is not an ASCII digit,
                 not ASCII whitespace, and not one of ( ) [ ] : , > * | & - " .
-                ! # $ % ^ + = { } < ; ' ` ~ / QUESTION MARK @ \ ? ;
+                ! # $ % ^ + = { } < ; ' ` ~ / QUESTION_MARK @ \ ? ;
 ident_char  = ? any valid UTF-8 codepoint that is not ASCII whitespace,
                 and not one of ( ) [ ] : , > * | & " .
-                ! # $ % ^ + = { } < ; ' ` ~ / QUESTION MARK @ \ ? ;
+                ! # $ % ^ + = { } < ; ' ` ~ / QUESTION_MARK @ \ ? ;
                 (* note: "-" is a valid ident_char, but the lexer stops
                    before "->" so that the arrow token is recognized
                    even without surrounding whitespace *)

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -31,8 +31,9 @@ type_name   = ident | "(" , ")" ;
 
 term     = ident , [ "(" , [ call_args ] , ")" ] , [ "?" ]
                                                     (* ident with optional args and question *)
-         | string , [ "?" ]                        (* string literal, optionally question;
-                                                      AST represents both as Question(expr) *)
+         | string , [ "?" ]                        (* string literal, optionally followed by "?";
+                                                      only the postfix-"?" form (expr?) becomes
+                                                      Question(expr) in the AST *)
          | "(" , ")" , [ "?" ]                     (* unit value, with optional question *)
          | "loop" , "(" , seq_expr , ")"            (* feedback loop *)
          | "(" , stmt , ")"                        (* grouping — allows let bindings
@@ -46,7 +47,7 @@ call_args = call_arg , { "," , call_arg } ;
 call_arg  = arg_key , ":" , value                   (* Named — per-arg disambiguation via key ":" *)
           | seq_expr                                (* Positional — any expression *)
           ;
-arg_key   = ident | "in" ;                          (* reserved words allowed as named arg keys *)
+arg_key   = ident | "in" ;                          (* reserved word "in" allowed as named arg key *)
 
 value    = string
          | number

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -300,7 +300,7 @@ Lambda with type annotations:
   >>> parse :: HTML -> Data
 ```
 
-Lambdas must be bound via `let` and applied to be valid programs — the examples above show the syntax construct. See [Let Bindings](#let-bindings) for complete usage.
+Bare lambdas are syntactically valid statements, but in practice they are most useful when bound via `let` and applied. See [Let Bindings](#let-bindings) for complete usage.
 
 ### Let Bindings
 

--- a/plugins/compose/skills/compose/references/dsl-grammar.md
+++ b/plugins/compose/skills/compose/references/dsl-grammar.md
@@ -283,19 +283,19 @@ read(source: "data.csv")
 
 Lambda creates parameterized workflow fragments:
 
-```
+```arrow
 \name -> hello(to: name) >>> respond
 ```
 
 Multi-parameter lambda:
 
-```
+```arrow
 \trigger, fix -> loop(trigger >>> (pass ||| fix))
 ```
 
 Lambda with type annotations:
 
-```
+```arrow
 \url -> fetch(url: url) :: URL -> HTML
   >>> parse :: HTML -> Data
 ```


### PR DESCRIPTION
## Summary
- Update compose DSL grammar and SKILL.md to match upstream ocaml-compose-dsl v0.10.0 EBNF
- Add new examples: lambda, let-binding, unit-type, multi-statement
- Refactor existing examples to use let/lambda abstraction
- Bump version to v0.10.0 in marketplace.json and CLAUDE.md

## Test plan
- [ ] Validate `.arr` examples with `ocaml-compose-dsl`
- [ ] Verify SKILL.md triggers and instructions are coherent
- [ ] Check marketplace.json version consistency