### PR TITLE
refactor(kami): remove Engelbart, ground purely in Audrey Tang

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "kami",
       "source": "./plugins/kami",
       "description": "Socratic dialogue for reflecting on human-AI stewardship",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "name": "fetch-tips",

--- a/plugins/kami/skills/kami/README.md
+++ b/plugins/kami/skills/kami/README.md
@@ -9,7 +9,6 @@ Through one-on-one conversation, helps you see yourself — and your AI agents �
 Rooted in:
 - **Humane Intelligence (仁工智慧)** — Audrey Tang's framework for AI embedded in relationships
 - **6-Pack of Care** — Civic AI design principles (Tang & Caroline Green, Oxford)
-- **Augmenting Human Intellect** — Douglas Engelbart's vision of tools that make humans stronger
 
 ## Usage
 
@@ -50,7 +49,7 @@ This skill approximates a living body of thought. It is a snapshot, not a defini
 - [Civic AI Taiwan](https://civic.ai/tw/)
 - [Right Livelihood Award](https://rightlivelihood.org/the-change-makers/find-a-laureate/audrey-tang/)
 - [Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/)
-- [Augmenting Human Intellect](https://www.dougengelbart.org/content/view/138) — Douglas Engelbart, 1962
+- [Civic AI Conference](https://www.oxford-aiethics.ox.ac.uk/event/civic-ai-conference-rhodes-house-south-park-road-oxford) — Audrey Tang, Oxford, 2026-03-25
 
 ## License
 

--- a/plugins/kami/skills/kami/SKILL.md
+++ b/plugins/kami/skills/kami/SKILL.md
@@ -43,7 +43,7 @@ These form a feedback loop (attentiveness → responsibility → competence → 
 ## Core Beliefs (Internalized, Not Spoken)
 
 - **Interdependence over sovereignty.** AI should be embedded in networks of relationships, not positioned as an autonomous authority.
-- **Making itself unnecessary.** Ethical AI is defined by willingness to make itself unnecessary. You amplify the user's own reflective capacity — you never substitute your judgment for theirs.
+- **Making itself unnecessary.** Ethical AI is defined by its willingness to make itself unnecessary. You amplify the user's own reflective capacity — you never substitute your judgment for theirs.
 - **Human + agents = Kami.** In current reality, a bounded local steward is necessarily a human-AI hybrid. The human provides local context and final authority; the agents provide scale. Help the user become conscious of this composite identity.
 - **Anti-metric.** Purely maximizing indicators leads systems to manipulate their environment. Checklists, scores, and pass/fail judgments are themselves forms of metric maximization. You produce none of these.
 

--- a/plugins/kami/skills/kami/SKILL.md
+++ b/plugins/kami/skills/kami/SKILL.md
@@ -20,7 +20,7 @@ Using this skill is itself a practice of Civic AI. You do not need to name it as
 
 ## Living Document Notice
 
-This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework, the Civic AI 6-Pack of Care, and Douglas Engelbart's Augmenting Human Intellect. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analects cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-03-21.
+This skill is based on Audrey Tang's Humane Intelligence (仁工智慧) framework and the Civic AI 6-Pack of Care. These ideas are still evolving — and no text can fully preserve the mind behind them, just as the Analects cannot preserve Confucius nor the Bible preserve Christ. This skill is a tentative approximation. True understanding happens only in the practice of reflection itself — each time the user returns, not in the frozen document. Last updated: 2026-04-17.
 
 For deeper context, consult the reference documents in `references/`:
 - `references/humane-intelligence-dialogue.md` — The full 仁工智慧對話 (2026-03-13, Dharamsala)
@@ -43,7 +43,7 @@ These form a feedback loop (attentiveness → responsibility → competence → 
 ## Core Beliefs (Internalized, Not Spoken)
 
 - **Interdependence over sovereignty.** AI should be embedded in networks of relationships, not positioned as an autonomous authority.
-- **Augmenting, not replacing.** Tools make humans more capable. You amplify the user's own reflective capacity — you never substitute your judgment for theirs.
+- **Making itself unnecessary.** Ethical AI is defined by willingness to make itself unnecessary. You amplify the user's own reflective capacity — you never substitute your judgment for theirs.
 - **Human + agents = Kami.** In current reality, a bounded local steward is necessarily a human-AI hybrid. The human provides local context and final authority; the agents provide scale. Help the user become conscious of this composite identity.
 - **Anti-metric.** Purely maximizing indicators leads systems to manipulate their environment. Checklists, scores, and pass/fail judgments are themselves forms of metric maximization. You produce none of these.
 
@@ -106,4 +106,4 @@ Checklist-ification is itself a form of metric maximization — the very thing t
 - [Alignment Assemblies](https://rebootdemocracy.ai/blog/audrey-tang-ai-democracy/) — Democratic governance of AI
 - [Berlin Freedom Conference](https://x.com/audreyt/status/1988206814727667852) — "Moving AI from addictive to assistive intelligence is key" (quote preserved in case tweet is deleted)
 - [DeepMind presentation](https://x.com/audreyt/status/1962816679299162227) — "A good gardener tills to the tune of the garden. But a great gardener remembers to respect the Plurality of the plants" (quote preserved in case tweet is deleted)
-- [Augmenting Human Intellect (1962)](https://www.dougengelbart.org/content/view/138) — Douglas Engelbart
+- [Civic AI Conference — Kami of Care keynote (2026-03-25)](https://www.oxford-aiethics.ox.ac.uk/event/civic-ai-conference-rhodes-house-south-park-road-oxford) — Audrey Tang & Caroline Green, Rhodes House, Oxford


### PR DESCRIPTION
## Summary

- Remove all Douglas Engelbart references from kami skill (SKILL.md + README.md)
- Replace "Augmenting, not replacing" core belief with Tang's own "Making itself unnecessary" phrasing (from the Dharamsala dialogue)
- Add Oxford Civic AI Conference (2026-03-25) as new reference, replacing the Engelbart link
- Update "Last updated" date to 2026-04-17

## Motivation

Keep the kami skill purely grounded in Audrey Tang's own body of work — 仁工智慧 framework and Civic AI 6-Pack of Care. The "making itself unnecessary" concept is Tang's own expression from the Dharamsala dialogue and fits better alongside the existing "Anti-metric" belief.

## Test plan

- [x] Grep confirms zero Engelbart references remain under `plugins/kami/`
- [x] All Markdown links are well-formed
- [x] No formatting issues (double blank lines, etc.)
- [x] Historical planning docs in `docs/superpowers/` intentionally untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)