### PR TITLE
feat(tsugu): add Tsugu plugin — git-native work preparation & convergence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "caasi's plugin collection for Claude Code",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -56,6 +56,12 @@
       "source": "./plugins/review-loop",
       "description": "Assisted multi-reviewer review loop — local Claude + Codex gate first, then GitHub Copilot for PRs; never merges autonomously",
       "version": "0.2.0"
+    },
+    {
+      "name": "tsugu",
+      "source": "./plugins/tsugu",
+      "description": "Git-native preparation & convergence skill — prepare/converge/settle work over git's DAG; never auto-merges",
+      "version": "0.1.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
     {
       "name": "tsugu",
       "source": "./plugins/tsugu",
-      "description": "Git-native preparation & convergence skill — prepare/converge/settle work over git's DAG; never auto-merges",
+      "description": "Git-native preparation & convergence skill — init/prepare/converge/settle work over git's DAG; never auto-merges",
       "version": "0.1.0"
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Claude Code plugin marketplace (`caasi/dong3`) containing eight independent plugins under `plugins/`. No traditional build system — this is a skill/plugin distribution repo.
+A Claude Code plugin marketplace (`caasi/dong3`) containing nine independent plugins under `plugins/`. No traditional build system — this is a skill/plugin distribution repo.
 
 Install: `claude plugin marketplace add caasi/dong3`
 
@@ -21,6 +21,7 @@ plugins/
   old-react/                      # FP-thinking review/refactor for pre-RSC React
   owasp/                          # OWASP security review with offline references
   review-loop/                    # Assisted multi-reviewer loop (Claude + Codex → Copilot), never auto-merges
+  tsugu/                          # Git-native unattended work prep & human–agent convergence (init/prepare/converge/settle)
 tools/                            # Repo-level dev tooling (NOT shipped to skill users)
   old-react/                      # Validator + fixtures for old-react rule files
 docs/superpowers/                 # Design specs and implementation plans
@@ -55,6 +56,8 @@ plugins/<name>/
 **old-react:** FP-thinking review/refactor for pre-RSC React (classes, hooks, Redux/MobX/observable, Reselect, Immer). Ships **architectural** rules only — categories already covered by the React-Compiler diagnostics in `eslint-plugin-react-hooks` v5+ (`recommended-latest`) and TypeScript discriminated unions are deferred. Five active categories: `model-`, `effect-`, `compose-`, `purity-`, `hooks-`. Two deferred: `immutable-`, `message-`. Canonical rule list lives in `plugins/old-react/skills/old-react/SKILL.md` (don't duplicate counts here — they drift). Rule bodies use FP/TEA pattern terms only; brand names live in `references/lib-suggestions.md`. Rules ship from real review examples, not a planned list (see spec §9 "Adding rules — real-example-driven"). One slash command: `/old-react [review|refactor] [path]`. Spec: `docs/superpowers/specs/001-old-react-skill-design.md`. Lineage source: `docs/old-react.md`.
 
 **review-loop:** Assisted, not autonomous, multi-reviewer convergence loop. Local reviewers run first — a Claude subagent always, plus Codex via `codex exec review` (headless) when `codex` is on `PATH`; tmux optional for a live-watch pane — then GitHub Copilot for PR targets. Helper scripts in `skills/review-loop/scripts/` (`copilot.sh`, `pr-comments.sh`) are referenced via `${CLAUDE_PLUGIN_ROOT}`. Target scope is any changed artifact: code or design artifacts (specs, plans, docs). One slash command: `/review-loop [PR# | branch | blank]`. Spec: `docs/superpowers/specs/002-review-loop-plugin-design.md` (Codex channel superseded by `docs/superpowers/specs/003-review-loop-headless-codex-design.md`).
+
+**tsugu:** Git-native skill for unattended work preparation and human–agent convergence (継ぐ — "to inherit / continue / carry forward"). Using git's DAG as the coordination substrate, an agent prepares engineering work privately on git branches (often while the human is away), records evidence in committed `.tsugu/` notes, and packages a convergence packet; the human then converges (decides together what becomes public) and the work is settled (cut a clean public branch with no `.tsugu/` in the diff / open a PR, human-gated). Four routines: `init` (set up the repo's `.tsugu/` workspace + `policy.md`; idempotent), `prepare` (private git work on `prepare/*` branches + tests + evidence while the human is absent; external silence), `converge` (present packet + branches and decide with the human; invokes no skill — the human triggers skills by keyword), `settle` (accept/reject/pause; promote reusable knowledge to shared context; clean up branches/worktrees). **Never auto-merges** (no public coordination without approval). **Light / script-free** — recipes are documented guidance; no scripts shipped. **Invokes no user-installed skill by default** — native git + its own built-in subagents only; a repo's `.tsugu/policy.md` may opt-in to named skills locally. One slash command: `/tsugu [init|prepare|converge|settle]`. Spec: `docs/superpowers/specs/004-tsugu-skill-design.md`.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Assisted (not autonomous) multi-reviewer convergence loop for any change — cod
 
 See [plugins/review-loop/skills/review-loop/README.md](plugins/review-loop/skills/review-loop/README.md) for full documentation.
 
+### tsugu
+
+A git-native skill for unattended work preparation and human–agent convergence. Using git's DAG as the coordination substrate, an agent prepares engineering work privately on git branches (often while you are away), records evidence in committed `.tsugu/` notes, and packages a convergence packet; when you return you converge (review the prepared evidence and decide together what becomes public), then the work is settled (cut a clean public branch / open a PR, human-gated). Four routines: `init` (set up the repo's `.tsugu/` workspace + `policy.md`), `prepare` (private git work + tests + evidence while you are absent), `converge` (present the packet and decide with you), `settle` (accept/reject/pause; promote reusable knowledge; clean up). Never auto-merges; light and script-free; invokes no user-installed skill by default (per-repo `policy.md` may opt-in). One slash command: `/tsugu [init|prepare|converge|settle]`.
+
+See [plugins/tsugu/skills/tsugu/README.md](plugins/tsugu/skills/tsugu/README.md) for full documentation.
+
 ## Install
 
 ```bash

--- a/plugins/tsugu/.claude-plugin/plugin.json
+++ b/plugins/tsugu/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "tsugu",
+  "description": "Git-native preparation & convergence — agents prepare work privately via git's DAG (init/prepare/converge/settle), package evidence for human-agent handoff, and settle cleanly. Never auto-merges; invokes no user-installed skill by default.",
+  "author": { "name": "caasi" },
+  "homepage": "https://github.com/caasi/dong3",
+  "repository": "https://github.com/caasi/dong3",
+  "license": "MIT",
+  "keywords": ["git", "worktree", "agent-coordination", "preparation", "convergence", "tsugu"],
+  "skills": "./skills/",
+  "commands": "./commands/"
+}

--- a/plugins/tsugu/commands/tsugu.md
+++ b/plugins/tsugu/commands/tsugu.md
@@ -1,0 +1,25 @@
+---
+description: Run a Tsugu routine — git-native unattended work preparation & human–agent convergence (init / prepare / converge / settle)
+argument-hint: "[init|prepare|converge|settle]"
+---
+
+# /tsugu
+
+Carry engineering work forward across human-absence and the agent→human handoff, using git's DAG as the coordination substrate. One lifecycle, four routines:
+
+- `/tsugu init` — set up the repo's `.tsugu/` workspace + `policy.md` (the agent's coordination metadata); ask the minimum, idempotent.
+- `/tsugu prepare` — while the human is absent: fetch, find work (git branches / intake notes / agent-discovered issues), do private git work on `prepare/*` branches, run tests, record evidence + a convergence packet. External silence.
+- `/tsugu converge` — while the human is present: present the packet + prepared branches and decide together what becomes public. Tsugu presents and yields; the human triggers any skill by keyword.
+- `/tsugu settle` — accept / reject / pause. For accepted work: cut a clean public branch (no `.tsugu/` in the diff) and open a PR (human-gated), promote reusable knowledge, clean up branches/worktrees.
+
+**Routing:**
+
+The argument (`$ARGUMENTS`) is passed to the `tsugu` skill, which dispatches to the matching routine. If no argument is supplied, the skill lists the four routines above with one-line descriptions and asks which to run.
+
+**Behavior:**
+
+Invoke the `tsugu` skill. Load-bearing invariants the skill enforces:
+
+- **Never auto-merges** — no public coordination (MR/PR, tracker, reviewer assignment) without human approval.
+- **Light / script-free** — routines are documented guidance; no shell scripts are shipped with the plugin.
+- **Invokes no user-installed skill by default** — Tsugu uses native git + its own built-in capabilities; a repo's `.tsugu/policy.md` may opt-in to named skills locally.

--- a/plugins/tsugu/skills/tsugu/README.md
+++ b/plugins/tsugu/skills/tsugu/README.md
@@ -1,0 +1,96 @@
+# tsugu
+
+A git-native skill for **unattended work preparation and human–agent convergence**.
+継ぐ (*tsugu*) means "to inherit / continue / carry forward" — Tsugu carries
+engineering work forward across the gap when no human is watching, the handoff from
+agent to human, and the resume by whoever comes next. It never auto-merges.
+
+## What this is
+
+Using git's DAG as the coordination substrate, an agent prepares engineering work
+**privately on git branches** (often while you are away), records evidence in
+committed `.tsugu/` notes, and packages a **convergence packet**. When you return,
+you **converge** — review the prepared evidence and decide together what becomes
+public — and the work is **settled** into clean public form. A branch is a unit of
+work one agent hands to the next; committed `.tsugu/` notes are the memory that
+outlives the session that produced them.
+
+Tsugu prepares the board; workflow skills (planning, debugging, TDD, review-loop)
+play the game with you; Tsugu settles the result. It is **not** an implementation
+methodology — it prepares the input and settles the output, and triggers none of
+those skills itself.
+
+## The four routines
+
+One lifecycle, four routines:
+
+1. **init** — set up the repo's `.tsugu/` workspace + `policy.md` (the agent's
+   coordination metadata). Asks the minimum; idempotent (re-running repairs the
+   skeleton and never overwrites a curated `policy.md`).
+2. **prepare** (human absent) — fetch, find work (from git branches / `.tsugu/`
+   intake notes / agent-discovered issues), do private git work on `prepare/*`
+   branches, run tests, record evidence + a convergence packet. **External
+   silence** — interrupt only if the task is unsafe, destructive, or blocked.
+3. **converge** (human present) — present the packet + prepared branches and decide
+   **with you** what becomes public. Tsugu presents and yields; it invokes no skill
+   (you trigger any workflow skill by keyword).
+4. **settle** — accept / reject / pause. For accepted work: cut a clean public
+   branch (no `.tsugu/` in the diff), open a PR (**human-gated**), promote reusable
+   knowledge to shared context, and clean up branches/worktrees.
+
+## How to invoke
+
+```text
+/tsugu              # lists the four routines and asks which to run
+/tsugu init         # set up .tsugu/ + policy.md
+/tsugu prepare      # private preparation while you are away
+/tsugu converge     # review the packet together, decide what goes public
+/tsugu settle       # accept / reject / pause the converged work
+```
+
+`prepare` is meant to run on a cadence — wire it to `/schedule` / cron so a cloud
+agent runs it. A SKILL.md cannot self-wake; the cadence always comes from an
+external driver.
+
+## The `.tsugu/` namespace at a glance
+
+All Tsugu metadata is **committed** under `.tsugu/` (it is shared memory, not local
+scratch):
+
+```text
+.tsugu/
+  policy.md      coordination rules (private vs public boundary, branch prefixes, …)
+  templates/     skeletons written by init
+  intake/        durable shared inbox (git-native work queue)
+  context/       shared / dormant / archived knowledge, promoted on settle
+  branch.md      per work branch: status + claim metadata
+  runs/          per-session work notes
+  packets/       convergence evidence for the human to review
+```
+
+After `git fetch`, the queue is read from remote-tracking refs — branch names plus
+`.tsugu/` notes must be legible enough that a cold-start agent can reconstruct what
+branches exist, why, and what's next, with **zero conversation transcript**.
+
+## Private vs public boundary
+
+The load-bearing invariant, recorded per-repo in `policy.md`:
+
+```text
+Git branch / pushed branch / .tsugu notes        →  agent may do freely
+MR / PR / tracker / Slack / reviewer assignment   →  human approval required
+```
+
+Tsugu works freely in private git space and **never performs public coordination
+without approval**.
+
+## Non-goals
+
+- **Never auto-merges** and never opens an MR/PR or touches a tracker on its own.
+- **Light / script-free** — recipes are documented git guidance; no scripts ship.
+- **Invokes no user-installed skill by default** — native git + its own built-in
+  subagents only. A repo's `.tsugu/policy.md` may opt-in to named skills locally;
+  the shipped skill stays skill-agnostic.
+
+See [the design spec](../../../../docs/superpowers/specs/004-tsugu-skill-design.md)
+for the full model.

--- a/plugins/tsugu/skills/tsugu/SKILL.md
+++ b/plugins/tsugu/skills/tsugu/SKILL.md
@@ -15,7 +15,7 @@ description: Git-native preparation & convergence — carry work forward across 
 
 **Git's DAG is the medium of inheritance.** A branch is a unit of work one agent hands to the next; committed `.tsugu/` notes are the memory that outlives the session that produced them.
 
-Tsugu prepares the board. Workflow skills play the game with the human. Tsugu settles the result. It is **not** an implementation methodology — it does not debug, plan, test, review, or implement; it prepares their input and settles their output.
+Tsugu prepares the board. Workflow skills play the game with the human. Tsugu settles the result. It is **not** an implementation methodology — it does not define *how* to debug, plan, write tests, review, or implement; it prepares their input and settles their output. (It still *runs* builds/tests as evidence during `prepare`/`settle` — it just doesn't own the testing or debugging method.)
 
 ## The spine
 

--- a/plugins/tsugu/skills/tsugu/SKILL.md
+++ b/plugins/tsugu/skills/tsugu/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: tsugu
+description: Git-native preparation & convergence — carry work forward across the gap when no human is watching, the handoff to a human, and the resume by whoever comes next. Use to prepare work before review, settle converged work into clean public form, or run the lifecycle via `/tsugu [init|prepare|converge|settle]`. Triggers on "prepare work before review", "carry work forward", "git-native preparation", "init/prepare/converge/settle", or "/tsugu". Human-triggered and schedule-wireable (wire `prepare` to `/schedule`/cron). Invokes no user-installed skill by default — native git + its own built-in subagents only. Never auto-merges and never performs public coordination without approval.
+---
+
+# Tsugu — 継ぐ (prepare & converge over git)
+
+## 継ぐ (tsugu)
+
+**継ぐ** · つぐ / *tsugu* · to **inherit**, **continue**, **carry forward** (succeed to a role). The name is the intent: work is carried forward rather than restarted —
+
+- **inherit** — a cold-start or *different* agent inherits the work from git + `.tsugu/` alone, with no conversation transcript;
+- **continue** — `prepare` continues the work while human attention is absent, leaving reversible evidence instead of an empty task description;
+- **carry forward** — `settle` carries the prepared, converged work into clean public form and promotes what is worth keeping.
+
+**Git's DAG is the medium of inheritance.** A branch is a unit of work one agent hands to the next; committed `.tsugu/` notes are the memory that outlives the session that produced them.
+
+Tsugu prepares the board. Workflow skills play the game with the human. Tsugu settles the result. It is **not** an implementation methodology — it does not debug, plan, test, review, or implement; it prepares their input and settles their output.
+
+## The spine
+
+**Git itself is the message bus.** `git fetch` surfaces new/changed branches and newly committed `.tsugu/` notes — that *is* the inbox. A pure-Tsugu workflow coordinates through git alone, with zero external integrations.
+
+- **`.tsugu/` is committed shared memory**, not local scratch. A branch or worktree is "a message with executable evidence."
+- **External tracker observation is an OPTIONAL human-bridge, never the spine.** Jira / GitLab / GitHub issues / CI / CVE feeds are a shim whose only job is to convert a human-world signal into the git-native substrate (a committed `.tsugu/intake/` note, optionally a seed branch). Once converted, every downstream step is identical. Pure-Tsugu users skip this layer entirely.
+- **Legibility is a hard constraint:** branch names + `.tsugu/intake/` + `.tsugu/branch.md` must let an agent that has only run `git fetch` reconstruct "what branches exist, why, and what's next" with no transcript. git-native intake depends on it.
+
+## Routing
+
+`/tsugu [init|prepare|converge|settle]` — one lifecycle, four routines:
+
+- **init** — first-run setup; ask the minimum, write the `.tsugu/` skeleton + policy.
+- **prepare** — human-absent: read the queue from git, work it privately, leave evidence.
+- **converge** — human-present: present the packet and yield; the human drives.
+- **settle** — carry the decided outcome forward (Accepted / Rejected / Paused).
+
+Mechanics are deferred — do not re-derive git commands here:
+
+- Exact git (fetch → read-queue-from-remote-refs, coordination-ref writes, cut-clean-public-branch, freshness rebase, cleanup order, init skeleton) → `${CLAUDE_PLUGIN_ROOT}/skills/tsugu/references/git-recipes.md`.
+- `policy.md` fields + intake interface (incl. the human-bridge) → `${CLAUDE_PLUGIN_ROOT}/skills/tsugu/references/policy-and-intake.md`.
+- `branch.md` / `intake` / `runs` / `packet` / `context` structure → `${CLAUDE_PLUGIN_ROOT}/skills/tsugu/references/notes-and-packet.md`.
+- `init` writes the repo's `.tsugu/` files from `${CLAUDE_PLUGIN_ROOT}/skills/tsugu/templates/`.
+
+## The four routines
+
+### `init`
+
+Runs when a repo has no `.tsugu/`. Capture the **minimum** preferences for safe unattended prep — ask only a few: may agents create/commit/push prep branches automatically? which public actions need approval (default: MR/PR, tracker comment/status, reviewer assignment, Slack, public commitments)? branch prefixes (default `prepare/* investigate/* review/* public/*`)? recurse into submodules (default: only when relevant)? intake sources (**default: none** — git-native only)?
+
+Then write the `.tsugu/` skeleton + `policy.md` from the plugin templates (seed each empty dir with a real file — git can't track empty directories).
+
+- **Idempotent:** re-running on an initialized repo *repairs* missing skeleton paths and is otherwise a no-op; it **never overwrites** a curated `policy.md`.
+- **Progressive:** when a new situation appears, ask once, record the rule in `policy.md`, let future agents inherit it.
+- **Push-protected default:** the fixed metadata (`policy.md`, `templates/`) must reach the default branch; if it is push-protected, write on an `init/*` branch and open a **human-approved PR**. `prepare` does not run in that repo until the metadata is merged.
+
+### `prepare` (human absent)
+
+The core routine. No human is present, so Tsugu does its own git work directly and may dispatch its **own built-in Task subagents** — but it invokes **no user-installed skill**. Posture: **external silence, internal preparation.** Interrupt the human only if the task is unsafe, destructive, or blocked; when unsure, continue with reversible private git work.
+
+`prepare` **does NOT self-wake** — a SKILL.md is a prompt loaded into a running agent and cannot schedule itself. Cadence always comes from an external `/schedule`/cron driver.
+
+1. **Fetch first**, resolving `<remote>` + `<default>`, so every read below uses fresh remote-tracking refs, not a stale checkout.
+2. Read `policy.md` + guidance from the **fetched default ref** (yields prefixes + `coordination-ref`).
+3. **Read the queue from remote-tracking refs**, plus `context/shared/` from the coordination ref. Partition by `branch.md status` × `claimed-by`:
+
+   | status | claimed-by | disposition |
+   | --- | --- | --- |
+   | `open` | empty | **pick up** |
+   | `open` | non-empty, **recent** `claimed-at` | **yield** (taken) |
+   | `open` | non-empty, **stale** `claimed-at` | **pick up** — reclaim (re-set `claimed-by`/`claimed-at`) |
+   | `paused` | — | **resume** (rebase onto default first) |
+   | `converged` | — | skip (awaiting human) |
+   | `settled` | — | skip (done) |
+
+   Plus `intake/` notes with `status: open` and no linked branch = unbranched work to consider.
+4. Open work branches or worktrees **with native git** (`git worktree add`), naming them with the **prefixes configured in `policy.md`** (defaults `prepare/*` / `investigate/*`) — discovery filters by the configured prefixes, so a hardcoded prefix that differs would be invisible to the next cold start. (Same applies to the `public/*` / `review/*` prefixes in `settle` and review-subagent dispatch.) Then reproduce, inspect, run tests, try reversible patches.
+5. Dispatch your **own review subagents** (built-in Task agents) when a change deserves a second pass before the human sees it — they return `review/*` branch/worktree artifacts, not prose-only reports. This is Tsugu working in private git space; it is distinct from the human-triggered review-loop, which the human triggers — Tsugu never runs it for them.
+6. Write `runs/` notes; maintain `branch.md` (set `status`, and `claimed-by` + `claimed-at` when active work begins — courtesy, see Multi-agent); create/update the convergence **packet**.
+7. **Commit the `prepare/*` branch; push it if policy permits.** Check the fetched `policy.md` Private-Git-Space boundary (the `init` answer to "may agents push preparation branches automatically?"). If yes, `git push --set-upstream <remote> <branch>` — cold-start discovery enumerates only remote-tracking refs, so pushing is what lets the human or next scheduled agent inherit the work (the branch *is* the message). If pushing is **not** permitted, commit locally and stop for approval (or use the policy-defined alternative) — never push past an explicit boundary.
+
+### `converge` (human present)
+
+The human-attention phase. **Tsugu presents and yields — it invokes no skill here.** The human triggers the skill they want by keyword ("let's brainstorm this", "debug it", "/review-loop"); the ecosystem takes over.
+
+1. Lay out the relevant packet, prepared branches/worktrees, and a summary of what was tried / worked / failed / evidence / remaining uncertainties.
+2. Surface open questions and decisions.
+3. Decide *with* the human which prepared changes become public.
+4. **Wait for approval before any public coordination.**
+5. Once the human has decided a disposition, set the branch's `branch.md status: converged` — the transition that writes the `converged` state the prepare table skips — then **commit and push that transition** (policy permitting). For a pushed branch, a local-only status change leaves the remote `branch.md` at `open`, so a scheduled `prepare` reading remote refs would pick the already-decided work up again.
+
+The packet may **hint** which workflow skill fits ("ready for planning", "this bug needs debugging", "this can go to review-loop") but must not fire it.
+
+### `settle`
+
+Three outcomes write a terminal status — Accepted/Rejected → `settled`, Paused → `paused` — and, **if the work has a linked intake note, also close it on the coordination ref** (`claimed → done` on Accepted, `→ dropped` on Rejected) so finished items don't linger as active in the durable inbox. **Timing matters: write the terminal `settled` (and close the intake note) only AFTER the public branch is cut and verified** — if patch-apply/build/tests fail, leave the branch `open`/`converged` and the intake `claimed` so the work stays in the queue rather than vanishing. (Paused/Rejected write their terminal status up front.) ⚙ = agent-mechanical (private git); 🔒 = human-triggered/approved.
+
+**Accepted:**
+1. ⚙ Cut a clean `public/*` branch fresh from the **fetched** `<remote>/<default>` (not a stale local default).
+2. ⚙ Apply only accepted code/test/doc/config **by path** — the public branch's diff vs default introduces **no `.tsugu/` changes**.
+3. ⚙ Verify (build / tests). **Only once this passes**, write `branch.md status: settled` and close the linked intake note (`claimed → done`) — a failed settlement keeps the work in the queue.
+4. 🔒 Opening the PR is human-gated — the human may use `finishing-a-development-branch` or trigger review-loop; **Tsugu does not run them for the human**.
+5. ⚙ Promote reusable knowledge to `.tsugu/context/shared/` (commit to the coordination ref).
+6. ⚙ Clean up: `git worktree remove` **before** `git branch -D` (never delete a branch a worktree still has checked out).
+
+**Rejected:** record why if it may matter later; archive/delete the packet per policy; remove temp worktrees; delete rejected `review/*` branches when safe; promote only important failure reasons.
+
+**Paused:** set `status: paused`; update the packet; write a run note; list what is needed to resume; leave the branch resumable (it **rebases onto default on resume** — see git-recipes freshness).
+
+## Private vs public boundary & skill use
+
+Recorded per-repo in `.tsugu/policy.md`:
+
+```text
+Git branch / pushed branch / .tsugu notes        →  agent may do freely
+MR / PR / tracker / Slack / reviewer assignment   →  human approval required
+```
+
+**Tsugu invokes NO user-installed skill by default** — present or absent. It uses **native git directly** (worktrees via `git worktree add`, branch/cleanup via plain git / `gh`) and its **own built-in capabilities** (Task subagents, Codex-as-a-tool, Claude's own reasoning). The only asymmetry is *what Tsugu does on its own*:
+
+- **Human absent** (`prepare`, the ⚙ parts of `settle`): work the git tree, dispatch own built-in subagents.
+- **Human present** (`converge`, the 🔒 parts of `settle`): present and yield; the human triggers workflow skills by keyword.
+
+Workflow skills (planning, debugging, TDD, finishing-a-development-branch, review-loop) are **human-triggered and optional** — Tsugu never runs them for the human. **Per-repo opt-in (config, not shipped behavior):** a repo MAY, in its own `.tsugu/policy.md` (never in this shipped SKILL.md), list specific user-installed skills Tsugu may use during human-absent `prepare` *in that repo*. The shipped skill stays skill-agnostic.
+
+## Multi-agent: reserved
+
+v1 is a **single agent + its built-in subagents**. The discovery layer is honored (fetch, read branch status, process the queue); concurrent arbitration is **not built**.
+
+- `claimed-by:` + `claimed-at:` in `branch.md` are a **courtesy yield** — set when active work begins, retained as history on settle/pause. A branch with `status: open` and a non-empty, *recent* claim is treated as taken; empty or stale claim = free to pick up. **No lock backs this.**
+- **No arbitration, no locks** (deferred to v2). Two agents grabbing the same branch at once is undefined in v1 (doesn't arise with one agent).
+- The substrate (committed + pushed `.tsugu/`, branch-as-message, per-branch status) is **forward-compatible** with multi-peer coordination; v1 introduces no design that assumes a single agent.
+
+## Scheduling & recursion
+
+**Scheduling.** `prepare` is meant to run on a cadence, wired by a human to `/schedule` / cron so a cloud agent runs it daily. But the skill **cannot self-wake** — the driver is always external. The skill depends on no scheduler.
+
+**Recursion (omni-repo).** A single repo and an omni-repo are the **same abstraction**. One agent (+ its built-in subagents) traverses the repo tree — working locally, delegating downward into submodules / child repos, and promoting knowledge upward. Recurse into submodules only when relevant to the current goal / intake / branch. **Context placement rule:** write context at the **lowest repo level where it stays true**; promote upward only when the knowledge affects multiple repos or future coordination, so the omni-repo never becomes a junk drawer.

--- a/plugins/tsugu/skills/tsugu/references/git-recipes.md
+++ b/plugins/tsugu/skills/tsugu/references/git-recipes.md
@@ -202,9 +202,11 @@ git -C <coord-worktree> commit --message "tsugu: bootstrap coordination ref (int
 git -C <coord-worktree> push --set-upstream <remote> <coordination-ref>
 ```
 
-Thereafter the normal commit → `pull --rebase` → push protocol applies. All queue
-reads resolve against `<remote>/<coordination-ref>`; always read `policy.md` /
-`templates/` from `<remote>/<default>`, never from the coord branch.
+Thereafter the normal commit → `fetch` + `rebase <remote>/<coordination-ref>` →
+`push <remote> HEAD:<coordination-ref>` protocol applies (never a bare `git pull`
+— see the warning above). All queue reads resolve against
+`<remote>/<coordination-ref>`; always read `policy.md` / `templates/` from
+`<remote>/<default>`, never from the coord branch.
 
 ---
 

--- a/plugins/tsugu/skills/tsugu/references/git-recipes.md
+++ b/plugins/tsugu/skills/tsugu/references/git-recipes.md
@@ -45,8 +45,10 @@ the remote, but you need a remote to read policy):
   default exists even when `<remote>/HEAD` was unset: `git remote set-head
   <remote> --auto`. Read the fetched policy using that provisional default —
   take the **bare branch name** (`git symbolic-ref --short
-  refs/remotes/<remote>/HEAD | sed "s@^<remote>/@@"`, as in step 3, falling back
-  to `main` only if set-head failed; never the full `refs/remotes/...` ref) —
+  refs/remotes/<remote>/HEAD | sed "s@^<remote>/@@"`, as in step 3; never the full
+  `refs/remotes/...` ref). If set-head still yields no HEAD, use the **same
+  non-assumptive fallback as step 3** — the checked-out branch's upstream, else
+  ask the human to set `default-branch:` — rather than assuming `main` —
   `<default>` is resolved properly in step 3, but the policy read can't wait for
   it: `git show <remote>/<provisional-default>:.tsugu/policy.md`. If it names a
   **different** `remote:` (or a `default-branch:`), adopt those, re-fetch if the
@@ -84,7 +86,9 @@ the fetched policy, don't hardcode, since `init` may have customized them. Do
 **not** include `public/*`: that is a `settle` output, not a queue item.
 
 ```bash
-git branch --remotes --format='%(refname:short)'      # pushed mode
+# scope to the configured remote + work prefixes (defaults shown); never raw --remotes
+git branch --remotes --format='%(refname:short)' \
+  | grep -E "^<remote>/(prepare|investigate|review)/"      # pushed mode
 ```
 
 **No-push mode is local.** When `policy.md` forbids auto-pushing preparation
@@ -226,7 +230,7 @@ index:
 # not reverted (a two-dot `..` diff would undo default-branch work that landed
 # after prepare/<x> diverged). Rebasing prepare/<x> onto <remote>/<default> first
 # is the robust alternative.
-git diff --binary <remote>/<default>...prepare/<x> -- <code paths> | git apply --index
+git diff --binary <remote>/<default>...prepare/<x> -- <code paths> | git apply --index --binary
 git commit --message "tsugu: public/<x> — accepted code"
 ```
 

--- a/plugins/tsugu/skills/tsugu/references/git-recipes.md
+++ b/plugins/tsugu/skills/tsugu/references/git-recipes.md
@@ -1,0 +1,335 @@
+# git-recipes
+
+These are **documented recipes** — guidance an agent follows with its own
+judgment, not scripts to run blindly. Tsugu ships no scripts; every operation
+below is plain git (or `gh`) that the agent runs inline, reading the situation
+and adapting. Where a recipe says "reconsider" or "stop and ask", that is a
+deliberate decision point for the agent's judgment, not a branch to automate
+away.
+
+Throughout, `<remote>` and `<default>` are **resolved**, never hardcoded — see
+[Read the queue](#read-the-queue-cold-start-safe) for how. Likewise the branch
+prefixes written below — `prepare/`, `investigate/`, `review/`, `public/` — are
+**placeholders for the prefixes configured in `policy.md`** (the defaults are
+shown); resolve them from the fetched policy when creating or matching branches,
+since `init` may have customized them, and discovery filters by the configured
+set. Examples use full-length CLI options on purpose (`--remotes`, `--message`,
+`--set-upstream`, `--force-with-lease`, `--delete`); the written recipe should
+read the same way the agent runs it.
+
+---
+
+## Read the queue (cold-start safe)
+
+A cold-start agent — no conversation transcript, only a clone — must reconstruct
+"what branches exist, why, and what's next" from git + `.tsugu/` alone. That
+only works if reads come from **fresh remote-tracking refs**, not whatever the
+local checkout happens to be sitting on.
+
+**1. Fetch first.** Before reading anything, refresh the remote-tracking refs —
+**with `--prune`**, so branches deleted upstream stop appearing in the queue:
+
+```bash
+git fetch --prune <remote>
+```
+
+Fetching first means every `<remote>/…` ref the rest of this recipe reads is
+fresh, never a stale checkout, and multi-remote repos stay unambiguous.
+
+**2. Resolve `<remote>`.** Bootstrap the circular dependency (policy lives behind
+the remote, but you need a remote to read policy):
+
+- Begin with `origin`, or the `remote:` field in the **local** checkout's
+  `.tsugu/policy.md` if present.
+- Fetch, then establish the remote's advertised HEAD **first** so a provisional
+  default exists even when `<remote>/HEAD` was unset: `git remote set-head
+  <remote> --auto`. Read the fetched policy using that provisional default —
+  take the **bare branch name** (`git symbolic-ref --short
+  refs/remotes/<remote>/HEAD | sed "s@^<remote>/@@"`, as in step 3, falling back
+  to `main` only if set-head failed; never the full `refs/remotes/...` ref) —
+  `<default>` is resolved properly in step 3, but the policy read can't wait for
+  it: `git show <remote>/<provisional-default>:.tsugu/policy.md`. If it names a
+  **different** `remote:` (or a `default-branch:`), adopt those, re-fetch if the
+  remote changed, and re-resolve below. The fetched policy wins over the bootstrap
+  guess.
+
+**3. Resolve `<default>`.** In priority order:
+
+- An explicit `default-branch:` field in `policy.md`, if set; otherwise
+- `<remote>/HEAD` — take the **bare branch name**, not the full ref
+  (`refs/remotes/<remote>/HEAD` → strip the `<remote>/` prefix, else later
+  `<remote>/<default>` expands to the invalid `origin/refs/remotes/origin/main`):
+
+  ```bash
+  git symbolic-ref --short refs/remotes/<remote>/HEAD | sed "s@^<remote>/@@"
+  ```
+
+  If that fails because `<remote>/HEAD` is unset, point it at the remote's
+  advertised default once, then re-read:
+
+  ```bash
+  git remote set-head <remote> --auto
+  ```
+
+  If the remote still advertises no HEAD (some self-hosted remotes), do **not**
+  blindly assume `main` — fall back to the checked-out branch's upstream
+  (`git rev-parse --abbrev-ref --symbolic-full-name @{upstream}`, stripped to the
+  branch name) or, failing that, ask the human to set `default-branch:` in policy.
+
+**4. Enumerate work branches.** Filter to **`<remote>/`** (the configured remote
+only — a multi-remote repo must not pull `upstream/prepare/foo` into an
+`origin` queue) **plus** the **work** prefixes **declared in `policy.md`'s Branch
+Prefixes** (defaults: `prepare`, `investigate`, `review`) — derive the filter from
+the fetched policy, don't hardcode, since `init` may have customized them. Do
+**not** include `public/*`: that is a `settle` output, not a queue item.
+
+```bash
+git branch --remotes --format='%(refname:short)'      # pushed mode
+```
+
+**No-push mode is local.** When `policy.md` forbids auto-pushing preparation
+branches, work stays on **local** branches, so remote-only enumeration would miss
+it. In that mode also enumerate local branches — `git branch
+--format='%(refname:short)'` — and read their `branch.md` from the local ref
+(`git show <branch>:.tsugu/branch.md`). No-push mode is single-machine by nature:
+the human and the next run share the same clone, so local discovery carries the
+work forward; cross-machine/agent handoff requires the pushed mode.
+
+Each kept line is **already a full remote-qualified ref** (e.g.
+`origin/prepare/foo`). Use it **verbatim** in every command below — never
+re-prefix `<remote>/`, which would double-prefix into `origin/origin/prepare/foo`.
+
+**5. Read branch context without a checkout.** No `git switch`, no dirty tree —
+read the committed note straight from the verbatim ref:
+
+```bash
+git show <branch-ref>:.tsugu/branch.md
+```
+
+**6. Discover intake notes.** Intake lives on the **coordination ref** (resolve
+`<coordination-ref>` from `policy.md`; default = `<default>`). List the tree,
+keep only `*.md`, and read each:
+
+```bash
+git ls-tree -r --name-only <remote>/<coordination-ref> -- .tsugu/intake/
+# for each *.md path:
+git show <remote>/<coordination-ref>:<path>
+```
+
+Treat a note as a queue item **only if it carries a `status:` field**. This skips
+seed files (`.gitkeep`, a `README`) that exist only to make git track the empty
+`intake/` directory.
+
+**7. Partition the queue.** Combine `branch.md` `status` × `claimed-by` per the
+`prepare` partition table in `SKILL.md`:
+
+| status | claimed-by | disposition |
+| --- | --- | --- |
+| `open` | empty | **pick up** |
+| `open` | non-empty, **recent** `claimed-at` | **yield** (taken) |
+| `open` | non-empty, **stale** `claimed-at` | **pick up** — reclaim (re-set `claimed-by`/`claimed-at`) |
+| `paused` | — | **resume candidate** (rebase onto default first — see Freshness) |
+| `converged` | — | skip (awaiting human) |
+| `settled` | — | skip (done) |
+
+Plus any `intake/` note with `status: open` and no linked branch = unbranched
+work to consider.
+
+---
+
+## Coordination-ref writes
+
+The coordination ref (`coordination-ref` in `policy.md`, **default: the default
+branch**) holds the mutable shared inbox (`intake/`) and promoted
+`context/shared/`. A commit that touches **only `.tsugu/`** on this ref is
+**private-space** — it is coordination memory, not public coordination, and needs
+**no approval**.
+
+> **Resolving `coordination-ref`:** the literal value `default` is a **sentinel**
+> meaning "the default branch" — resolve it to `<default>` wherever the recipes
+> interpolate `<coordination-ref>` (so reads/writes target `<remote>/<default>`,
+> never a nonexistent `origin/default`). Any other value is a literal branch name
+> (e.g. `tsugu/coord`).
+
+**Write protocol** — do this **from a dedicated checkout/worktree of the
+coordination ref**, never from a `prepare/*` worktree (pushing that branch's `HEAD`
+to the coordination ref would replay your private code commits onto it — possibly
+straight onto the default branch). Commit only the `.tsugu/` change, rebase onto
+the latest `<remote>/<coordination-ref>`, then push there **explicitly** (bare
+`git pull` / `git push` use the current branch's upstream, which may not be the
+configured `<remote>` or ref):
+
+```bash
+git -C <coord-worktree> add .tsugu/ && git -C <coord-worktree> commit \
+  --message "tsugu: claim intake/<slug> → prepare/<slug>"
+git -C <coord-worktree> fetch <remote> && git -C <coord-worktree> rebase <remote>/<coordination-ref>
+git -C <coord-worktree> push <remote> HEAD:<coordination-ref>
+```
+
+**On conflict, exercise judgment — do not blind-overwrite.** If the rebase
+conflicts over a *contended* intake note, re-read that note's **current lifecycle
+state** (`open → claimed → done | dropped`) and **reconsider** before reapplying.
+Never clobber a `claimed` or `done` another agent just wrote. The ref is
+append-mostly, so conflicts are rare; when one happens over a note someone else
+moved, that is exactly the signal to re-evaluate, not to force-resolve.
+
+**If the default branch is push-protected**, the agent cannot push `.tsugu/`
+coordination data to it. Point `coordination-ref` at a dedicated branch instead.
+**Prefer an orphan branch** (e.g. `tsugu/coord`) that holds **only** `intake/`
+and `context/shared/` — an orphan has no code history to drift, whereas a plain
+`git branch tsugu/coord <remote>/<default>` would inherit a full copy of default
+(code, `policy.md`, `templates/`) that goes stale. Keep `policy.md` and
+`templates/` on the default branch so the coordination ref stays **discoverable**
+(no circularity — you always know where to find policy).
+
+Bootstrap once **in a dedicated worktree** — never switch the user's active
+checkout to the orphan (`git switch --orphan` there would blank the working tree,
+or fail outright against local modifications). Git can't track empty directories,
+so seed each with a real file:
+
+```bash
+git worktree add --detach <coord-worktree>          # isolated; doesn't touch the active checkout
+git -C <coord-worktree> switch --orphan <coordination-ref>   # the configured ref (e.g. tsugu/coord), not a literal
+( cd <coord-worktree>
+  mkdir -p .tsugu/intake .tsugu/context/shared
+  touch .tsugu/intake/.gitkeep .tsugu/context/shared/.gitkeep )
+git -C <coord-worktree> add .tsugu
+git -C <coord-worktree> commit --message "tsugu: bootstrap coordination ref (intake/ + context/shared/)"
+git -C <coord-worktree> push --set-upstream <remote> <coordination-ref>
+```
+
+Thereafter the normal commit → `pull --rebase` → push protocol applies. All queue
+reads resolve against `<remote>/<coordination-ref>`; always read `policy.md` /
+`templates/` from `<remote>/<default>`, never from the coord branch.
+
+---
+
+## Cut a clean public branch
+
+The reviewed public branch must be **cut fresh from the default branch** and carry
+**only** accepted code — its diff vs default must introduce **no `.tsugu/`
+changes** (the guarantee is "never introduced", not "stripped afterward").
+
+**1. Cut from the fetched ref** — use the configured `<remote>`, never a hardcoded
+`origin`, and never a stale local default:
+
+```bash
+git switch --create public/<x> <remote>/<default>
+```
+
+**2. Apply only accepted paths via a path-scoped diff.** Generate the diff between
+default and the prepare branch for the accepted code paths, and apply it to the
+index:
+
+```bash
+# three-dot: diff from the MERGE BASE, so upstream changes to accepted paths are
+# not reverted (a two-dot `..` diff would undo default-branch work that landed
+# after prepare/<x> diverged). Rebasing prepare/<x> onto <remote>/<default> first
+# is the robust alternative.
+git diff --binary <remote>/<default>...prepare/<x> -- <code paths> | git apply --index
+git commit --message "tsugu: public/<x> — accepted code"
+```
+
+`git apply --index` only **stages** the patch — it does **not** advance the branch,
+so you must commit before any sanity-check or handoff (above), else `public/<x>`
+carries no code and the diff check below compares an unchanged branch. `--binary`
+is required so binary assets transfer (a plain `git diff` emits only a "Binary files
+differ" marker that `git apply` cannot consume). The diff faithfully reproduces
+**adds, modifies, deletions, and renames**. Do **not** use `git checkout
+prepare/<x> -- <paths>`: a checkout copies files that exist on the source ref, so it
+**cannot reproduce a deletion** — a file the prepare branch deleted would silently
+survive on the public branch.
+
+**3. Never include `.tsugu/`.** Scope `<code paths>` to code/test/doc/config only.
+Sanity-check that no Tsugu metadata leaked in:
+
+```bash
+git diff <remote>/<default>..public/<x> -- .tsugu/    # must be empty
+```
+
+**4. Verify, then stop.** Build and run tests on `public/<x>`. **Opening the PR is
+human-gated** — Tsugu prepares the branch and yields; it does not open the PR or
+invoke `finishing-a-development-branch` / `review-loop`.
+
+---
+
+## Freshness
+
+Persistent branches drift when default moves under them. Refresh on resume (and
+optionally periodically) by rebasing onto the **fetched** default ref — never a
+stale **local** default:
+
+```bash
+git fetch <remote>
+git rebase <remote>/<default>        # scratch prepare/* investigate/* branches
+```
+
+- **Scratch branches** (`prepare/*`, `investigate/*`): rebase freely. If the
+  branch was already pushed, the rebase rewrites it, so update the remote with
+  lease protection — **never** a plain `--force`:
+
+  ```bash
+  git push --force-with-lease
+  ```
+
+- **History-bearing / long-lived branches**: **prefer merge** to preserve history
+  (`git merge <remote>/<default>`), honoring the repo's history-protection
+  convention.
+
+- **Non-trivial conflict → stop and ask the human.** Do not auto-resolve a
+  conflict that needs a judgment call about intent.
+
+## Cleanup order
+
+Always remove the worktree **before** deleting the branch. A branch still checked
+out by a worktree cannot be safely deleted.
+
+```bash
+git worktree remove <path>
+git branch --delete --force <branch>
+```
+
+Never run `git branch --delete --force` on a branch that a worktree still has
+checked out.
+
+---
+
+## init skeleton
+
+`init` runs when a repo has no `.tsugu/`. It writes the fixed metadata and the
+durable skeleton, idempotently.
+
+**1. Create the `.tsugu/` tree** and seed every directory with a real file (git
+can't track empty directories):
+
+```bash
+mkdir -p .tsugu/intake \
+         .tsugu/context/shared .tsugu/context/dormant .tsugu/context/archived \
+         .tsugu/templates
+touch .tsugu/intake/.gitkeep \
+      .tsugu/context/shared/.gitkeep \
+      .tsugu/context/dormant/.gitkeep \
+      .tsugu/context/archived/.gitkeep \
+      .tsugu/templates/.gitkeep
+```
+
+**2. Write `policy.md` + templates only if absent.** This makes re-running `init`
+an **idempotent repair**: it fills in any missing skeleton path and is otherwise a
+no-op. **Never overwrite a curated `policy.md`** — a re-run must not clobber rules
+a human already tuned.
+
+**3. Land the metadata on the default branch.** `policy.md` and `templates/` must
+reach `<default>` so policy stays resolvable. If the default branch is
+**push-protected**, write them on an `init/*` branch and open a
+**human-approved PR**:
+
+```bash
+git switch --create init/tsugu-bootstrap <remote>/<default>
+git add .tsugu
+git commit --message "chore(tsugu): bootstrap .tsugu policy + templates"
+git push --set-upstream <remote> init/tsugu-bootstrap
+# then open the PR for human approval (human-gated)
+```
+
+Do **not** run `prepare` in that repo until the metadata PR is merged — `prepare`
+needs `policy.md` / `coordination-ref` resolvable from `<remote>/<default>`.

--- a/plugins/tsugu/skills/tsugu/references/notes-and-packet.md
+++ b/plugins/tsugu/skills/tsugu/references/notes-and-packet.md
@@ -1,0 +1,109 @@
+# notes-and-packet
+
+The shape and lifecycle of every `.tsugu/` note Tsugu maintains: `branch.md`,
+`intake/`, `runs/`, `packets/`, and `context/`. Placement on the durability
+gradient (which branch each lives on) is summarized in `SKILL.md`; this document
+covers structure and load/lifecycle semantics.
+
+## `branch.md` — work-level live state
+
+Ephemeral, lives **on each work branch**. Read without a checkout via
+`git show <branch-ref>:.tsugu/branch.md`. It is the live context for one unit of
+work.
+
+- **`status:`** — `open | paused | converged | settled`. The work-level lifecycle:
+  `open` while active or available, `paused` when set aside (resumable), `converged`
+  after the human has reviewed and decided a disposition, `settled` at a terminal
+  outcome (accepted or rejected).
+- **`claimed-by:`** + **`claimed-at:`** — a **courtesy** pair, no lock. **Set when
+  an agent begins active work**; **retained as historical state** on settle/pause
+  (never auto-cleared). Polite-yield rule: `status: open` with a non-empty
+  `claimed-by` and a **recent** `claimed-at` = treated as taken (another agent
+  skips it); `status: open` with empty `claimed-by` or a **stale** `claimed-at` =
+  free to pick up (re-set both on pickup). Recency is the agent's judgment in v1.
+- Body sections: `## Why this branch exists`, `## Current understanding`,
+  `## Open questions`, `## Next actions`, `## Verification`,
+  `## Promotion candidates`.
+
+## `intake/` — inbox-level record (two-layer model)
+
+Durable, lives on the **coordination ref** (default = default branch) as
+`intake/<slug>.md`. Intake and `branch.md` describe **different layers**, so they
+never contradict:
+
+| Layer | Where | Status field | Records |
+| --- | --- | --- | --- |
+| **Inbox** | `intake/<slug>.md` (coordination ref) | `open → claimed → done \| dropped` | *that* work entered the inbox and where it went |
+| **Work** | `branch.md` (work branch) | `open \| paused \| converged \| settled` | the *live* work context |
+
+Lifecycle: a queue-worthy intake item = a note with `status: open` and **no linked
+branch**. When an agent opens a `prepare/*` branch for it, the note flips to
+`claimed` and records a breadcrumb in `linked-branch:`. `settle` flips it to
+`done` (accepted/handled) or `dropped` (abandoned). The inbox status tracks *where
+the item went*; the branch status tracks *the work itself* — keeping them separate
+is why two agents reading the same inbox never see a contradictory state.
+
+Fields: `status:`, `linked-branch:` (set when → `claimed`); sections
+`## Observed source` (git-native self-note / agent-discovered / `human-bridge:
+<ref>`), `## Summary`, `## Related repos`, `## Initial guess`,
+`## Need human context`.
+
+## `runs/` — session notes
+
+Ephemeral, on the work branch as `runs/<date-time>.md`. One note per `prepare`
+session: an append-only trail of what an agent actually did, so a later agent (or
+human) can reconstruct the session without the transcript. Sections: `## Goal`,
+`## Context read`, `## Actions taken`, `## Branches touched`, `## Verification`,
+`## Follow-up`, `## Need human context`, `## Promotion candidates`.
+
+## `packets/` — convergence evidence
+
+Ephemeral, on the work branch as `packets/<work-slug>.md`. The **bridge to the
+human** at `converge`: a concise, reviewable summary so the human reviews
+convergence instead of cold-starting. Sections:
+
+- `## Intake source`
+- `## Branches prepared`
+- `## What was tried`
+- `## What worked`
+- `## What failed`
+- `## Evidence`
+- `## Relevant files`
+- `## Test results`
+- `## Remaining uncertainties`
+- `## Need human decisions`
+- `## Candidate next plans` — **hints** which workflow skill fits ("ready for
+  planning", "this bug needs debugging", "this can go to review-loop"). It is a
+  hint for the human to act on; it **does NOT fire a skill** — Tsugu invokes none.
+- `## Public actions requiring approval`
+- `## Suggested public branch` — a **name/target** for the branch `settle` will cut
+  **fresh** from default. It is a proposal, **not "push this branch as-is"**: the
+  prepare branch is messy private space; the public branch is cut clean.
+
+## `context/` — promoted knowledge
+
+Lives on the coordination ref. Three tiers with distinct **load semantics**:
+
+- **`shared/`** — loaded by default. Reusable knowledge inherited by future
+  branches/agents. Written **only after deliberate promotion** (during `settle`),
+  never as a dumping ground. When `coordination-ref` ≠ the default branch, a branch
+  cut from default won't contain `shared/`, so it must be read explicitly from
+  `<remote>/<coordination-ref>`.
+- **`dormant/`** — **not loaded by default.** Knowledge kept but not currently
+  relevant; pulled in deliberately when needed.
+- **`archived/`** — **not searched by default.** Retired knowledge kept for the
+  record only.
+
+## Context placement rule (omni-repo framing)
+
+A single repo and an omni-repo are the **same abstraction** — Tsugu traverses a
+tree of repos, and "where does this context belong" has one answer at any scale:
+
+> Write context at the **lowest repo level where it remains true.** Promote upward
+> (toward the omni-repo) **only** when the knowledge affects multiple repos or
+> future coordination.
+
+A fact true of one repo stays in that repo's `context/`; a fact true across
+several repos is promoted to the enclosing omni-repo level. This keeps an
+omni-repo from becoming a junk drawer — promotion is a deliberate "this is true
+more broadly now" decision, not the default.

--- a/plugins/tsugu/skills/tsugu/references/policy-and-intake.md
+++ b/plugins/tsugu/skills/tsugu/references/policy-and-intake.md
@@ -13,7 +13,7 @@ human-bridge.
 The whole point of the file: where the agent may act freely vs where it must ask.
 
 - **`## Private Git Space (agent may do freely)`** — actions the agent performs
-  without approval: create/commit/push `prepare·investigate·review` branches,
+  without approval: create/commit/push `prepare/*` / `investigate/*` / `review/*` branches,
   worktrees, write `.tsugu/*`, run tests, try reversible patches, dispatch its own
   built-in review subagents. All of this is git-local and reversible.
 - **`## Public Coordination (ask first)`** — actions requiring human approval:

--- a/plugins/tsugu/skills/tsugu/references/policy-and-intake.md
+++ b/plugins/tsugu/skills/tsugu/references/policy-and-intake.md
@@ -1,0 +1,105 @@
+# policy-and-intake
+
+`.tsugu/policy.md` records the per-repo rules a cold-start agent reads before any
+unattended preparation. It lives on the **default branch always** (so the
+coordination ref it points to stays discoverable — no circularity). This document
+gives the one-line semantics of every field, then explains the intake
+human-bridge.
+
+## `policy.md` fields
+
+### Private / Public boundary
+
+The whole point of the file: where the agent may act freely vs where it must ask.
+
+- **`## Private Git Space (agent may do freely)`** — actions the agent performs
+  without approval: create/commit/push `prepare·investigate·review` branches,
+  worktrees, write `.tsugu/*`, run tests, try reversible patches, dispatch its own
+  built-in review subagents. All of this is git-local and reversible.
+- **`## Public Coordination (ask first)`** — actions requiring human approval:
+  open MR/PR, tracker comment / status change, assign reviewers, Slack, public
+  commitments, moving findings into human-facing docs, irreversible cleanup.
+
+The boundary in one line:
+
+```text
+Git branch / pushed branch / .tsugu notes  →  agent may do freely
+MR / PR / tracker / Slack / reviewer assignment  →  human approval required
+```
+
+### `## Branch Prefixes`
+
+The branch namespaces Tsugu uses. Default `prepare/*  investigate/*  review/*
+public/*`. The first three are **work** prefixes (queue items); `public/*` is a
+**settle output** (cut fresh, never enumerated into the queue).
+
+### `remote:`
+
+The authoritative remote for `git fetch` and branch enumeration. Default
+`origin`. Stated explicitly for **multi-remote safety** — so `<remote>/…` refs are
+unambiguous regardless of which remote the local checkout tracks.
+
+### `default-branch:`
+
+Optional override for `<default>`. If blank, `<default>` is resolved from
+`<remote>/HEAD` (`git symbolic-ref refs/remotes/<remote>/HEAD`). Set it only when
+`<remote>/HEAD` is unreliable or the repo's default is non-obvious.
+
+### `coordination-ref:`
+
+The ref where the mutable inbox (`intake/`) and promoted `context/shared/` are
+written. **Default: `default`** (the repo's default branch). Point it at a
+dedicated branch (e.g. `tsugu/coord`) when the default branch is **push-protected**
+— the agent needs a writable home for `.tsugu/` coordination data, but in a
+human-collaborative repo the task **code** only ever reaches default through a
+human-merged PR, not an agent push. That right varies per environment, which is
+why it is a per-repo policy field.
+
+### `## Intake Sources`
+
+The human-bridge sources (if any) the repo observes. **Default: none** —
+git-native only. List sources (e.g. `gh issues`, CI) here only if this repo needs
+to bridge a human-world signal into git. See the human-bridge section below.
+
+### `## Skill use`
+
+States the shipped invariant: **Tsugu invokes no user-installed skill by
+default** — it uses native git plus its own built-in capabilities (Task subagents,
+Codex-as-a-tool, Claude's own reasoning). Humans trigger workflow skills
+(planning, debugging, review-loop, …) by keyword. This text reflects the shipped
+behavior and is the same in every repo.
+
+### `## Skills Tsugu may use (this repo, opt-in)`
+
+The **per-repo opt-in** — and the *only* place a skill name may appear. **Default:
+none.** A repo owner MAY list specific user-installed skills (e.g.
+`systematic-debugging`) that Tsugu may use during **human-absent `prepare`** in
+**this repo**. This is repo-local config: the shipped `SKILL.md` never names a
+skill, so the plugin stays universal while a repo extends it locally.
+
+### `## Recursion`
+
+Whether to recurse into submodules / child repos. Default: **only when relevant to
+the current goal / intake / branch.** Keeps an omni-repo traversal scoped instead
+of descending into every nested repo unconditionally.
+
+## Intake: the optional human-bridge
+
+**Git is the inbox.** A pure-Tsugu workflow communicates through git alone: an
+agent fetches, sees new/changed branches and newly committed `.tsugu/intake/`
+notes, and that *is* the work queue. No external tracker is required, and the
+default loop runs with zero external integrations.
+
+Tracker observation — Jira, GitHub/GitLab issues, CI, CVE feeds, Slack — is
+**OPTIONAL** and is **not the spine.** It is a thin shim whose only job is to
+convert a **human-world signal** into the git-native substrate: a committed
+`.tsugu/intake/<slug>.md` note (and optionally a seed branch). The note records
+where the signal came from in its `## Observed source` line (e.g.
+`human-bridge: gh issue #128`).
+
+Once that conversion happens, **every downstream step is identical** — the queue
+read, the partition, the `prepare`/`converge`/`settle` routines all operate on the
+committed note and branches, never on the tracker. A pure-Tsugu user **skips this
+layer entirely**: they (or the agent) author intake notes directly, and git is the
+only inbox. Tsugu ships no adapter for any tracker; `## Intake Sources` is an
+interface stub, not built integration.

--- a/plugins/tsugu/skills/tsugu/templates/branch.md
+++ b/plugins/tsugu/skills/tsugu/templates/branch.md
@@ -1,0 +1,9 @@
+status: open          # open | paused | converged | settled
+claimed-by:           # courtesy only (no lock); set when active work begins, kept as history
+claimed-at:           # ISO timestamp paired with claimed-by; lets a stale claim be reclaimed
+## Why this branch exists
+## Current understanding
+## Open questions
+## Next actions
+## Verification
+## Promotion candidates

--- a/plugins/tsugu/skills/tsugu/templates/intake.md
+++ b/plugins/tsugu/skills/tsugu/templates/intake.md
@@ -1,0 +1,7 @@
+status: open          # open | claimed | done | dropped
+linked-branch:        # breadcrumb set when status → claimed
+## Observed source    (git-native self-note / agent-discovered / human-bridge: <ref>)
+## Summary
+## Related repos
+## Initial guess
+## Need human context

--- a/plugins/tsugu/skills/tsugu/templates/packet.md
+++ b/plugins/tsugu/skills/tsugu/templates/packet.md
@@ -8,6 +8,8 @@
 ## Test results
 ## Remaining uncertainties
 ## Need human decisions
-## Candidate next plans          # hints which workflow skill fits — does not fire it
+## Candidate next plans
+<!-- hints which workflow skill fits — does not fire it -->
 ## Public actions requiring approval
-## Suggested public branch        # name/target for the to-be-cut-fresh branch (see settle), not "push this branch as-is"
+## Suggested public branch
+<!-- name/target for the to-be-cut-fresh branch (see settle), not "push this branch as-is" -->

--- a/plugins/tsugu/skills/tsugu/templates/packet.md
+++ b/plugins/tsugu/skills/tsugu/templates/packet.md
@@ -1,0 +1,13 @@
+## Intake source
+## Branches prepared
+## What was tried
+## What worked
+## What failed
+## Evidence
+## Relevant files
+## Test results
+## Remaining uncertainties
+## Need human decisions
+## Candidate next plans          # hints which workflow skill fits — does not fire it
+## Public actions requiring approval
+## Suggested public branch        # name/target for the to-be-cut-fresh branch (see settle), not "push this branch as-is"

--- a/plugins/tsugu/skills/tsugu/templates/policy.md
+++ b/plugins/tsugu/skills/tsugu/templates/policy.md
@@ -1,5 +1,5 @@
 ## Private Git Space (agent may do freely)
-create/commit/push `prepare/*` / `investigate/*` / `review/*` branches; worktrees; write .tsugu/*;
+create/commit/push `prepare/*` / `investigate/*` / `review/*` branches; worktrees; write `.tsugu/*`;
 run tests; try reversible patches; dispatch own (built-in) review subagents
 ## Public Coordination (ask first)
 open MR/PR; tracker comment / status change; assign reviewers; Slack; public
@@ -11,9 +11,9 @@ remote: origin                   # authoritative remote for fetch + branch enume
 default-branch:                  # optional; if blank, resolved from <remote>/HEAD
 ## Coordination ref
 coordination-ref: default        # where intake/ + context/shared/ are written.
-# `default` is a sentinel = the repo's default branch (resolves to <default>, not a
-# branch literally named "default"). Set to a branch (e.g. tsugu/coord) only if the
-# default branch is push-protected.
+<!-- `default` is a sentinel = the repo's default branch (resolves to <default>, not a
+branch literally named "default"). Set to a branch (e.g. tsugu/coord) only if the
+default branch is push-protected. -->
 ## Intake Sources
 None by default (git-native only). Add human-bridge sources here only if needed
 (e.g. gh issues, CI).

--- a/plugins/tsugu/skills/tsugu/templates/policy.md
+++ b/plugins/tsugu/skills/tsugu/templates/policy.md
@@ -1,0 +1,30 @@
+## Private Git Space (agent may do freely)
+create/commit/push prepare·investigate·review branches; worktrees; write .tsugu/*;
+run tests; try reversible patches; dispatch own (built-in) review subagents
+## Public Coordination (ask first)
+open MR/PR; tracker comment / status change; assign reviewers; Slack; public
+commitments; move findings into human-facing docs; irreversible cleanup
+## Branch Prefixes
+prepare/*  investigate/*  review/*  public/*
+## Remote
+remote: origin                   # authoritative remote for fetch + branch enumeration (multi-remote safety)
+default-branch:                  # optional; if blank, resolved from <remote>/HEAD
+## Coordination ref
+coordination-ref: default        # where intake/ + context/shared/ are written.
+# `default` is a sentinel = the repo's default branch (resolves to <default>, not a
+# branch literally named "default"). Set to a branch (e.g. tsugu/coord) only if the
+# default branch is push-protected.
+## Intake Sources
+default: none (git-native only). Add human-bridge sources here only if needed
+(e.g. gh issues, CI).
+## Skill use
+Tsugu invokes no user-installed skill by default; it uses native git + its own
+built-in capabilities. Humans trigger workflow skills (planning, review-loop, …)
+by keyword.
+## Skills Tsugu may use (this repo, opt-in)
+default: none. List user-installed skills Tsugu may use during human-absent
+prepare in THIS repo (e.g. systematic-debugging). Repo-local only — the shipped
+SKILL.md never names skills.
+## Recursion
+Recurse into submodules / child repos only when relevant to the current goal /
+intake / branch.

--- a/plugins/tsugu/skills/tsugu/templates/policy.md
+++ b/plugins/tsugu/skills/tsugu/templates/policy.md
@@ -1,5 +1,5 @@
 ## Private Git Space (agent may do freely)
-create/commit/push prepare·investigate·review branches; worktrees; write .tsugu/*;
+create/commit/push `prepare/*` / `investigate/*` / `review/*` branches; worktrees; write .tsugu/*;
 run tests; try reversible patches; dispatch own (built-in) review subagents
 ## Public Coordination (ask first)
 open MR/PR; tracker comment / status change; assign reviewers; Slack; public
@@ -15,14 +15,14 @@ coordination-ref: default        # where intake/ + context/shared/ are written.
 # branch literally named "default"). Set to a branch (e.g. tsugu/coord) only if the
 # default branch is push-protected.
 ## Intake Sources
-default: none (git-native only). Add human-bridge sources here only if needed
+None by default (git-native only). Add human-bridge sources here only if needed
 (e.g. gh issues, CI).
 ## Skill use
 Tsugu invokes no user-installed skill by default; it uses native git + its own
 built-in capabilities. Humans trigger workflow skills (planning, review-loop, …)
 by keyword.
 ## Skills Tsugu may use (this repo, opt-in)
-default: none. List user-installed skills Tsugu may use during human-absent
+None by default. List user-installed skills Tsugu may use during human-absent
 prepare in THIS repo (e.g. systematic-debugging). Repo-local only — the shipped
 SKILL.md never names skills.
 ## Recursion

--- a/plugins/tsugu/skills/tsugu/templates/policy.md
+++ b/plugins/tsugu/skills/tsugu/templates/policy.md
@@ -2,8 +2,8 @@
 create/commit/push `prepare/*` / `investigate/*` / `review/*` branches; worktrees; write `.tsugu/*`;
 run tests; try reversible patches; dispatch own (built-in) review subagents
 ## Public Coordination (ask first)
-open MR/PR; tracker comment / status change; assign reviewers; Slack; public
-commitments; move findings into human-facing docs; irreversible cleanup
+open MR/PR; tracker comment / status change; assign reviewers; Slack;
+public commitments; move findings into human-facing docs; irreversible cleanup
 ## Branch Prefixes
 prepare/*  investigate/*  review/*  public/*
 ## Remote

--- a/plugins/tsugu/skills/tsugu/templates/run.md
+++ b/plugins/tsugu/skills/tsugu/templates/run.md
@@ -1,0 +1,8 @@
+## Goal
+## Context read
+## Actions taken
+## Branches touched
+## Verification
+## Follow-up
+## Need human context
+## Promotion candidates


### PR DESCRIPTION
Adds the **`tsugu`** plugin (spec 004): a single-skill plugin, `/tsugu [init|prepare|converge|settle]`, for **git-native work preparation & human–agent convergence**.

継ぐ (*tsugu*) — "to inherit / continue / carry forward." Using git's DAG as the coordination substrate, an agent prepares engineering work privately on git branches (often while the human is away), records evidence in committed `.tsugu/` notes, and packages a convergence packet; the human **converges** (decides what becomes public) and the work is **settled** (clean public branch / PR, human-gated). **Never auto-merges; invokes no user-installed skill by default.**

## What's here
- **Manifest + registration** — `plugins/tsugu/.claude-plugin/plugin.json`; marketplace entry (`v0.1.0`); `metadata.version` 1.3.0 → 1.4.0.
- **SKILL.md** — spine (git is the message bus; tracker = optional human-bridge), routing, four routines (prepare partition table; converge sets + pushes `converged`; settle writes terminal status *after* verify, ⚙/🔒), private/public boundary, no-skill-by-default + per-repo `policy.md` opt-in, multi-agent reserved, scheduling/recursion, 継ぐ framing.
- **references/git-recipes.md** — documented plain-git recipes (no shipped scripts): cold-start read-queue from remote-tracking refs, coordination-ref writes (dedicated worktree, `default` sentinel, conflict-reconsider), public branch via merge-base diff + `git apply --index --binary` (preserves deletions), freshness rebase + `--force-with-lease`, cleanup order, idempotent init.
- **references/{policy-and-intake,notes-and-packet}.md**, five `.tsugu/` templates, user-facing `README.md`, the `/tsugu` command.
- **README.md + CLAUDE.md** entries (plugin count eight → nine).

## Quality
**Light by design** — documented recipes, no shipped scripts. Built via subagent-driven development with per-task spec reviews; hardened through a local Claude + headless Codex review gate (**13 rounds**). The two riskiest recipes — cold-start read-queue and the deletion-preserving public branch — **dogfood-pass** in a throwaway repo.

Spec: `docs/superpowers/specs/004-tsugu-skill-design.md` · Plan: `docs/superpowers/plans/004-tsugu-skill-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)