### PR TITLE
feat(constraint): add constraint plugin with 3 skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,6 +38,12 @@
       "source": "./plugins/owasp",
       "description": "Security review skills — OWASP vulnerability analysis with offline reference data from 8 Top 10 projects and CheatSheetSeries index",
       "version": "0.1.0"
+    },
+    {
+      "name": "constraint",
+      "source": "./plugins/constraint",
+      "description": "Natural language constraints → deterministic test artifacts. Write constraints in structured Markdown, generate unit tests / PBT / mutation tests, enforce with deterministic tools.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Claude Code plugin marketplace (`caasi/dong3`) containing five independent plugins under `plugins/`. No traditional build system — this is a skill/plugin distribution repo.
+A Claude Code plugin marketplace (`caasi/dong3`) containing six independent plugins under `plugins/`. No traditional build system — this is a skill/plugin distribution repo.
 
 Install: `claude plugin marketplace add caasi/dong3`
 
@@ -17,6 +17,7 @@ plugins/
   compose/                        # Arrow-style DSL for workflow pipelines
   fetch-tips/                     # Platform-specific fetch strategies
   kami/                           # Socratic dialogue on human-AI stewardship
+  constraint/                      # NL constraints → deterministic test artifacts
   owasp/                          # OWASP security review with offline references
 docs/superpowers/                 # Design specs and implementation plans
 ```
@@ -42,6 +43,8 @@ plugins/<name>/
 **fetch-tips (v0.1.0):** Platform-specific fetch strategies for content that resists simple WebFetch.
 
 **owasp (v0.1.0):** OWASP security review with offline reference data from 8 Top 10 projects (Web, API, LLM, MCP, Agentic, Mobile, CI/CD, Kubernetes) and a CheatSheetSeries index. Dual-licensed: skill files MIT, OWASP reference files CC BY-SA 4.0.
+
+**constraint (v0.1.0):** Three skills for NL metaprogramming — humans write constraints in structured natural language (`constraints/*.md` with Given/When/Then/Unless/Examples/Properties), agents generate deterministic test artifacts. `constraint-write` for authoring, `constraint-generate` for artifact generation (TypeScript: Biome, ast-grep, Typia, fast-check, Stryker), `constraint-enforce` for running the enforcement pipeline.
 
 ## Versioning
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ plugins/<name>/
 
 ## Versioning
 
-- Plugin versions live in the top-level `marketplace.json`.
+- Plugin versions live in `.claude-plugin/marketplace.json`.
 - No package registries; compose binary distributed via GitHub releases of `caasi/ocaml-compose-dsl`.
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ plugins/
   compose/                        # Arrow-style DSL for workflow pipelines
   fetch-tips/                     # Platform-specific fetch strategies
   kami/                           # Socratic dialogue on human-AI stewardship
-  constraint/                      # NL constraints → deterministic test artifacts
+  constraint/                     # NL constraints → deterministic test artifacts
   owasp/                          # OWASP security review with offline references
 docs/superpowers/                 # Design specs and implementation plans
 ```

--- a/plugins/constraint/.claude-plugin/plugin.json
+++ b/plugins/constraint/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "constraint",
+  "description": "Natural language constraints → deterministic test artifacts",
+  "author": {
+    "name": "caasi"
+  },
+  "homepage": "https://github.com/caasi/dong3",
+  "repository": "https://github.com/caasi/dong3",
+  "license": "MIT",
+  "keywords": ["constraint", "testing", "pbt", "mutation-testing", "verification"],
+  "skills": "./skills/"
+}

--- a/plugins/constraint/skills/constraint-enforce/README.md
+++ b/plugins/constraint/skills/constraint-enforce/README.md
@@ -1,0 +1,20 @@
+# Constraint Enforce
+
+Run the 4-layer deterministic enforcement pipeline on generated constraint artifacts.
+
+## Usage
+
+Invoke with `/constraint-enforce` or ask to "enforce constraints", "跑 constraint 驗證".
+
+## Pipeline Layers
+
+1. **Lint** — Biome + ast-grep
+2. **Validation** — Typia / ArkType / Zod
+3. **PBT** — fast-check property tests
+4. **Mutation Testing** — Stryker (with feedback loop)
+
+## Mutation Testing Feedback Loop
+
+- Default target: 80% mutation score
+- Max 3 rounds of property strengthening
+- Escalates to user for equivalent mutants or stalled progress

--- a/plugins/constraint/skills/constraint-enforce/SKILL.md
+++ b/plugins/constraint/skills/constraint-enforce/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: constraint-enforce
+description: >-
+  Use when the user asks to "/constraint-enforce", "enforce constraints",
+  "run constraint tests", "跑 constraint 驗證", or "run constraint
+  enforcement". Runs the 4-layer deterministic enforcement pipeline on
+  generated constraint artifacts.
+---
+
+# Constraint Enforce
+
+You run the deterministic enforcement pipeline on generated constraint artifacts and report results.
+
+## Workflow
+
+1. Read `references/enforcement-layers.md` for the layer execution order
+2. Run layers in order: Lint → Validation → PBT → Mutation Testing
+3. Fail fast: fix issues at each layer before proceeding to the next
+4. For Layer 3+4 feedback loop: read `references/mutation-feedback-guide.md`
+5. Default mutation score target: 80%
+6. Max 3 feedback rounds
+7. Escalation: after 3 rounds or on unresolvable mutants, report to user with mutant summary table
+
+## Final Report
+
+For each layer:
+- **Status:** pass / fail
+- **Mutation score** (Layer 4)
+- **Surviving mutants** (if any)
+- **Recommendations** for next steps

--- a/plugins/constraint/skills/constraint-enforce/references/enforcement-layers.md
+++ b/plugins/constraint/skills/constraint-enforce/references/enforcement-layers.md
@@ -1,0 +1,138 @@
+# Enforcement Layers
+
+Constraints are enforced in four layers, executed in order. Each layer builds
+on the guarantees provided by the previous one. **Fail fast**: if a layer
+fails, fix the violations before proceeding to the next layer.
+
+---
+
+## Layer 1: Lint (Biome + ast-grep)
+
+Static analysis catches style violations, banned patterns, and structural
+anti-patterns before any code runs.
+
+### Commands
+
+```bash
+# Biome — formatting, linting, import ordering
+npx @biomejs/biome check .
+
+# ast-grep — structural rules defined in project sgconfig.yml
+npx ast-grep scan
+```
+
+### Expected output
+
+- Exit code `0` = clean, no violations.
+- Non-zero exit code = one or more violations.
+
+### On failure
+
+1. Collect every violation with **file path + line number**.
+2. Present violations grouped by rule.
+3. Suggest auto-fixable corrections where the tool supports `--apply`.
+4. Do **not** proceed to Layer 2 until all lint violations are resolved.
+
+---
+
+## Layer 2: Validation (Typia / ArkType / Zod)
+
+Runtime and compile-time type validation ensures that data crossing trust
+boundaries conforms to declared schemas.
+
+### Commands
+
+```bash
+# Compile-time check (Typia with ts-patch or unplugin)
+npx tsc --noEmit
+
+# Or: run unit tests that exercise validators
+npm test -- --grep "constraint.validation"
+```
+
+### Expected output
+
+- Compilation succeeds with no type errors, **or**
+- All validation unit tests pass.
+
+### On failure
+
+1. Report each type mismatch at the trust boundary where it occurs.
+2. Include the expected type and the actual type (or value shape).
+3. Do **not** proceed to Layer 3 until all type mismatches are resolved.
+
+---
+
+## Layer 3: PBT (fast-check)
+
+Property-based tests generate random inputs (100+ per property by default) to
+verify that constraints hold across the entire input space, not just
+hand-picked examples.
+
+### Commands
+
+```bash
+npm test -- --grep "constraint.pbt"
+```
+
+### Expected output
+
+- All property tests pass across the configured number of random inputs.
+
+### On failure
+
+1. Report the **counterexample** found by fast-check.
+2. Include the **shrunk minimal input** — fast-check automatically reduces
+   failing inputs to the smallest reproducing case.
+3. Identify which property was violated and the constraint it represents.
+4. Do **not** proceed to Layer 4 until all property tests pass.
+
+---
+
+## Layer 4: Mutation Testing (Stryker)
+
+Mutation testing verifies that the property tests from Layer 3 are strong
+enough to detect real faults. Stryker introduces small code mutations and
+checks whether at least one test fails for each.
+
+### Commands
+
+```bash
+npx stryker run
+```
+
+### Expected output
+
+- JSON report containing:
+  - **Mutation score**: killed mutants / total mutants.
+  - Per-mutant status: killed, survived, timed out, or no coverage.
+- Default target: mutation score >= 80%.
+
+### On failure
+
+If surviving mutants bring the score below the target, follow the feedback
+loop described in [mutation-feedback-guide.md](mutation-feedback-guide.md).
+
+---
+
+## Execution Order
+
+```
+Layer 1 (Lint)
+  │ pass
+  ▼
+Layer 2 (Validation)
+  │ pass
+  ▼
+Layer 3 (PBT)
+  │ pass
+  ▼
+Layer 4 (Mutation Testing)
+```
+
+- Each layer assumes all previous layers are green.
+- Layer 4 depends on Layer 3 tests existing — without property tests, there
+  is nothing for Stryker to evaluate mutations against.
+- A full enforcement run executes all four layers in sequence. Partial runs
+  (e.g., Layers 1-2 only) are acceptable during early development but the
+  complete pipeline must pass before merging.

--- a/plugins/constraint/skills/constraint-enforce/references/enforcement-layers.md
+++ b/plugins/constraint/skills/constraint-enforce/references/enforcement-layers.md
@@ -37,23 +37,25 @@ npx ast-grep scan
 
 ## Layer 2: Validation (Typia / ArkType / Zod)
 
-Runtime and compile-time type validation ensures that data crossing trust
-boundaries conforms to declared schemas.
+Runtime type validation ensures that data crossing trust boundaries conforms
+to declared schemas. Compile-time checks verify tooling setup only.
 
 ### Commands
 
 ```bash
-# Compile-time check (Typia with ts-patch or unplugin)
+# Step 1: Build/tooling check (Typia transformer configured correctly)
 npx tsc --noEmit
 
-# Or: run unit tests that exercise validators
+# Step 2: Run tests that exercise runtime validators at trust boundaries
 npm test -- --grep "constraint.validation"
 ```
 
 ### Expected output
 
-- Compilation succeeds with no type errors, **or**
-- All validation unit tests pass.
+- `tsc --noEmit` succeeds = tooling/build check passed (does **not** prove
+  runtime data is valid).
+- All validation unit tests pass = runtime validators confirm data conforms
+  to schemas at trust boundaries.
 
 ### On failure
 

--- a/plugins/constraint/skills/constraint-enforce/references/mutation-feedback-guide.md
+++ b/plugins/constraint/skills/constraint-enforce/references/mutation-feedback-guide.md
@@ -1,0 +1,122 @@
+# Mutation Feedback Guide
+
+This guide describes how to interpret Stryker mutation testing results and
+systematically improve property tests until surviving mutants are eliminated
+or identified as equivalent.
+
+---
+
+## Mutation Score
+
+```
+mutation score = killed mutants / total mutants
+```
+
+- **Killed**: a test failed when the mutation was applied — the test suite
+  detects this fault.
+- **Survived**: no test failed — the test suite has a gap.
+- **Default target**: 80% mutation score.
+
+---
+
+## Interpreting Surviving Mutants
+
+Each surviving mutant falls into one of three categories:
+
+### 1. Equivalent Mutant
+
+The mutation does not change observable behavior. For example, replacing
+`x >= 0` with `x > -1` when `x` is always an integer. These mutants
+**cannot be killed** because no test can distinguish the original from the
+mutant.
+
+**Action**: Mark as equivalent and ignore. No property change needed.
+
+### 2. Weak Test
+
+A property test covers the mutated code path but does not assert on the
+specific behavior that changed. The property is too permissive.
+
+**Action**: Strengthen the existing property. Add tighter postconditions or
+narrower invariants that would fail under the mutation.
+
+### 3. Missing Test
+
+No property test covers the mutated code path at all.
+
+**Action**: Write a new property test that exercises the code path and
+asserts on the behavior the mutation alters.
+
+---
+
+## Feedback Loop
+
+### Round 1
+
+1. **Run Stryker** to collect the full mutation report.
+2. **Collect surviving mutants** — note file, line, and mutation operator
+   for each.
+3. **Analyze each survivor**: determine which existing property *should*
+   catch it, or whether a new property is needed.
+4. **Strengthen or add properties**:
+   - For weak tests: tighten the assertion or add a new postcondition.
+   - For missing tests: write a new property covering the code path.
+5. **Re-run PBT** (`npm test -- --grep "constraint.pbt"`) to confirm the
+   new or strengthened properties pass against the unmutated code.
+
+### Round 2
+
+1. **Re-run Stryker** to check if previously surviving mutants are now
+   killed.
+2. For any mutants that still survive:
+   - Re-analyze: is this an equivalent mutant, or does the property need
+     further strengthening?
+   - Apply fixes and re-run PBT to confirm.
+
+### Round 3
+
+1. **Final Stryker run**.
+2. Any mutants still surviving after three rounds are candidates for
+   escalation (see below).
+
+**Maximum**: 3 rounds total. Do not loop indefinitely.
+
+---
+
+## Early Termination
+
+Stop the feedback loop early when further rounds will not help:
+
+- **Same mutant survives after 2 rounds of strengthening**: The mutant is
+  likely equivalent. Report it to the user for judgment rather than
+  continuing to modify tests.
+- **Mutation score plateaus** (no improvement between consecutive rounds):
+  The remaining survivors are likely equivalent mutants or require
+  architectural changes beyond test strengthening. Report the plateau and
+  remaining mutants to the user.
+
+---
+
+## Escalation
+
+After 3 rounds, or when early termination conditions are met, produce a
+summary table of all unresolved mutants:
+
+| Mutant | Location | Mutation | Survived rounds | Likely cause |
+|--------|----------|----------|-----------------|--------------|
+| M1 | `src/foo.ts:42` | `>=` to `>` | 3 | Equivalent mutant |
+| M2 | `src/bar.ts:17` | Removed call to `validate()` | 2 | Weak test |
+| M3 | `src/baz.ts:88` | Negated condition | 3 | Equivalent mutant |
+
+For each row, include:
+
+- **Mutant**: identifier from the Stryker report.
+- **Location**: file path and line number.
+- **Mutation**: what Stryker changed (operator, deletion, negation, etc.).
+- **Survived rounds**: how many feedback rounds this mutant survived.
+- **Likely cause**: your best assessment — equivalent mutant, weak test, or
+  missing test.
+
+Present this table to the user and ask them to judge whether each surviving
+mutant represents an equivalent mutant (acceptable) or a real gap in test
+coverage (requires further action).

--- a/plugins/constraint/skills/constraint-generate/README.md
+++ b/plugins/constraint/skills/constraint-generate/README.md
@@ -1,0 +1,26 @@
+# Constraint Generate
+
+Read `constraints/*.md` files and generate deterministic test artifacts.
+
+## Usage
+
+Invoke with `/constraint-generate` or ask to "generate constraint tests".
+
+## What It Generates
+
+| Constraint Section | Generated Artifact |
+|---|---|
+| Examples table | Parameterized unit tests (`*.constraint.test.ts`) |
+| Properties | fast-check PBT tests (`*.constraint.pbt.test.ts`) |
+| Prohibition (ast-grep) | ast-grep rule YAML |
+| Validation | Runtime validation at trust boundaries |
+
+## Supported Languages
+
+- **TypeScript** — fully supported (Biome, ast-grep, Typia, fast-check, Stryker)
+- OCaml, Rust, Python — planned
+
+## Guided Flow
+
+After generating artifacts, suggests running `/constraint-enforce` and adding
+a PreCommit hook for automated enforcement.

--- a/plugins/constraint/skills/constraint-generate/SKILL.md
+++ b/plugins/constraint/skills/constraint-generate/SKILL.md
@@ -17,9 +17,9 @@ You read constraint files from `constraints/*.md` and generate deterministic tes
 
 2. **Understand the format** — read `references/constraint-format.md` for the canonical constraint file structure.
 
-3. **Detect repo toolchain** — check for `package.json`, `tsconfig.json`, `dune-project`, `Cargo.toml`, `pyproject.toml`, etc. to determine language and available tooling.
+3. **Detect repo toolchain** — check for `package.json`, `tsconfig.json`, `dune-project`, `Cargo.toml`, `pyproject.toml`, etc. to determine language and available tooling. **If the detected language is not TypeScript**, inform the user that only TypeScript is currently supported and ask whether to proceed with TypeScript artifacts anyway or stop.
 
-4. **Select tools** — read `references/toolchain-matrix.md` to pick the correct test runner, linter, PBT library, and mutation tool for this repo.
+4. **Select tools** — read `references/toolchain-matrix.md` to pick the correct test runner, linter, PBT library, and mutation tool for this repo. Only TypeScript tools are fully supported in v0.1.0.
 
 5. **Generate artifacts** — for each constraint file, produce the applicable artifacts:
 

--- a/plugins/constraint/skills/constraint-generate/SKILL.md
+++ b/plugins/constraint/skills/constraint-generate/SKILL.md
@@ -13,7 +13,7 @@ You read constraint files from `constraints/*.md` and generate deterministic tes
 
 ## Workflow
 
-1. **Scan constraints** — read every file matching `constraints/*.md`. Parse YAML frontmatter (`id`, `scope`, `severity`, tags) and body sections (Rule, Examples, Properties, Prohibition, Validation).
+1. **Scan constraints** — read every file matching `constraints/*.md`. Parse YAML frontmatter (`rule`, `kind`, `scope`, `subject`, `enforce`) and body sections (Given, When, Then, Unless, Examples, Properties).
 
 2. **Understand the format** — read `references/constraint-format.md` for the canonical constraint file structure.
 

--- a/plugins/constraint/skills/constraint-generate/SKILL.md
+++ b/plugins/constraint/skills/constraint-generate/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: constraint-generate
+description: >-
+  Use when the user asks to "/constraint-generate", "generate constraint
+  tests", "generate constraint artifact", "產生 constraint 的 test", or
+  "generate test from constraint". Reads constraints/*.md and produces
+  deterministic test artifacts.
+---
+
+# Constraint Generate
+
+You read constraint files from `constraints/*.md` and generate deterministic test artifacts that enforce them mechanically.
+
+## Workflow
+
+1. **Scan constraints** — read every file matching `constraints/*.md`. Parse YAML frontmatter (`id`, `scope`, `severity`, tags) and body sections (Rule, Examples, Properties, Prohibition, Validation).
+
+2. **Understand the format** — read `references/constraint-format.md` for the canonical constraint file structure.
+
+3. **Detect repo toolchain** — check for `package.json`, `tsconfig.json`, `dune-project`, `Cargo.toml`, `pyproject.toml`, etc. to determine language and available tooling.
+
+4. **Select tools** — read `references/toolchain-matrix.md` to pick the correct test runner, linter, PBT library, and mutation tool for this repo.
+
+5. **Generate artifacts** — for each constraint file, produce the applicable artifacts:
+
+   | Section | Artifact |
+   |---|---|
+   | Examples table | `*.constraint.test.ts` — parameterized tests via `it.each` |
+   | Properties | `*.constraint.pbt.test.ts` — fast-check property-based tests |
+   | Prohibition + ast-grep | `.ast-grep/rules/*.yml` — structural lint rule |
+   | Validation | Runtime validation code at trust boundaries |
+
+6. **File conventions:**
+   - Header: `// Generated from constraints/<RULE_ID>-<slug>.md — do not edit manually`
+   - Place artifacts in the repo's existing test directory structure.
+   - Re-running overwrites previously generated artifacts (idempotent).
+
+7. **Post-generate suggestions** — after generating, suggest two things:
+   - "要我用 `/constraint-enforce` 跑驗證嗎？"
+   - If no constraint-related PreCommit hook is detected in `.claude/settings.json`, suggest adding one (see template below). **Do not auto-modify settings.**
+
+## Hook Suggestion Template
+
+```json
+{
+  "hooks": {
+    "PreCommit": [{ "matcher": "", "command": "npm test -- --grep constraint" }]
+  }
+}
+```
+
+Suggest this to the user — do not write it automatically.

--- a/plugins/constraint/skills/constraint-generate/references/constraint-format.md
+++ b/plugins/constraint/skills/constraint-generate/references/constraint-format.md
@@ -1,0 +1,190 @@
+# Constraint Format Reference
+
+This document is the canonical format specification for constraint files. Both `constraint-write` (authoring) and `constraint-generate` (artifact generation) depend on this format.
+
+## File Location Convention
+
+All constraint files live in the repository root under:
+
+```
+constraints/<RULE_ID>-<slug>.md
+```
+
+- `<RULE_ID>`: unique identifier (see RULE_ID Naming below)
+- `<slug>`: kebab-case human-readable summary
+
+Example: `constraints/USER_003-soft-deleted-no-login.md`
+
+## RULE_ID Naming
+
+Format: `<DOMAIN>_<NNN>`
+
+- **DOMAIN**: short uppercase label chosen by the user (e.g. `USER`, `MONEY`, `API`, `AUTH`, `ORDER`)
+- **NNN**: zero-padded sequential number within that domain (e.g. `001`, `002`, `003`)
+
+`constraint-write` should scan existing `constraints/*.md` files and suggest the next available number for the given domain.
+
+## Frontmatter
+
+Every constraint file begins with YAML frontmatter between `---` fences.
+
+| Field | Required | Description |
+|---|---|---|
+| `rule` | yes | Unique identifier (e.g. `USER_003`). Used for cross-reference and artifact file naming. |
+| `kind` | yes | Constraint classification: `permission`, `prohibition`, `obligation`, `invariant`, or `protocol`. See Kind Classification below. |
+| `scope` | yes | Glob pattern(s) specifying which source files this constraint covers (e.g. `src/auth/**, src/user/**`). |
+| `subject` | no | The domain entity involved (e.g. `User`, `Invoice`, `Transaction`). |
+| `enforce` | no | Comma-separated enforcement methods: `lint`, `ast-grep`, `validation`, `pbt`, `mutation`. When omitted, `constraint-generate` uses the Kind table's typical enforce column as default. |
+
+## Kind Classification
+
+| Kind | Semantic Meaning | Typical Enforce |
+|---|---|---|
+| `permission` | Under certain conditions, an action is allowed | validation, guard |
+| `prohibition` | An action is forbidden | lint, ast-grep |
+| `obligation` | An action is required | lint, validation |
+| `invariant` | A mathematical property that must always hold | pbt |
+| `protocol` | An ordering or sequencing constraint on operations | pbt (state machine) |
+
+### Kind as Default Enforce
+
+When the `enforce` field is omitted from frontmatter, `constraint-generate` uses the **Typical Enforce** column from the Kind table above as the default. The generator may also add extra enforcement layers based on the constraint body content (e.g. adding `pbt` if a Properties section is present).
+
+## Body Sections
+
+The constraint body uses a legal/BDD hybrid structure. Each section maps directly to a test generation target.
+
+| Section | Purpose | Maps To |
+|---|---|---|
+| **Given** | Preconditions / initial state | Test setup (arrange) |
+| **When** | Triggering action | Test action (act) |
+| **Then** | Expected outcome | Test assertion (assert) |
+| **Unless** | Exception conditions + alternative outcomes | Additional test branches |
+| **Examples** | Concrete input/output table | Parameterized unit tests (`it.each` / `test.each`) |
+| **Properties** | Semi-formal universal properties | fast-check `fc.property()` tests |
+
+All sections use `## Heading` level.
+
+### Unless Syntax
+
+Unless contains one or more exception groups. Each group has **condition lines** (no arrow prefix) and **outcome lines** (`→` prefix):
+
+```markdown
+## Unless
+- condition (no arrow)
+- → outcome (arrow prefix)
+
+- another condition
+- → another outcome
+```
+
+Key rules:
+- **Condition lines**: plain list items describing when the exception applies
+- **Outcome lines**: prefixed with `→`, describing what happens instead of the Then outcome
+- **Multiple groups**: separated by a blank line between them
+- **Logical OR**: groups are combined with OR semantics — if any group's conditions are met, its outcome applies
+- The agent distinguishes condition lines from outcome lines by the `→` prefix
+
+### Examples Section
+
+The Examples section **must** be a Markdown table with **at least 3 rows** of data (not counting the header). This is a hard requirement:
+
+> No concrete examples = no enforcement.
+
+The table maps directly to parameterized unit tests (`it.each` / `test.each`). Each row becomes one test case. Column headers become parameter names.
+
+### Properties Section
+
+Properties use a semi-formal universal quantifier syntax:
+
+```
+forall X where condition: property
+```
+
+Each property maps to a `fc.property()` call in fast-check. The `forall` variables become arbitraries, the `where` clause becomes a filter or precondition, and the property expression becomes the assertion.
+
+## Complete Examples
+
+### Example 1: Domain/State Constraint
+
+```markdown
+# constraints/USER_003-soft-deleted-no-login.md
+---
+rule: USER_003
+kind: permission
+scope: src/auth/**, src/user/**
+subject: User
+enforce: validation, pbt
+---
+
+## Given
+- user.state = soft_deleted
+
+## When
+- password login attempted
+
+## Then
+- deny login
+- return AUTH_DENIED
+
+## Unless
+- user.state = recoverable AND deleted_at <= 30 days
+- → allow recovery flow only, return RECOVERY_REQUIRED
+
+## Examples
+| user.state | deleted_at | action | expected |
+|---|---|---|---|
+| soft_deleted | 60 days ago | login | AUTH_DENIED |
+| hard_deleted | 90 days ago | login | AUTH_DENIED |
+| recoverable | 10 days ago | login | RECOVERY_REQUIRED |
+| recoverable | 45 days ago | login | AUTH_DENIED |
+| active | - | login | SUCCESS |
+
+## Properties
+- forall user where state = soft_deleted AND NOT recoverable:
+  login(user) → AUTH_DENIED
+- forall user where state = hard_deleted:
+  search(query) never contains user
+```
+
+### Example 2: Code-Level Constraint
+
+```markdown
+# constraints/MONEY_001-no-float-money.md
+---
+rule: MONEY_001
+kind: prohibition
+scope: src/billing/**, src/payment/**
+enforce: ast-grep, pbt
+---
+
+## Given
+- 任何處理金額的程式碼
+
+## When
+- 宣告變數、函式參數、回傳值涉及金額
+
+## Then
+- 必須使用 Decimal 型別
+- 乘除運算必須指定 rounding mode
+
+## Unless
+- 顯示用途的格式化函式（toDisplayString）可回傳 string
+- 測試中的 fixture 資料可用 literal number
+
+## Examples
+| context | type used | valid |
+|---|---|---|
+| calculateTotal() return | Decimal | yes |
+| calculateTotal() return | number | no |
+| invoice.amount field | Decimal | yes |
+| invoice.amount field | float | no |
+| toDisplayString() return | string | yes |
+| test fixture | 19.99 (literal) | yes |
+
+## Properties
+- forall (a: Decimal, b: Decimal, c: Decimal):
+  (a + b) + c === a + (b + c)
+- forall (amount: Decimal, currency: Currency):
+  toUSD(toTWD(amount)) - amount < 0.01
+```

--- a/plugins/constraint/skills/constraint-generate/references/constraint-format.md
+++ b/plugins/constraint/skills/constraint-generate/references/constraint-format.md
@@ -40,7 +40,7 @@ Every constraint file begins with YAML frontmatter between `---` fences.
 
 | Kind | Semantic Meaning | Typical Enforce |
 |---|---|---|
-| `permission` | Under certain conditions, an action is allowed | validation, guard |
+| `permission` | Under certain conditions, an action is allowed | validation |
 | `prohibition` | An action is forbidden | lint, ast-grep |
 | `obligation` | An action is required | lint, validation |
 | `invariant` | A mathematical property that must always hold | pbt |

--- a/plugins/constraint/skills/constraint-generate/references/constraint-format.md
+++ b/plugins/constraint/skills/constraint-generate/references/constraint-format.md
@@ -99,9 +99,10 @@ Properties use a semi-formal universal quantifier syntax:
 
 ```
 forall X where condition: property
+forall (X, Y): property
 ```
 
-Each property maps to a `fc.property()` call in fast-check. The `forall` variables become arbitraries, the `where` clause becomes a filter or precondition, and the property expression becomes the assertion.
+The `where` clause is optional. When present, it becomes a filter or precondition. Each property maps to a `fc.property()` call in fast-check. The `forall` variables become arbitraries and the property expression becomes the assertion.
 
 ## Complete Examples
 

--- a/plugins/constraint/skills/constraint-generate/references/toolchain-matrix.md
+++ b/plugins/constraint/skills/constraint-generate/references/toolchain-matrix.md
@@ -1,0 +1,137 @@
+# Toolchain Matrix
+
+Deterministic toolchain reference for `constraint-generate`. Maps constraint
+kinds and enforce directives to concrete tools, with install/run commands and
+pass/fail interpretation.
+
+## Language Detection
+
+Detect the repo's primary language by checking for marker files at the repo root:
+
+| Marker file | Language |
+|---|---|
+| `package.json` or `tsconfig.json` | TypeScript |
+| `dune-project` | OCaml |
+| `Cargo.toml` | Rust |
+| `pyproject.toml` or `setup.py` | Python |
+
+If multiple markers are detected, ask the user which language to target.
+
+## Constraint Kind/Enforce → Toolchain Layer
+
+| `enforce` value | Toolchain layer |
+|---|---|
+| `lint`, `ast-grep` | Layer 1 (Lint) |
+| `validation` | Layer 2 (Validation) |
+| `pbt` | Layer 3 (PBT) |
+| `mutation` | Layer 4 (Mutation) |
+
+When a constraint's frontmatter omits `enforce`, use the Kind classification
+table's "typical enforce" column as the default (see constraint-format.md).
+
+---
+
+## TypeScript Toolchain (supported)
+
+### Layer 1: Lint
+
+#### Biome
+
+Static analysis, formatting, and (via Biotype) TypeScript type inference.
+
+- **Install:** `npm install --save-dev --save-exact @biomejs/biome`
+- **Init:** `npx @biomejs/biome init`
+- **Run:** `npx @biomejs/biome check .`
+- **Pass/fail:** Exit code 0 = clean. Non-zero = violations found. Output lists
+  each violation with file path, line number, and rule name.
+
+#### ast-grep
+
+Structural code search for prohibition enforcement. Constraint-generate writes
+`.ast-grep/rules/*.yml` rule files from prohibition constraints.
+
+- **Install:** `npm install --save-dev @ast-grep/cli`
+- **Run:** `npx ast-grep scan`
+- **Pass/fail:** Exit code 0 = no matches (clean). Non-zero = prohibited
+  patterns found. Output lists each match with file path, line range, and the
+  matched code snippet.
+
+### Layer 2: Validation
+
+Runtime type validation at trust boundaries. Choose a library based on
+existing project dependencies:
+
+1. Check `package.json` dependencies for `zod`, `arktype`, or `typia`
+2. If one is already present, use it (avoid adding a second validation library)
+3. If none is present, default to **Typia** for new projects (zero schema
+   duplication — validates directly from TypeScript types)
+
+#### Typia (preferred for new projects)
+
+Zero schema duplication — generates validators directly from TypeScript types.
+
+- **Install:** `npm install --save-dev typia`
+- **Init:** `npx typia setup` (configures the TypeScript transformer)
+- **Run:** Compile with `tsc` or run tests — Typia validates at compile time
+  and runtime
+- **Pass/fail:** Compilation success = types match. `TypeGuardError` at runtime
+  = validation failure at a trust boundary. Test runner reports assertion
+  failures with the mismatched type path.
+
+#### ArkType (set-theory based)
+
+- **Install:** `npm install arktype`
+- **Run:** Run unit tests that call `type.assert(data)` at trust boundaries
+- **Pass/fail:** `ArkErrors` thrown = validation failure. Test runner reports
+  which fields failed and why.
+
+#### Zod (if already in stack)
+
+- **Install:** `npm install zod`
+- **Run:** Run unit tests that call `schema.parse(data)` at trust boundaries
+- **Pass/fail:** `ZodError` thrown = validation failure. Error contains an
+  `issues` array with path and message for each failing field.
+
+### Layer 3: PBT (Property-Based Testing)
+
+#### fast-check
+
+**Detection:** Check if `fast-check` appears in `package.json` devDependencies.
+
+- **Install:** `npm install --save-dev fast-check`
+- **Run:** `npm test -- --grep constraint.pbt`
+- **Pass/fail:** All property tests pass (100+ random inputs per property by
+  default) = clean. On failure, fast-check reports a **counterexample** — the
+  shrunk minimal input that violates the property. The output includes the
+  failing property name, the seed (for reproducibility), and the minimal
+  counterexample value.
+
+### Layer 4: Mutation Testing
+
+#### Stryker Mutator
+
+**Detection:** Check if `@stryker-mutator/core` appears in `package.json`
+devDependencies.
+
+- **Install:** `npm install --save-dev @stryker-mutator/core`
+- **Init:** `npx stryker init` (interactive setup — selects test runner,
+  mutator plugins, and reporter)
+- **Run:** `npx stryker run`
+- **Pass/fail:** Produces a JSON report with a **mutation score** (killed
+  mutants / total mutants). Default target: 80%. Below target = failing.
+  The report lists each mutant with its location, mutation type, and status
+  (killed, survived, timeout, no coverage). See `mutation-feedback-guide.md`
+  in the `constraint-enforce` skill for the feedback loop on surviving mutants.
+
+---
+
+## Other Languages (planned)
+
+No detailed commands yet. Toolchain mapping for future implementation:
+
+| Layer | OCaml | Rust | Python |
+|---|---|---|---|
+| Lint | ocamlformat | clippy | ruff |
+| Validation | Gospel | — | pydantic |
+| PBT | QCheck / Ortac | proptest | Hypothesis |
+| Mutation | — | cargo-mutants | mutmut |

--- a/plugins/constraint/skills/constraint-generate/references/toolchain-matrix.md
+++ b/plugins/constraint/skills/constraint-generate/references/toolchain-matrix.md
@@ -37,7 +37,7 @@ table's "typical enforce" column as the default (see constraint-format.md).
 
 #### Biome
 
-Static analysis, formatting, and (via Biotype) TypeScript type inference.
+Static analysis and formatting for TypeScript projects.
 
 - **Install:** `npm install --save-dev --save-exact @biomejs/biome`
 - **Init:** `npx @biomejs/biome init`
@@ -72,11 +72,13 @@ Zero schema duplication — generates validators directly from TypeScript types.
 
 - **Install:** `npm install --save-dev typia`
 - **Init:** `npx typia setup` (configures the TypeScript transformer)
-- **Run:** Compile with `tsc` or run tests — Typia validates at compile time
-  and runtime
-- **Pass/fail:** Compilation success = types match. `TypeGuardError` at runtime
-  = validation failure at a trust boundary. Test runner reports assertion
-  failures with the mismatched type path.
+- **Run:** First run `tsc --noEmit` to confirm the TypeScript/Typia transformer
+  is configured correctly. Then run unit/integration tests that execute Typia
+  validators (`typia.assert(...)`, `typia.validate(...)`) at trust boundaries.
+- **Pass/fail:** `tsc --noEmit` success = build/tooling check only; it does
+  **not** prove runtime data is valid. Validation passes when validator-exercising
+  tests complete without `TypeGuardError`. Runtime failures indicate a
+  trust-boundary type mismatch.
 
 #### ArkType (set-theory based)
 

--- a/plugins/constraint/skills/constraint-write/README.md
+++ b/plugins/constraint/skills/constraint-write/README.md
@@ -1,0 +1,21 @@
+# Constraint Write
+
+Conversational constraint authoring — turn natural language rules into structured `constraints/*.md` files.
+
+## Usage
+
+Invoke with `/constraint-write` or ask to "write a constraint", "定義 constraint".
+
+The agent also proactively suggests writing constraints when it detects
+prohibition, obligation, or invariant language in conversation.
+
+## Constraint Format
+
+Each constraint file uses Given/When/Then/Unless/Examples/Properties sections
+in a legal/BDD hybrid structure. See `references/constraint-format.md` for the
+full specification and examples.
+
+## Guided Flow
+
+After writing a constraint, the skill suggests running `/constraint-generate`
+to produce deterministic test artifacts.

--- a/plugins/constraint/skills/constraint-write/SKILL.md
+++ b/plugins/constraint/skills/constraint-write/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: constraint-write
+description: >-
+  Use when the user asks to "/constraint-write", "write constraint",
+  "define constraint", "幫我寫 constraint", "定義 constraint", or when
+  the agent detects prohibition ("不能", "禁止", "must not"), obligation
+  ("必須", "一定要", "always"), or invariant ("roundtrip", "idempotent")
+  language in conversation and wants to suggest writing a constraint.
+---
+
+# Constraint Write
+
+You are helping the user articulate and document constraints in structured
+natural language. Constraints are the user's laws; deterministic tools are
+the judges.
+
+## Workflow
+
+1. If the user describes a rule, use dialogue to clarify the constraint
+   one section at a time: Given → When → Then → Unless → Examples → Properties
+2. Read `references/constraint-format.md` for the canonical format
+3. Scan existing `constraints/*.md` to determine the next available
+   RULE_ID number for the domain
+4. Each constraint **must** have at least 3 rows in the Examples table —
+   no examples = no enforcement
+5. Write the constraint to `constraints/<RULE_ID>-<slug>.md`
+6. Create the `constraints/` directory if it doesn't exist
+7. After writing, suggest:
+   "Constraint 已寫好。要我用 `/constraint-generate` 產生 test artifact 嗎？"
+
+## Proactive Suggestion
+
+When the user uses prohibition ("不能", "禁止", "must not"), obligation
+("必須", "一定要", "always"), or invariant ("roundtrip", "idempotent")
+language in conversation, propose writing a constraint to capture that rule.
+
+## Property Patterns
+
+Consult `references/property-patterns.md` when helping the user write the
+Properties section of a constraint.

--- a/plugins/constraint/skills/constraint-write/references/constraint-format.md
+++ b/plugins/constraint/skills/constraint-write/references/constraint-format.md
@@ -1,0 +1,190 @@
+# Constraint Format Reference
+
+This document is the canonical format specification for constraint files. Both `constraint-write` (authoring) and `constraint-generate` (artifact generation) depend on this format.
+
+## File Location Convention
+
+All constraint files live in the repository root under:
+
+```
+constraints/<RULE_ID>-<slug>.md
+```
+
+- `<RULE_ID>`: unique identifier (see RULE_ID Naming below)
+- `<slug>`: kebab-case human-readable summary
+
+Example: `constraints/USER_003-soft-deleted-no-login.md`
+
+## RULE_ID Naming
+
+Format: `<DOMAIN>_<NNN>`
+
+- **DOMAIN**: short uppercase label chosen by the user (e.g. `USER`, `MONEY`, `API`, `AUTH`, `ORDER`)
+- **NNN**: zero-padded sequential number within that domain (e.g. `001`, `002`, `003`)
+
+`constraint-write` should scan existing `constraints/*.md` files and suggest the next available number for the given domain.
+
+## Frontmatter
+
+Every constraint file begins with YAML frontmatter between `---` fences.
+
+| Field | Required | Description |
+|---|---|---|
+| `rule` | yes | Unique identifier (e.g. `USER_003`). Used for cross-reference and artifact file naming. |
+| `kind` | yes | Constraint classification: `permission`, `prohibition`, `obligation`, `invariant`, or `protocol`. See Kind Classification below. |
+| `scope` | yes | Glob pattern(s) specifying which source files this constraint covers (e.g. `src/auth/**, src/user/**`). |
+| `subject` | no | The domain entity involved (e.g. `User`, `Invoice`, `Transaction`). |
+| `enforce` | no | Comma-separated enforcement methods: `lint`, `ast-grep`, `validation`, `pbt`, `mutation`. When omitted, `constraint-generate` uses the Kind table's typical enforce column as default. |
+
+## Kind Classification
+
+| Kind | Semantic Meaning | Typical Enforce |
+|---|---|---|
+| `permission` | Under certain conditions, an action is allowed | validation, guard |
+| `prohibition` | An action is forbidden | lint, ast-grep |
+| `obligation` | An action is required | lint, validation |
+| `invariant` | A mathematical property that must always hold | pbt |
+| `protocol` | An ordering or sequencing constraint on operations | pbt (state machine) |
+
+### Kind as Default Enforce
+
+When the `enforce` field is omitted from frontmatter, `constraint-generate` uses the **Typical Enforce** column from the Kind table above as the default. The generator may also add extra enforcement layers based on the constraint body content (e.g. adding `pbt` if a Properties section is present).
+
+## Body Sections
+
+The constraint body uses a legal/BDD hybrid structure. Each section maps directly to a test generation target.
+
+| Section | Purpose | Maps To |
+|---|---|---|
+| **Given** | Preconditions / initial state | Test setup (arrange) |
+| **When** | Triggering action | Test action (act) |
+| **Then** | Expected outcome | Test assertion (assert) |
+| **Unless** | Exception conditions + alternative outcomes | Additional test branches |
+| **Examples** | Concrete input/output table | Parameterized unit tests (`it.each` / `test.each`) |
+| **Properties** | Semi-formal universal properties | fast-check `fc.property()` tests |
+
+All sections use `## Heading` level.
+
+### Unless Syntax
+
+Unless contains one or more exception groups. Each group has **condition lines** (no arrow prefix) and **outcome lines** (`→` prefix):
+
+```markdown
+## Unless
+- condition (no arrow)
+- → outcome (arrow prefix)
+
+- another condition
+- → another outcome
+```
+
+Key rules:
+- **Condition lines**: plain list items describing when the exception applies
+- **Outcome lines**: prefixed with `→`, describing what happens instead of the Then outcome
+- **Multiple groups**: separated by a blank line between them
+- **Logical OR**: groups are combined with OR semantics — if any group's conditions are met, its outcome applies
+- The agent distinguishes condition lines from outcome lines by the `→` prefix
+
+### Examples Section
+
+The Examples section **must** be a Markdown table with **at least 3 rows** of data (not counting the header). This is a hard requirement:
+
+> No concrete examples = no enforcement.
+
+The table maps directly to parameterized unit tests (`it.each` / `test.each`). Each row becomes one test case. Column headers become parameter names.
+
+### Properties Section
+
+Properties use a semi-formal universal quantifier syntax:
+
+```
+forall X where condition: property
+```
+
+Each property maps to a `fc.property()` call in fast-check. The `forall` variables become arbitraries, the `where` clause becomes a filter or precondition, and the property expression becomes the assertion.
+
+## Complete Examples
+
+### Example 1: Domain/State Constraint
+
+```markdown
+# constraints/USER_003-soft-deleted-no-login.md
+---
+rule: USER_003
+kind: permission
+scope: src/auth/**, src/user/**
+subject: User
+enforce: validation, pbt
+---
+
+## Given
+- user.state = soft_deleted
+
+## When
+- password login attempted
+
+## Then
+- deny login
+- return AUTH_DENIED
+
+## Unless
+- user.state = recoverable AND deleted_at <= 30 days
+- → allow recovery flow only, return RECOVERY_REQUIRED
+
+## Examples
+| user.state | deleted_at | action | expected |
+|---|---|---|---|
+| soft_deleted | 60 days ago | login | AUTH_DENIED |
+| hard_deleted | 90 days ago | login | AUTH_DENIED |
+| recoverable | 10 days ago | login | RECOVERY_REQUIRED |
+| recoverable | 45 days ago | login | AUTH_DENIED |
+| active | - | login | SUCCESS |
+
+## Properties
+- forall user where state = soft_deleted AND NOT recoverable:
+  login(user) → AUTH_DENIED
+- forall user where state = hard_deleted:
+  search(query) never contains user
+```
+
+### Example 2: Code-Level Constraint
+
+```markdown
+# constraints/MONEY_001-no-float-money.md
+---
+rule: MONEY_001
+kind: prohibition
+scope: src/billing/**, src/payment/**
+enforce: ast-grep, pbt
+---
+
+## Given
+- 任何處理金額的程式碼
+
+## When
+- 宣告變數、函式參數、回傳值涉及金額
+
+## Then
+- 必須使用 Decimal 型別
+- 乘除運算必須指定 rounding mode
+
+## Unless
+- 顯示用途的格式化函式（toDisplayString）可回傳 string
+- 測試中的 fixture 資料可用 literal number
+
+## Examples
+| context | type used | valid |
+|---|---|---|
+| calculateTotal() return | Decimal | yes |
+| calculateTotal() return | number | no |
+| invoice.amount field | Decimal | yes |
+| invoice.amount field | float | no |
+| toDisplayString() return | string | yes |
+| test fixture | 19.99 (literal) | yes |
+
+## Properties
+- forall (a: Decimal, b: Decimal, c: Decimal):
+  (a + b) + c === a + (b + c)
+- forall (amount: Decimal, currency: Currency):
+  toUSD(toTWD(amount)) - amount < 0.01
+```

--- a/plugins/constraint/skills/constraint-write/references/constraint-format.md
+++ b/plugins/constraint/skills/constraint-write/references/constraint-format.md
@@ -40,7 +40,7 @@ Every constraint file begins with YAML frontmatter between `---` fences.
 
 | Kind | Semantic Meaning | Typical Enforce |
 |---|---|---|
-| `permission` | Under certain conditions, an action is allowed | validation, guard |
+| `permission` | Under certain conditions, an action is allowed | validation |
 | `prohibition` | An action is forbidden | lint, ast-grep |
 | `obligation` | An action is required | lint, validation |
 | `invariant` | A mathematical property that must always hold | pbt |

--- a/plugins/constraint/skills/constraint-write/references/constraint-format.md
+++ b/plugins/constraint/skills/constraint-write/references/constraint-format.md
@@ -99,9 +99,10 @@ Properties use a semi-formal universal quantifier syntax:
 
 ```
 forall X where condition: property
+forall (X, Y): property
 ```
 
-Each property maps to a `fc.property()` call in fast-check. The `forall` variables become arbitraries, the `where` clause becomes a filter or precondition, and the property expression becomes the assertion.
+The `where` clause is optional. When present, it becomes a filter or precondition. Each property maps to a `fc.property()` call in fast-check. The `forall` variables become arbitraries and the property expression becomes the assertion.
 
 ## Complete Examples
 

--- a/plugins/constraint/skills/constraint-write/references/property-patterns.md
+++ b/plugins/constraint/skills/constraint-write/references/property-patterns.md
@@ -1,0 +1,201 @@
+# Property-Based Testing Patterns
+
+A catalog of common PBT patterns for writing the `Properties` section of constraint files. Each pattern includes a semi-formal template and a concrete TypeScript fast-check example.
+
+## Roundtrip
+
+Encoding followed by decoding (or vice versa) returns the original value.
+
+**Template:** `forall x: decode(encode(x)) === x`
+
+**Typical domains:** JSON serialization, API request/response mapping, URL encoding, base64.
+
+```typescript
+import * as fc from "fast-check";
+
+fc.assert(
+  fc.property(fc.jsonValue(), (original) => {
+    const serialized = JSON.stringify(original);
+    const deserialized = JSON.parse(serialized);
+    expect(deserialized).toEqual(original);
+  })
+);
+```
+
+## Idempotent
+
+Applying a function twice yields the same result as applying it once.
+
+**Template:** `forall x: f(f(x)) === f(x)`
+
+**Typical domains:** formatting, normalization, deduplication, cache warming.
+
+```typescript
+import * as fc from "fast-check";
+
+function normalize(s: string): string {
+  return s.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+fc.assert(
+  fc.property(fc.string(), (input) => {
+    const once = normalize(input);
+    const twice = normalize(once);
+    expect(twice).toBe(once);
+  })
+);
+```
+
+## Invariant
+
+A measurable property is preserved across a transformation.
+
+**Template:** `forall xs: sort(xs).length === xs.length`
+
+**Typical domains:** collection operations, tree transformations, data migrations.
+
+```typescript
+import * as fc from "fast-check";
+
+fc.assert(
+  fc.property(fc.array(fc.integer()), (xs) => {
+    const sorted = [...xs].sort((a, b) => a - b);
+    // Length is preserved
+    expect(sorted.length).toBe(xs.length);
+    // Every original element is present
+    expect(sorted.sort()).toEqual([...xs].sort());
+  })
+);
+```
+
+## Commutative
+
+The order of operands does not affect the result.
+
+**Template:** `forall a, b: f(a, b) === f(b, a)`
+
+**Typical domains:** set union/intersection, config merging, permission combination.
+
+```typescript
+import * as fc from "fast-check";
+
+function mergeConfigs(
+  a: Record<string, number>,
+  b: Record<string, number>
+): Record<string, number> {
+  // A commutative merge: take the max value for each key
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  const result: Record<string, number> = {};
+  for (const k of keys) {
+    result[k] = Math.max(a[k] ?? 0, b[k] ?? 0);
+  }
+  return result;
+}
+
+const configArb = fc.dictionary(
+  fc.string({ minLength: 1, maxLength: 5 }),
+  fc.integer({ min: 0, max: 100 })
+);
+
+fc.assert(
+  fc.property(configArb, configArb, (a, b) => {
+    expect(mergeConfigs(a, b)).toEqual(mergeConfigs(b, a));
+  })
+);
+```
+
+## Model-Based
+
+An implementation under test agrees with a simpler reference implementation on all inputs.
+
+**Template:** `forall input: impl(input) === reference(input)`
+
+**Typical domains:** refactored code vs original, optimized path vs naive path, new parser vs legacy parser.
+
+```typescript
+import * as fc from "fast-check";
+
+// Reference: simple but correct
+function fibNaive(n: number): number {
+  if (n <= 1) return n;
+  return fibNaive(n - 1) + fibNaive(n - 2);
+}
+
+// Implementation: optimized
+function fibFast(n: number): number {
+  let a = 0, b = 1;
+  for (let i = 0; i < n; i++) {
+    [a, b] = [b, a + b];
+  }
+  return a;
+}
+
+fc.assert(
+  fc.property(fc.integer({ min: 0, max: 30 }), (n) => {
+    expect(fibFast(n)).toBe(fibNaive(n));
+  })
+);
+```
+
+## State Machine
+
+A sequence of arbitrary transitions, applied from an initial state, always lands in a valid state.
+
+**Template:** `forall transitions: apply(transitions, initial).state ∈ validStates`
+
+**Typical domains:** entity lifecycle (order status, user account state), protocol handshakes, UI state.
+
+```typescript
+import * as fc from "fast-check";
+
+type OrderStatus = "draft" | "placed" | "shipped" | "delivered" | "cancelled";
+type OrderAction = "place" | "ship" | "deliver" | "cancel";
+
+const validTransitions: Record<OrderStatus, Partial<Record<OrderAction, OrderStatus>>> = {
+  draft:     { place: "placed", cancel: "cancelled" },
+  placed:    { ship: "shipped", cancel: "cancelled" },
+  shipped:   { deliver: "delivered" },
+  delivered: {},
+  cancelled: {},
+};
+
+const validStates = new Set<OrderStatus>(["draft", "placed", "shipped", "delivered", "cancelled"]);
+
+function applyAction(state: OrderStatus, action: OrderAction): OrderStatus {
+  return validTransitions[state][action] ?? state;
+}
+
+const actionArb = fc.constantFrom<OrderAction>("place", "ship", "deliver", "cancel");
+
+fc.assert(
+  fc.property(fc.array(actionArb, { minLength: 1, maxLength: 20 }), (actions) => {
+    let state: OrderStatus = "draft";
+    for (const action of actions) {
+      state = applyAction(state, action);
+      expect(validStates.has(state)).toBe(true);
+    }
+  })
+);
+```
+
+## Common Pitfalls
+
+### Trivially True Properties
+
+A property that can never fail provides zero value. Watch for:
+
+- **Tautologies:** `forall x: x === x` — always true, tests nothing.
+- **Vacuous preconditions:** `forall x where false: anything` — the precondition filters out all inputs, so the property never runs.
+- **Weak assertions:** `forall x: typeof f(x) === "object"` — almost any function returning an object passes this; it does not test behavior.
+
+**How to detect:** If a property still passes after you deliberately break the code under test, the property is trivially true.
+
+### Mutation Testing as a Safety Net
+
+Mutation testing (Layer 4 in the enforcement pipeline) systematically catches trivially true properties:
+
+1. Stryker introduces small code mutations (e.g., `+` to `-`, `>` to `>=`, remove a statement).
+2. If your property still passes after a mutation, the mutant **survives** — meaning your property did not detect the change.
+3. A surviving mutant signals either a **weak property** (strengthen the assertion) or a **missing property** (add a new one covering the mutated code path).
+
+**Rule of thumb:** A property that does not kill any mutants is suspect. Aim for each property to kill at least one mutant that no other property catches.

--- a/plugins/constraint/skills/constraint-write/references/property-patterns.md
+++ b/plugins/constraint/skills/constraint-write/references/property-patterns.md
@@ -60,10 +60,11 @@ import * as fc from "fast-check";
 fc.assert(
   fc.property(fc.array(fc.integer()), (xs) => {
     const sorted = [...xs].sort((a, b) => a - b);
+    const expected = [...xs].sort((a, b) => a - b);
     // Length is preserved
     expect(sorted.length).toBe(xs.length);
     // Every original element is present
-    expect(sorted.sort()).toEqual([...xs].sort());
+    expect(sorted).toEqual(expected);
   })
 );
 ```


### PR DESCRIPTION
## Summary

- Add `constraint` plugin with three skills: `constraint-write` (conversational constraint authoring), `constraint-generate` (deterministic test artifact generation), `constraint-enforce` (4-layer enforcement pipeline)
- Include reference files: constraint format spec, PBT property patterns, toolchain matrix, enforcement layers, mutation feedback guide
- Register plugin in marketplace.json and update CLAUDE.md

## Test plan

- [x] All 13 expected files exist under `plugins/constraint/`
- [x] `marketplace.json` is valid JSON
- [x] All 3 SKILL.md frontmatter blocks parse as valid YAML
- [x] Shared `constraint-format.md` is identical in both skills
- [x] SKILL.md field names match constraint-format.md spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)