### PR TITLE
feat(review-loop): migrate review-loop skill to a dong3 plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "caasi's plugin collection for Claude Code",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -50,6 +50,12 @@
       "source": "./plugins/old-react",
       "description": "FP-thinking review and refactor rules for pre-RSC React projects",
       "version": "0.2.0"
+    },
+    {
+      "name": "review-loop",
+      "source": "./plugins/review-loop",
+      "description": "Assisted multi-reviewer review loop — local Claude + Codex gate first, then GitHub Copilot for PRs; never merges autonomously",
+      "version": "0.1.0"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Claude Code plugin marketplace (`caasi/dong3`) containing seven independent plugins under `plugins/`. No traditional build system — this is a skill/plugin distribution repo.
+A Claude Code plugin marketplace (`caasi/dong3`) containing eight independent plugins under `plugins/`. No traditional build system — this is a skill/plugin distribution repo.
 
 Install: `claude plugin marketplace add caasi/dong3`
 
@@ -20,6 +20,7 @@ plugins/
   kami/                           # Socratic dialogue on human-AI stewardship
   old-react/                      # FP-thinking review/refactor for pre-RSC React
   owasp/                          # OWASP security review with offline references
+  review-loop/                    # Assisted multi-reviewer loop (Claude + Codex → Copilot), never auto-merges
 tools/                            # Repo-level dev tooling (NOT shipped to skill users)
   old-react/                      # Validator + fixtures for old-react rule files
 docs/superpowers/                 # Design specs and implementation plans
@@ -52,6 +53,8 @@ plugins/<name>/
 **constraint:** Three skills for NL metaprogramming — humans write constraints in structured natural language (`constraints/*.md` with Given/When/Then/Unless/Examples/Properties), agents generate deterministic test artifacts. `constraint-write` for authoring, `constraint-generate` for language-agnostic artifact generation (see `references/toolchain-matrix.md`; TS is the primary reference, OCaml verified), `constraint-enforce` for running the enforcement pipeline.
 
 **old-react:** FP-thinking review/refactor for pre-RSC React (classes, hooks, Redux/MobX/observable, Reselect, Immer). Ships **architectural** rules only — categories already covered by the React-Compiler diagnostics in `eslint-plugin-react-hooks` v5+ (`recommended-latest`) and TypeScript discriminated unions are deferred. Five active categories: `model-`, `effect-`, `compose-`, `purity-`, `hooks-`. Two deferred: `immutable-`, `message-`. Canonical rule list lives in `plugins/old-react/skills/old-react/SKILL.md` (don't duplicate counts here — they drift). Rule bodies use FP/TEA pattern terms only; brand names live in `references/lib-suggestions.md`. Rules ship from real review examples, not a planned list (see spec §9 "Adding rules — real-example-driven"). One slash command: `/old-react [review|refactor] [path]`. Spec: `docs/superpowers/specs/001-old-react-skill-design.md`. Lineage source: `docs/old-react.md`.
+
+**review-loop:** Assisted, not autonomous, multi-reviewer convergence loop. Local reviewers run first — a Claude subagent always, plus Codex in a `tmux` pane when available — then GitHub Copilot for PR targets. Helper scripts in `skills/review-loop/scripts/` (`codex-pane.sh`, `copilot.sh`, `pr-comments.sh`) are referenced via `${CLAUDE_PLUGIN_ROOT}`. Target scope is any changed artifact: code or design artifacts (specs, plans, docs). One slash command: `/review-loop [PR# | branch | blank]`. Spec: `docs/superpowers/specs/002-review-loop-plugin-design.md`.
 
 ## Versioning
 

--- a/plugins/review-loop/.claude-plugin/plugin.json
+++ b/plugins/review-loop/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "review-loop",
+  "description": "Assisted multi-reviewer convergence loop — local Claude + Codex gate first, then GitHub Copilot for PRs; tiers comments, auto-fixes mechanical ones, never merges autonomously",
+  "author": {
+    "name": "caasi"
+  },
+  "homepage": "https://github.com/caasi/dong3",
+  "repository": "https://github.com/caasi/dong3",
+  "license": "MIT",
+  "keywords": [
+    "code-review",
+    "pull-request",
+    "copilot",
+    "codex",
+    "review-loop",
+    "tmux"
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/"
+}

--- a/plugins/review-loop/commands/review-loop.md
+++ b/plugins/review-loop/commands/review-loop.md
@@ -1,0 +1,31 @@
+---
+description: Run the assisted multi-reviewer review loop (local Claude + Codex gate, then Copilot for PRs)
+argument-hint: "[PR-number | branch | (blank = current branch vs base)]"
+---
+
+# /review-loop
+
+Run the `review-loop` skill against a target.
+
+**Usage:**
+
+- `/review-loop` — review the current branch versus its base (local diff target).
+- `/review-loop <branch>` — review the given branch versus its base.
+- `/review-loop <PR-number>` — review an open GitHub PR (adds the Copilot phase).
+
+**Target:**
+
+The change under review may be code or design artifacts (specs, plans, docs). For
+document targets the loop reviews clarity, consistency, structure, and factual
+accuracy; TDD / one-commit-per-item discipline applies only to executable changes.
+
+**Behavior:**
+
+Invoke the `review-loop` skill. Load-bearing invariants the skill enforces:
+
+- **Local gate first** — a Claude subagent always reviews; Codex (in a tmux pane)
+  joins when `$TMUX` is set and `codex` is on `PATH`, otherwise it is skipped
+  silently. The local gate must be clean before any GitHub PR is opened.
+- **Copilot is GitHub-only** — requested only for PR targets, after the local gate.
+- **Never merges autonomously** — the author decides T2/T3 fixes and the final
+  merge. Default to a merge commit to preserve history.

--- a/plugins/review-loop/skills/review-loop/README.md
+++ b/plugins/review-loop/skills/review-loop/README.md
@@ -1,0 +1,56 @@
+# review-loop
+
+An assisted (not autonomous) multi-reviewer convergence loop for changes — code or
+design artifacts (specs, plans, docs). It runs local reviewers first and only then
+reaches for GitHub Copilot, and it never merges on its own.
+
+## What this is
+
+A Claude Code skill that loops reviewers over a diff until they stop finding
+problems, classifying every comment into tiers and pausing for your judgment on the
+architectural ones. The point of the local-first ordering: Claude and Codex
+reviewing **together** catch different classes of issues and tighten the diff before
+it ever reaches GitHub, so Copilot has much less to flag and rounds converge faster.
+
+## Reviewer roster (in priority order)
+
+1. **Claude subagent** — always; needs nothing extra.
+2. **Codex** (in a `tmux` pane) — when `$TMUX` is set and `codex` is on `PATH`;
+   skipped silently otherwise.
+3. **GitHub Copilot** — only for GitHub PR targets, after the local gate is clean.
+
+## Requirements
+
+- **Always usable:** the Claude subagent reviewer.
+- **Codex (optional):** a `tmux` session and the `codex` CLI on `PATH`.
+- **Copilot phase (optional):** an authenticated `gh` CLI and `jq`; GitHub PRs only.
+
+## Tiers
+
+- **T1 mechanical** — typos, lint, null checks, doc fixes — auto-fixed.
+- **T2 local refactor** — extraction, naming, validation — resolved with you first.
+- **T3 architectural** — module moves, API shape, "should this exist" — your call.
+
+For document targets, findings are about clarity, consistency, structure, and
+factual accuracy; the TDD / one-commit-per-item discipline applies only where there
+is executable behavior.
+
+## How to use
+
+```text
+review this branch with review-loop
+```
+
+Or the slash command:
+
+```text
+/review-loop              # current branch vs base
+/review-loop 1234         # open PR #1234 (adds Copilot)
+```
+
+## Non-goals
+
+- Not autonomous — you decide T2/T3 fixes and the final merge.
+- Not a squash-merge tool — defaults to a merge commit to preserve history.
+- The Copilot path is GitHub-only; on other forges the local Claude + Codex gate
+  still applies.

--- a/plugins/review-loop/skills/review-loop/SKILL.md
+++ b/plugins/review-loop/skills/review-loop/SKILL.md
@@ -19,14 +19,14 @@ Claude and Codex reviewing **together** produces noticeably better output than e
 - **Codex reviewer (optional):** a `tmux` session (`$TMUX` set) and the `codex` CLI on `PATH`. Absent either, the Codex step is skipped silently.
 - **GitHub Copilot phase (optional):** the authenticated `gh` CLI and `jq`. Only used for GitHub PR targets.
 
-The helper scripts use POSIX-friendly options and resolve `codex`/`gh` from `PATH`, so the skill is self-contained and portable across machines.
+The helper scripts use POSIX-friendly options and resolve their CLI dependencies (`codex`, `tmux`, `gh`, `jq`) from `PATH`, so the skill is self-contained and portable across machines.
 
 ## Inputs
 
 - **Target** — one of:
   - a **local diff/branch** (default: current branch vs its base), or
   - a **GitHub PR number** (or a branch that already has an open PR → treat as GitHub target).
-  - The diff may contain code, design docs (specs/plans), or both — the loop reviews whatever changed.
+  - The diff may contain code, design artifacts (specs, plans, docs), or both — the loop reviews whatever changed.
 - Repo / base branch inferred from the current working directory.
 
 ## Reviewer roster & priority

--- a/plugins/review-loop/skills/review-loop/SKILL.md
+++ b/plugins/review-loop/skills/review-loop/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: review-loop
+description: General assisted review loop for changes — code or design artifacts (specs, plans, docs). Prefers local reviewers (Claude subagent + Codex in a tmux pane) as the first gate; for GitHub PR targets, also requests Copilot after the PR is open. Loops each reviewer until clean or its usage limit, classifies comments into tiers, auto-fixes mechanical ones, pauses on architectural ones for user judgment. Never merges autonomously.
+---
+
+# Review Loop (Assisted)
+
+Assisted, not autonomous. Preserves the author's architectural voice and learning across review cycles. General-purpose: the target may be a **local branch / working diff** (no remote needed) or a **GitHub PR**, and the changes under review may be **code or design artifacts** (specs, plans, docs).
+
+**Local reviewers are preferred and run first.** A Claude subagent and Codex (via the `codex` CLI in a tmux pane) cost nothing extra and are fast, so they are the first gate. GitHub Copilot is added only when the target is a GitHub PR, and only after the local gate is clean.
+
+## Why this loop exists
+
+Claude and Codex reviewing **together** produces noticeably better output than either model alone — they catch different classes of issues, and Codex's pass tightens the diff before it ever reaches GitHub. The downstream payoff: by the time Copilot sees the PR, there's much less for it to complain about, so review rounds converge faster. Front-loading combined local Claude+Codex review as the first gate is the entire reason this loop exists.
+
+## Requirements
+
+- **Always usable:** the Claude subagent reviewer needs nothing extra.
+- **Codex reviewer (optional):** a `tmux` session (`$TMUX` set) and the `codex` CLI on `PATH`. Absent either, the Codex step is skipped silently.
+- **GitHub Copilot phase (optional):** the authenticated `gh` CLI and `jq`. Only used for GitHub PR targets.
+
+The helper scripts use POSIX-friendly options and resolve `codex`/`gh` from `PATH`, so the skill is self-contained and portable across machines.
+
+## Inputs
+
+- **Target** — one of:
+  - a **local diff/branch** (default: current branch vs its base), or
+  - a **GitHub PR number** (or a branch that already has an open PR → treat as GitHub target).
+  - The diff may contain code, design docs (specs/plans), or both — the loop reviews whatever changed.
+- Repo / base branch inferred from the current working directory.
+
+## Reviewer roster & priority
+
+1. **Local Claude subagent** — always. Dispatch a subagent (Task tool) to do the review.
+2. **Local Codex** (tmux pane) — when `$TMUX` is set and `codex` is on `PATH`. See A2.
+3. **GitHub Copilot** — only for GitHub PR targets, after the PR is open.
+
+## Helper scripts
+
+Prebuilt so you don't re-derive the same commands each run. All in `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/`, executable:
+
+- `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/codex-pane.sh {find | ensure | send <pane> <message> | capture <pane> | usage-limited <pane>}` — manage the Codex tmux pane. `ensure` finds-or-creates (splits the current window) and prints the pane id; its **exit code** matters: `0` ready, `10` a trust/onboarding prompt is showing (you must approve it), `1` Codex failed to start. `send` pastes a possibly multi-line message faithfully and submits it. `usage-limited` exits 0 when the pane shows a rate/usage-limit message.
+- `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh {status <pr> | request <pr> | rerequest <pr>}` — manage the Copilot reviewer. `request` uses REST; `rerequest` uses the GraphQL `requestReviews` mutation. Note: the first-ever Copilot review may need a one-time request through the GitHub UI (see B1).
+- `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh {fetch <pr> | clean-pass <pr>}` — paginated fetch of reviews + inline comments; `clean-pass` exits 0 when Copilot's newest review is a clean pass.
+
+Reach for these first. Only hand-write a command when a script genuinely doesn't cover the case.
+
+## Tiers (used for every reviewer's comments)
+
+- **T1 mechanical**: typos, lint, null checks, test-only changes, doc fixes, rename within one file.
+- **T2 local refactor**: method extraction, variable naming across a module, added validation.
+- **T3 architectural**: file/module moves, API shape, "should this exist", simplification, scope cuts.
+
+Per round: post the grouped findings, **resolve T2/T3 with the author first** (quote the comment, draft 2–3 approaches with trade-offs, recommend one, wait for their pick), **then** apply the fixes — T1 auto-fixed, T2/T3 done as chosen. One commit per item, TDD, and reply/note the commit hash. (TDD and one-commit-per-item apply to executable changes; for prose/doc targets there are no tests to write first — prefer one logical edit per finding and review for clarity, consistency, structure, and factual accuracy.) Architectural decisions always land before mechanical edits are committed.
+
+## Flow
+
+### Phase A — Local review (always first)
+
+**A0. Author pass first** — before touching anything, ask: "Any simplifications you'd collapse across these changes before I start?" Capture as a commit-plan override.
+
+**A1. Claude subagent review** — dispatch a subagent to review the diff. Classify findings into T1/T2/T3, post the grouped list, resolve T2/T3 picks, then apply fixes (per *Tiers*). Commit fixes; push only if a remote/PR branch exists, otherwise commit locally.
+
+**A2. Codex review** (only if `$TMUX` is set and `codex` is on `PATH`; otherwise skip silently — don't block, don't mention it):
+- **Find or open the Codex pane** (capture the exit code safely — a bare `rc=$?` after a `set -e` command substitution can abort before you read it):
+  ```bash
+  if pane=$(${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/codex-pane.sh ensure); then rc=0; else rc=$?; fi
+  ```
+  Splitting the current window is intentional: the Codex pane sits beside the working pane so the interaction is visible. Accept the narrower pane as the trade-off.
+  - `rc == 10` → Codex is showing a **trust/onboarding prompt**. Do **not** auto-approve it. Pause and tell the author: "Codex needs you to approve the folder-trust prompt in pane `$pane`, then say continue." Resume the Codex step once they confirm.
+  - `rc == 1` → Codex couldn't start; skip the Codex step (fall back to Claude-only) and note it.
+  - `rc == 0` → ready.
+- **Send the work and read the reply:**
+  ```bash
+  ${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/codex-pane.sh send "$pane" 'Please review this change: <paste diff or summary>'
+  ${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/codex-pane.sh capture "$pane"      # read Codex's reply
+  ```
+- **Loop Codex until clean or its usage limit:** classify its findings into tiers, resolve picks, fix, then re-send for re-review. Check `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/codex-pane.sh usage-limited "$pane"` (exit 0 = limited) each round. Repeat until **either**:
+  - Codex reports no remaining problems → Codex gate clean, **or**
+  - it hits a **usage / rate-limit** message. On detection: **stop the Codex sub-loop**, note "Codex hit its usage limit — falling back to Claude-only local review (+ Copilot if this is a GitHub target)," and continue without Codex.
+
+**A3. Converge the local gate** — re-run A1/A2 after fixes until Claude is clean **and** Codex is clean *when available* (Codex skipped for no-tmux/no-CLI, or stopped at its usage limit, counts as done). Only then proceed.
+
+### Phase B — GitHub Copilot (only for GitHub PR targets)
+
+**B0. Ensure a PR exists.** If the target is a branch with no PR yet, open it now with `gh pr create` — **only after Phase A is clean** (the local gate comes before opening a PR). If a PR number was given, skip creation.
+
+**B1. Request Copilot review** — get `copilot-pull-request-reviewer` onto the reviewer list before any polling, or the loop waits forever for a bot that was never asked:
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh status <num>     # who's requested vs who reviewed
+${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh request <num>    # add Copilot via REST
+```
+First-time caveat: on some repos REST returns 422 for the bot, and the GraphQL re-request can't run yet because it needs a bot node id that only exists once Copilot has reviewed. If `request` fails 422 and Copilot has never reviewed this PR, ask the author to trigger the first Copilot review through the GitHub UI once; every later round can then use `rerequest`.
+
+**B2. Pre-scan** — `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh fetch <num>` (paginated reviews + inline comments). Group unresolved comments into tiers, then handle them per *Tiers*.
+
+**B3. Re-request Copilot** after fixes push — Copilot won't re-examine otherwise: `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh rerequest <num>`. If a Codex pane is reachable, have Codex review the new commits **before** re-requesting Copilot (local gate first).
+
+**B4. Poll** — `/loop 3m` re-run `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh fetch <num>`. New comments → re-classify → B2.
+- **Copilot clean-pass stop signal:** when `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh clean-pass <num>` exits 0 (newest Copilot review contains **"and generated no new comments."**), **STOP immediately** — cancel the cron/`/loop` job, do not schedule another poll. Post: "Copilot review is clean — no new comments. Stopping the loop; your call on what's next (review / merge / more work)." Then wait.
+
+**B5. Repeat-comment guard (NL-based)** — for each new comment, compare semantically against prior comments on the same file/line. "Does this raise the same concern as a prior one that already had a fix commit?" If yes → **stop**, post "Copilot re-raised <X> after <commit>. Prior fix didn't satisfy it. Your call." and wait. Fingerprint (file:line + first 40 chars) is an acceptable fallback heuristic; NL comparison is the primary signal.
+
+## Exit conditions
+
+- **Local gate clean + (for GitHub) Copilot clean pass** ("and generated no new comments.") → stop and surface to the author. This is the primary, explicit stop signal — prefer it over inferring doneness from "no new comments for N polls".
+- **Codex usage limit** → stop only the Codex sub-loop; the rest of the loop continues.
+- **Merge** — never merge autonomously. Only on an explicit `merge` instruction. Default to a merge commit (`gh pr merge --merge`, not `--squash`) to preserve history; ask before deleting the branch, and prefer leaving the local branch in place for the author to prune. Honor the project's own merge conventions if they differ.
+
+## Learning capture
+
+After each round, append to a review journal in the repo (e.g. `.claude/pr-review-journal.md`, create if absent):
+- Target (PR # or branch), round N, which reviewer raised it (Claude / Codex / Copilot)
+- Comment → fix pattern
+- T3 decisions + chosen approach + why
+- Repeat-issue escalations (these = gaps in the project's conventions; candidates for the project's guidelines doc)
+
+Periodically distill recurring patterns into the project's conventions/guidelines doc.
+
+## Non-goals
+
+- Not fully autonomous. The author decides T2/T3 fixes and the final merge.
+- Not a squash-merge tool. Default to a merge commit to preserve history.
+- The Copilot path is GitHub-only (uses `gh` + GitHub GraphQL). For other forges, the local Claude + Codex gate still applies; the remote-reviewer phase does not.

--- a/plugins/review-loop/skills/review-loop/scripts/codex-pane.sh
+++ b/plugins/review-loop/skills/review-loop/scripts/codex-pane.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Manage a local Codex reviewer pane inside tmux for the review-loop skill.
+#
+# Subcommands:
+#   find                    print an existing Codex pane id (empty + exit 0 if none)
+#   ensure                  find-or-create a Codex pane (splits the current window), print its id.
+#                           exit 0  = ready to receive a review
+#                           exit 10 = a trust/onboarding prompt is showing; approve it yourself in
+#                                     the pane, then re-run (the skill never auto-approves these)
+#                           exit 1  = Codex failed to start (not on PATH, or pane never came up)
+#   send <pane> <message>   paste a (possibly multi-line) message into the pane and submit it
+#   capture <pane>          dump the pane's visible content to stdout
+#   usage-limited <pane>    exit 0 if the pane shows a rate/usage-limit message, else 1
+#
+# Requires: tmux (must be run inside a tmux session) and the `codex` CLI on PATH.
+# Uses POSIX-friendly short options so it runs on both BSD (macOS) and GNU systems.
+set -euo pipefail
+
+# tmux truncates pane_current_command, and the codex binary may be named e.g.
+# "codex-x86_64-apple-darwin" — so match the command field on a leading "codex", and
+# match ONLY the command, never the pane title (matching the title gave false positives,
+# e.g. an editor open on codex-pane.sh, or a pane titled after this skill).
+find_pane() {
+  tmux list-panes -a -F '#{pane_current_command}|#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null \
+    | awk -F'|' 'tolower($1) ~ /^codex/ { print $2; exit }'
+}
+
+pane_command() {
+  tmux display-message -t "$1" -p '#{pane_current_command}' 2>/dev/null
+}
+
+# Heuristic: is the visible pane a trust / first-run prompt awaiting a choice?
+looks_like_approval_prompt() {
+  capture_pane "$1" | grep -iE 'yes, continue|no, quit|trust|press enter to continue|allow this folder' > /dev/null
+}
+
+ensure_pane() {
+  local pane
+  pane="$(find_pane)"
+  if [ -n "${pane}" ]; then
+    printf '%s\n' "${pane}"
+    # An already-open pane can still be parked on a trust/onboarding prompt — check it too.
+    if looks_like_approval_prompt "${pane}"; then
+      echo "review-loop: Codex pane ${pane} is showing a trust/onboarding prompt." >&2
+      echo "Approve it yourself in that pane, then re-run the Codex step." >&2
+      return 10
+    fi
+    return 0
+  fi
+
+  if ! command -v codex > /dev/null 2>&1; then
+    echo "review-loop: 'codex' not found on PATH — cannot start a Codex pane." >&2
+    return 1
+  fi
+
+  # No Codex pane yet — split the current window and launch Codex beside it.
+  pane="$(tmux split-window -h -P -F '#{session_name}:#{window_index}.#{pane_index}')"
+  tmux send-keys -t "${pane}" 'codex' Enter
+
+  # Wait (bounded) for one of: ready, awaiting-approval, or failed-to-start.
+  # Gate on a positive signal (the codex process is the pane's foreground command),
+  # not just "output stopped changing" — a static error/onboarding screen is also "stable".
+  local i=0 cmd
+  while [ "${i}" -lt 60 ]; do
+    sleep 0.5
+    i=$((i + 1))
+    cmd="$(printf '%s' "$(pane_command "${pane}")" | tr '[:upper:]' '[:lower:]')"
+    case "${cmd}" in
+      codex*) : ;;       # Codex is up — decide between ready vs awaiting-approval below
+      *) continue ;;     # still a shell / starting — keep waiting
+    esac
+    if looks_like_approval_prompt "${pane}"; then
+      printf '%s\n' "${pane}"
+      echo "review-loop: Codex is showing a trust/onboarding prompt in pane ${pane}." >&2
+      echo "Approve it yourself in that pane, then re-run the Codex step." >&2
+      return 10
+    fi
+    printf '%s\n' "${pane}"   # Codex running, no approval prompt → ready
+    return 0
+  done
+
+  printf '%s\n' "${pane}"
+  echo "review-loop: Codex pane ${pane} did not become ready within the timeout." >&2
+  return 1
+}
+
+# Paste arbitrary (multi-line) text faithfully via a tmux buffer, then submit with a
+# separate Enter. Going through a buffer avoids send-keys interpreting key names and
+# collapsing/mangling whitespace in the message.
+send_review() {
+  local pane="$1"; shift
+  local buf='review-loop-msg'
+  printf '%s' "$*" | tmux load-buffer -b "${buf}" -
+  tmux paste-buffer -t "${pane}" -b "${buf}" -d
+  sleep 0.3                          # let the TUI ingest the paste before submitting
+  tmux send-keys -t "${pane}" Enter
+}
+
+capture_pane() {
+  tmux capture-pane -t "$1" -p
+}
+
+usage_limited() {
+  capture_pane "$1" \
+    | grep -iE 'usage limit|rate limit|quota|too many requests|try again later' \
+    > /dev/null
+}
+
+usage() {
+  echo "usage: codex-pane.sh {find | ensure | send <pane> <message> | capture <pane> | usage-limited <pane>}" >&2
+  exit 2
+}
+
+cmd="${1:-}"; shift || true
+case "${cmd}" in
+  find)          find_pane ;;
+  ensure)        ensure_pane ;;
+  send)          [ "$#" -ge 2 ] || usage; send_review "$@" ;;
+  capture)       [ "$#" -ge 1 ] || usage; capture_pane "$@" ;;
+  usage-limited) [ "$#" -ge 1 ] || usage; usage_limited "$@" ;;
+  *)             usage ;;
+esac

--- a/plugins/review-loop/skills/review-loop/scripts/copilot.sh
+++ b/plugins/review-loop/skills/review-loop/scripts/copilot.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Request / re-request a GitHub Copilot review on a PR for the review-loop skill.
+#
+# Subcommands:
+#   status <pr>      print who is requested vs who has reviewed (JSON)
+#   request <pr>     add Copilot as a reviewer via REST (see the first-time note below)
+#   rerequest <pr>   force a fresh Copilot review via the GraphQL requestReviews mutation
+#
+# First-time requests: the GraphQL re-request needs Copilot's bot node id, which is only
+# discoverable from an EXISTING review by Copilot. So on repos where REST returns 422 for the
+# bot, the very first Copilot review must be requested once through the GitHub UI (or wherever
+# REST is accepted). After Copilot has reviewed once, `rerequest` works for every later round.
+#
+# Requires: the `gh` CLI, authenticated. Repo (owner/name) is inferred from the current directory.
+set -euo pipefail
+
+BOT_LOGIN='copilot-pull-request-reviewer'
+
+# Guard against non-numeric input — `pr` is interpolated into GraphQL queries.
+require_pr_number() {
+  case "$1" in
+    ''|*[!0-9]*) echo "PR must be a number, got: '$1'" >&2; exit 2 ;;
+  esac
+}
+
+repo_owner() { gh repo view --json owner --jq '.owner.login'; }
+repo_name()  { gh repo view --json name  --jq '.name'; }
+
+status() {
+  gh pr view "$1" --json reviewRequests,reviews \
+    --jq '{requested: [.reviewRequests[].login], reviewed: [.reviews[].author.login]}'
+}
+
+request() {
+  local pr="$1"
+  if gh pr edit "${pr}" --add-reviewer "${BOT_LOGIN}" 2>/dev/null; then
+    echo "Copilot requested via 'gh pr edit'."
+    return 0
+  fi
+  echo "'gh pr edit --add-reviewer ${BOT_LOGIN}' failed (a 422 is expected for bots on some repos)." >&2
+  echo "  - If Copilot has already reviewed this PR once, run: copilot.sh rerequest ${pr}" >&2
+  echo "  - If this is the FIRST request, ask for the initial Copilot review through the GitHub UI once." >&2
+  return 1
+}
+
+rerequest() {
+  local pr="$1" owner name resp pr_id bot_id
+  owner="$(repo_owner)"
+  name="$(repo_name)"
+
+  # Scan the 100 most recent reviews for Copilot's bot id. Practical cap: on an
+  # extremely noisy PR where Copilot's reviews are all older than the last 100,
+  # this would miss it — accept that bound rather than paginate backward.
+  resp="$(gh api graphql --raw-field query="query {
+    repository(owner: \"${owner}\", name: \"${name}\") {
+      pullRequest(number: ${pr}) {
+        id
+        reviews(last: 100) { nodes { author { __typename login ... on Bot { id } } } }
+      }
+    }
+  }")" || { echo "GraphQL query failed (auth/network?) — see the error above." >&2; return 1; }
+
+  pr_id="$(printf '%s' "${resp}" | jq -r '.data.repository.pullRequest.id // ""')"
+  bot_id="$(printf '%s' "${resp}" | jq -r --arg login "${BOT_LOGIN}" '
+    [ .data.repository.pullRequest.reviews.nodes[]?
+      | select(.author.__typename == "Bot" and .author.login == $login)
+      | .author.id ][0] // ""')"
+
+  if [ -z "${pr_id}" ]; then
+    echo "Could not resolve the PR node id. GraphQL response:" >&2
+    printf '%s\n' "${resp}" >&2
+    return 1
+  fi
+  if [ -z "${bot_id}" ]; then
+    echo "Copilot bot node id not found — Copilot hasn't reviewed PR #${pr} yet." >&2
+    echo "Request the first Copilot review through the GitHub UI once, then retry." >&2
+    return 1
+  fi
+
+  gh api graphql --raw-field query="mutation {
+    requestReviews(input: { pullRequestId: \"${pr_id}\", botIds: [\"${bot_id}\"], union: true }) {
+      pullRequest { reviewRequests(first: 5) { nodes { requestedReviewer { __typename ... on Bot { login } } } } }
+    }
+  }"
+}
+
+usage() { echo "usage: copilot.sh {status <pr> | request <pr> | rerequest <pr>}" >&2; exit 2; }
+
+cmd="${1:-}"; shift || true
+case "${cmd}" in
+  status)    [ "$#" -ge 1 ] || usage; require_pr_number "$1"; status "$@" ;;
+  request)   [ "$#" -ge 1 ] || usage; require_pr_number "$1"; request "$@" ;;
+  rerequest) [ "$#" -ge 1 ] || usage; require_pr_number "$1"; rerequest "$@" ;;
+  *)         usage ;;
+esac

--- a/plugins/review-loop/skills/review-loop/scripts/pr-comments.sh
+++ b/plugins/review-loop/skills/review-loop/scripts/pr-comments.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fetch PR review state and detect Copilot's clean-pass stop signal for the review-loop skill.
+#
+# Subcommands:
+#   fetch <pr>        dump reviews, top-level comments, and inline review comments (paginated)
+#   clean-pass <pr>   exit 0 if Copilot's LATEST review is a clean pass, else 1
+#
+# `--paginate` is mandatory on list endpoints: page 1 holds only 30 items, and silent
+# truncation can mask real review comments. clean-pass selects the newest Copilot review by
+# submitted_at across all pages of the REST reviews endpoint (not `gh pr view --json reviews`,
+# which is itself capped and whose ordering is not guaranteed).
+#
+# Requires: the `gh` CLI (authenticated) and `jq`.
+set -euo pipefail
+
+# Copilot prints this sentence when it reviewed and found nothing to flag.
+CLEAN_SIGNAL='and generated no new comments.'
+BOT_LOGIN='copilot-pull-request-reviewer'
+
+require_pr_number() {
+  case "$1" in
+    ''|*[!0-9]*) echo "PR must be a number, got: '$1'" >&2; exit 2 ;;
+  esac
+}
+
+repo_owner() { gh repo view --json owner --jq '.owner.login'; }
+repo_name()  { gh repo view --json name  --jq '.name'; }
+
+fetch() {
+  local pr="$1" owner name
+  owner="$(repo_owner)"; name="$(repo_name)"
+  # Paginate every list endpoint — page 1 caps at 30 items and silently truncates.
+  echo '--- reviews ---'
+  gh api --paginate "repos/${owner}/${name}/pulls/${pr}/reviews"
+  echo '--- top-level (issue) comments ---'
+  gh api --paginate "repos/${owner}/${name}/issues/${pr}/comments"
+  echo '--- inline review comments ---'
+  gh api --paginate "repos/${owner}/${name}/pulls/${pr}/comments"
+}
+
+clean_pass() {
+  local pr="$1" owner name body
+  owner="$(repo_owner)"; name="$(repo_name)"
+  # gh --paginate emits one JSON array per page; `jq -s 'add'` merges them into a single
+  # array regardless of how the pages are concatenated, then we take the newest Copilot review.
+  body="$(gh api --paginate "repos/${owner}/${name}/pulls/${pr}/reviews" \
+    | jq -r -s --arg login "${BOT_LOGIN}" '
+        (add // [])
+        | map(select(.user.login == $login))
+        | sort_by(.submitted_at)
+        | last
+        | .body // ""')"
+  printf '%s' "${body}" | grep -F "${CLEAN_SIGNAL}" > /dev/null
+}
+
+usage() { echo "usage: pr-comments.sh {fetch <pr> | clean-pass <pr>}" >&2; exit 2; }
+
+cmd="${1:-}"; shift || true
+case "${cmd}" in
+  fetch)      [ "$#" -ge 1 ] || usage; require_pr_number "$1"; fetch "$@" ;;
+  clean-pass) [ "$#" -ge 1 ] || usage; require_pr_number "$1"; clean_pass "$@" ;;
+  *)          usage ;;
+esac

--- a/plugins/review-loop/skills/review-loop/scripts/pr-comments.sh
+++ b/plugins/review-loop/skills/review-loop/scripts/pr-comments.sh
@@ -13,8 +13,11 @@
 # Requires: the `gh` CLI (authenticated) and `jq`.
 set -euo pipefail
 
-# Copilot prints this sentence when it reviewed and found nothing to flag.
-CLEAN_SIGNAL='and generated no new comments.'
+# Copilot prints this when it reviewed and found nothing to flag. A first review says
+# "generated no comments."; a re-review says "generated no new comments." — match both.
+CLEAN_SIGNAL_RE='generated no (new )?comments\.'
+# The REST API returns the bot login WITH a "[bot]" suffix (copilot-pull-request-reviewer[bot]),
+# unlike `gh pr view` which drops it — so match by prefix to accept either form.
 BOT_LOGIN='copilot-pull-request-reviewer'
 
 require_pr_number() {
@@ -46,11 +49,11 @@ clean_pass() {
   body="$(gh api --paginate "repos/${owner}/${name}/pulls/${pr}/reviews" \
     | jq -r -s --arg login "${BOT_LOGIN}" '
         (add // [])
-        | map(select(.user.login == $login))
+        | map(select(.user.login | startswith($login)))
         | sort_by(.submitted_at)
         | last
         | .body // ""')"
-  printf '%s' "${body}" | grep -F "${CLEAN_SIGNAL}" > /dev/null
+  printf '%s' "${body}" | grep -Eq "${CLEAN_SIGNAL_RE}"
 }
 
 usage() { echo "usage: pr-comments.sh {fetch <pr> | clean-pass <pr>}" >&2; exit 2; }


### PR DESCRIPTION
Implements `docs/superpowers/specs/002-review-loop-plugin-design.md` (plan: `docs/superpowers/plans/002-review-loop-plugin.md`).

## What

Packages the local `~/.claude/skills/review-loop` skill as a standalone `review-loop` plugin in the marketplace (single source of truth), with:

- `plugin.json` manifest + `/review-loop` slash command (`[PR# | branch | blank]`)
- `SKILL.md` ported with all 14 script refs hardened to `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/...`
- Three helper scripts vendored **byte-identical** (`codex-pane.sh`, `copilot.sh`, `pr-comments.sh`)
- New user-facing `README.md`
- Target scope broadened from "code" to **any generated artifact** (code or design docs: specs/plans/docs)
- `marketplace.json` registration, `metadata.version` 1.2.0 → **1.3.0**
- Project `CLAUDE.md` updated to eight plugins

## Dogfooding

The spec, plan, and this code were all reviewed through `review-loop`'s own local Claude + Codex gate before this PR. Codex caught nine real issues across the artifacts (missing `jq`/`tmux` deps, code-only TDD framing, a repo-inference bug in dogfooding paths, narrowed scope wording, a flaky verification regex). The local gate is clean (Claude APPROVED, Codex APPROVED).

## Follow-ups (not in this PR)

- Plan doc `002` (on `main`) uses a non-portable `(^|[^/])scripts/` grep in its Task 8 / Task 3 checks — flaky on BSD grep; will fix with a `docs:` commit.
- Pre-existing source inaccuracy carried over verbatim (`SKILL.md` "request uses REST" vs the script's `gh pr edit`).
- After merge + install + verify: retire `~/.claude/skills/review-loop/` and repoint global `~/.claude/CLAUDE.md` (different repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)