### PR TITLE
fix(review-loop): correct REST/clean-pass prose to match script behavior

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,7 +55,7 @@
       "name": "review-loop",
       "source": "./plugins/review-loop",
       "description": "Assisted multi-reviewer review loop — local Claude + Codex gate first, then GitHub Copilot for PRs; never merges autonomously",
-      "version": "0.1.0"
+      "version": "0.1.1"
     }
   ]
 }

--- a/plugins/review-loop/skills/review-loop/SKILL.md
+++ b/plugins/review-loop/skills/review-loop/SKILL.md
@@ -40,7 +40,7 @@ The helper scripts use POSIX-friendly options and resolve their CLI dependencies
 Prebuilt so you don't re-derive the same commands each run. All in `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/`, executable:
 
 - `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/codex-pane.sh {find | ensure | send <pane> <message> | capture <pane> | usage-limited <pane>}` — manage the Codex tmux pane. `ensure` finds-or-creates (splits the current window) and prints the pane id; its **exit code** matters: `0` ready, `10` a trust/onboarding prompt is showing (you must approve it), `1` Codex failed to start. `send` pastes a possibly multi-line message faithfully and submits it. `usage-limited` exits 0 when the pane shows a rate/usage-limit message.
-- `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh {status <pr> | request <pr> | rerequest <pr>}` — manage the Copilot reviewer. `request` uses REST; `rerequest` uses the GraphQL `requestReviews` mutation. Note: the first-ever Copilot review may need a one-time request through the GitHub UI (see B1).
+- `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh {status <pr> | request <pr> | rerequest <pr>}` — manage the Copilot reviewer. `request` uses `gh pr edit --add-reviewer`; `rerequest` uses the GraphQL `requestReviews` mutation. Note: the first-ever Copilot review may need a one-time request through the GitHub UI (see B1).
 - `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh {fetch <pr> | clean-pass <pr>}` — paginated fetch of reviews + inline comments; `clean-pass` exits 0 when Copilot's newest review is a clean pass.
 
 Reach for these first. Only hand-write a command when a script genuinely doesn't cover the case.
@@ -88,22 +88,22 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
 **B1. Request Copilot review** — get `copilot-pull-request-reviewer` onto the reviewer list before any polling, or the loop waits forever for a bot that was never asked:
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh status <num>     # who's requested vs who reviewed
-${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh request <num>    # add Copilot via REST
+${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh request <num>    # add Copilot via gh pr edit --add-reviewer
 ```
-First-time caveat: on some repos REST returns 422 for the bot, and the GraphQL re-request can't run yet because it needs a bot node id that only exists once Copilot has reviewed. If `request` fails 422 and Copilot has never reviewed this PR, ask the author to trigger the first Copilot review through the GitHub UI once; every later round can then use `rerequest`.
+First-time caveat: on some repos `gh pr edit --add-reviewer` returns 422 for the bot, and the GraphQL re-request can't run yet because it needs a bot node id that only exists once Copilot has reviewed. If `request` fails 422 and Copilot has never reviewed this PR, ask the author to trigger the first Copilot review through the GitHub UI once; every later round can then use `rerequest`.
 
 **B2. Pre-scan** — `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh fetch <num>` (paginated reviews + inline comments). Group unresolved comments into tiers, then handle them per *Tiers*.
 
 **B3. Re-request Copilot** after fixes push — Copilot won't re-examine otherwise: `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh rerequest <num>`. If a Codex pane is reachable, have Codex review the new commits **before** re-requesting Copilot (local gate first).
 
 **B4. Poll** — `/loop 3m` re-run `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh fetch <num>`. New comments → re-classify → B2.
-- **Copilot clean-pass stop signal:** when `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh clean-pass <num>` exits 0 (newest Copilot review contains **"and generated no new comments."**), **STOP immediately** — cancel the cron/`/loop` job, do not schedule another poll. Post: "Copilot review is clean — no new comments. Stopping the loop; your call on what's next (review / merge / more work)." Then wait.
+- **Copilot clean-pass stop signal:** when `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh clean-pass <num>` exits 0 (newest Copilot review matches `generated no (new )?comments.` — "generated no comments." on a first review, "generated no new comments." on a re-review), **STOP immediately** — cancel the cron/`/loop` job, do not schedule another poll. Post: "Copilot review is clean — no new comments. Stopping the loop; your call on what's next (review / merge / more work)." Then wait.
 
 **B5. Repeat-comment guard (NL-based)** — for each new comment, compare semantically against prior comments on the same file/line. "Does this raise the same concern as a prior one that already had a fix commit?" If yes → **stop**, post "Copilot re-raised <X> after <commit>. Prior fix didn't satisfy it. Your call." and wait. Fingerprint (file:line + first 40 chars) is an acceptable fallback heuristic; NL comparison is the primary signal.
 
 ## Exit conditions
 
-- **Local gate clean + (for GitHub) Copilot clean pass** ("and generated no new comments.") → stop and surface to the author. This is the primary, explicit stop signal — prefer it over inferring doneness from "no new comments for N polls".
+- **Local gate clean + (for GitHub) Copilot clean pass** (matches "generated no comments." / "generated no new comments.") → stop and surface to the author. This is the primary, explicit stop signal — prefer it over inferring doneness from "no new comments for N polls".
 - **Codex usage limit** → stop only the Codex sub-loop; the rest of the loop continues.
 - **Merge** — never merge autonomously. Only on an explicit `merge` instruction. Default to a merge commit (`gh pr merge --merge`, not `--squash`) to preserve history; ask before deleting the branch, and prefer leaving the local branch in place for the author to prune. Honor the project's own merge conventions if they differ.
 

--- a/plugins/review-loop/skills/review-loop/scripts/copilot.sh
+++ b/plugins/review-loop/skills/review-loop/scripts/copilot.sh
@@ -3,13 +3,13 @@
 #
 # Subcommands:
 #   status <pr>      print who is requested vs who has reviewed (JSON)
-#   request <pr>     add Copilot as a reviewer via REST (see the first-time note below)
+#   request <pr>     add Copilot as a reviewer via `gh pr edit --add-reviewer` (see the first-time note below)
 #   rerequest <pr>   force a fresh Copilot review via the GraphQL requestReviews mutation
 #
 # First-time requests: the GraphQL re-request needs Copilot's bot node id, which is only
-# discoverable from an EXISTING review by Copilot. So on repos where REST returns 422 for the
-# bot, the very first Copilot review must be requested once through the GitHub UI (or wherever
-# REST is accepted). After Copilot has reviewed once, `rerequest` works for every later round.
+# discoverable from an EXISTING review by Copilot. So on repos where `gh pr edit --add-reviewer`
+# returns 422 for the bot, the very first Copilot review must be requested once through the
+# GitHub UI. After Copilot has reviewed once, `rerequest` works for every later round.
 #
 # Requires: the `gh` CLI, authenticated. Repo (owner/name) is inferred from the current directory.
 set -euo pipefail


### PR DESCRIPTION
First real dogfood of the **installed** `review-loop` plugin — run against itself, driven by the plugin's own `${CLAUDE_PLUGIN_ROOT}` scripts (the local skill copy is retired). The loop's local gate (Claude subagent + Codex) found prose/behavior drift in the merged plugin; all documentation-only:

- **"REST" mislabel** — SKILL.md (B1 helper list, request comment, first-time caveat) and `copilot.sh`'s own header comments said `request` "uses REST" / "REST returns 422", but `request()` uses `gh pr edit --add-reviewer`. Corrected the mechanism label (the 422 is real; only the label was wrong). *Codex additionally caught the stale wording inside the script's comments, which the Claude leg missed.*
- **Stale clean-pass prose** — SKILL.md quoted the exact string `"and generated no new comments."`, but `pr-comments.sh` now matches the regex `generated no (new )?comments.` (covering a first review's "no comments." and a re-review's "no new comments."). This was drift introduced by the earlier clean-pass bugfix that updated the script but not the prose describing it. Updated the B4 stop signal and the Exit-conditions line.

Bumps the plugin to **0.1.1** so corrected docs propagate on reinstall (marketplace `metadata.version` unchanged — no plugin added/removed).

## Review
Local gate clean: Claude subagent found the issues → fixed → Codex re-reviewed → APPROVED. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)