### PR TITLE
review-loop: fix Codex gate false-clean on local unpushed commits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,7 +55,7 @@
       "name": "review-loop",
       "source": "./plugins/review-loop",
       "description": "Assisted multi-reviewer review loop — local Claude + Codex gate first, then GitHub Copilot for PRs; never merges autonomously",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     {
       "name": "tsugu",

--- a/plugins/review-loop/skills/review-loop/SKILL.md
+++ b/plugins/review-loop/skills/review-loop/SKILL.md
@@ -66,6 +66,8 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
   ```bash
   log="/tmp/review-loop-codex.<runid>.log"; err="/tmp/review-loop-codex.<runid>.err"
   : >"$log"   # cumulative across rounds — for the tail -f watch pane only
+  # Preflight once: can Codex's command sandbox build here? Routing hint only.
+  sandbox=$("${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/sandbox-preflight.sh" 2>/dev/null) || true   # usable | broken | unknown
   ```
   Then **each round**: write Codex's stdout to a fresh `$round` file, capture `rc`, append that round to `$log` for the watch, and read **`$round`** (this round only):
   ```bash
@@ -83,7 +85,33 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
   ```
   The agent **never reads from this pane** — it reads `codex exec`'s stdout. All rounds append to the same `$log`, so the single pane keeps showing them. **Tear it down** at loop end (clean, usage-limit fallback, or abort) so it doesn't orphan — guard it so an unset/failed pane doesn't abort under `set -e`: `[ -n "${watch_pane:-}" ] && tmux kill-pane -t "$watch_pane" 2>/dev/null || true`. No tmux? Codex still runs — the human sees its findings relayed in Claude's own grouped tier list.
 
-- **Resolve the target into the working tree first.** `codex exec review` reviews the *current checkout*, so before reviewing, make the checkout match the requested target: for a `<branch>` target, `git checkout` it (or run from its worktree); for a `<PR-number>` target, `gh pr checkout <num>` first. Only then does `review --base "$base"` (or `--uncommitted`) look at the right diff. (If checkout isn't possible, **don't** pipe `gh pr diff` into `review -` — `review`'s stdin is *instructions*, not the diff, so it would still review the current checkout. Use the plain-exec fallback below with the diff embedded in the prompt: `codex exec --sandbox read-only "Review this diff for correctness, design, and risk:\n$(gh pr diff <num>)"` — or tell the author the PR can't be reviewed without checkout.)
+- **Resolve the target into the working tree first.** `codex exec review` reviews the *current checkout*, so before reviewing, make the checkout match the requested target: for a `<branch>` target, `git checkout` it (or run from its worktree); for a `<PR-number>` target, `gh pr checkout <num>` first. Only then does `review --base "$base"` (or `--uncommitted`) look at the right diff. (If checkout isn't possible, **don't** pipe a diff into `review -`: both `codex exec -` and `review -` read the *prompt / instructions* from stdin, **never** a diff or review target — so it would still review the current checkout. Instead use the embedded-diff form (A2): put the diff in the prompt, e.g. `codex exec --json --sandbox read-only "Review this diff for correctness, design, and risk:\n$(gh pr diff <num>)"` — or tell the author the PR can't be reviewed without checkout.)
+
+- **Route by sandbox state, not by target.** The preflight `$sandbox` decides which Codex form is primary:
+  - `usable` → native `review` (below): it reads the local tree directly, correct for pushed *and* unpushed targets (no remote fallback happens).
+  - `broken` / `unknown` → **embedded-diff form** (below): native may be unable to read the tree (a `broken` host falls back to the connected GitHub repo, which for a local-only target silently false-cleans; `unknown` is inconclusive — bwrap absent, working Landlock, or an unrecognized failure), so route conservatively. Embedding the diff sidesteps the sandbox entirely, so it is safe for every target on such a host. This also skips the wasted false-clean round on the common docs-to-`main` (unpushed design-artifact) case.
+
+  The **local-only** check is routing rationale (it explains *why* a broken host is dangerous), not a separate gate — it never overrides a `usable` sandbox. Detect local-only per target mode (heuristic, not proof — remote-tracking refs can be stale, so optionally `git fetch` first; the post-round detector is the real backstop): `--commit <sha>` → `git branch -r --contains <sha>` empty; `--base <base>` → any commit in `<base>..HEAD` unreachable (an unpushed `HEAD` ⇒ treat the whole target as local-only); `--uncommitted` → inherently local-only.
+
+- **Embedded-diff form (the `broken`/`unknown` path).** Put the diff *into the prompt* — no sandboxed subprocess is needed to read the tree, so the failure cannot occur. Keep `--json` (captures `thread_id` for resume):
+  ```bash
+  round="$(mktemp "${TMPDIR:-/tmp}/review-loop-codex.XXXXXX")"
+  rc=0
+  printf '%s\n\n%s\n' "Review this diff for correctness, design, and risk. List concrete defects:" "$(git show "$sha")" \
+    | codex exec --json --sandbox read-only - >"$round" 2>"$err" || rc=$?   # trailing - reads the PROMPT from stdin
+  cat "$round" >>"$log"
+  [ "$rc" = 0 ] && thread_id=$(jq -r 'select(.type=="thread.started") | .thread_id' "$round" 2>/dev/null | head -1) || true
+  ```
+  Do **not** also pass a `[PROMPT]` argument alongside `-` — stdin replaces it. Target variants: `--base` embeds `$(git diff "$base"...HEAD)`. `--uncommitted` must embed the **complete** snapshot — `git diff HEAD` (staged + unstaged tracked) **plus** each untracked file's contents (a filename list alone has none). Because `git diff --no-index` exits 1 whenever it emits a diff, build the snapshot `set -e`-safely by swallowing that status per file:
+  ```bash
+  unc="$(git diff HEAD
+  git ls-files --others --exclude-standard -z \
+    | xargs -0 -I{} sh -c 'git diff --no-index -- /dev/null "$1" || true' _ {}
+  echo "--- untracked files ---"; git ls-files --others --exclude-standard)"
+  # then embed "$unc" in the prompt. The trailing manifest is always appended so
+  # genuinely empty new files (which produce no diff) are still part of the snapshot.
+  ```
+  On a `usable` sandbox prefer native `review --uncommitted` instead (it covers all three directly).
 
 - **First round — map the loop's target to a `review` invocation, with `--json`.** This is the round whose session id we need, so run it with `--json` and capture `thread_id` for resume (§ Convergence rounds). `--sandbox read-only` goes **before** the subcommand. Target flags take **no** prompt (they conflict with `[PROMPT]` — `review --uncommitted -` errors rc=2), so the targeted forms carry no instructions. Use `--base "$base"` as the canonical default-target form:
   ```bash
@@ -111,23 +139,35 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
 - **Model / effort — defer to the user's Codex config.** Pass **no `-m` and no reasoning-effort override**: `codex exec review` honors `~/.codex/config.toml`'s `review_model` (falling back to the session default). Only if the author names a model for the session ("use gpt-5.4") pass `-m` for the rest of the loop.
 
 - **Three outcomes** after each call — branch on `rc`:
-  - **`rc == 0` → read the review (NL judgment).** Read **this round's `$round`** (not the cumulative `$log`, which replays earlier rounds) — a JSON event stream on the first round (read the review text from the assistant/agent-message events), plain text on `resume` rounds. Either way Claude classifies it into T1/T2/T3 or judges "no remaining problems," exactly as it handles its own subagent review. (Only `thread_id` is parsed out of the JSON; the review itself is read, not grepped.)
+  - **`rc == 0` → first confirm Codex actually read the tree, *then* read the review.** Read **this round's `$round`** (not the cumulative `$log`). **Post-round detector (the guarantee) — all native-path rounds (initial `review`, `resume`, and the fresh native fallback):** a native round that ran **zero `command_execution` items** never executed a local command, so it never read the tree (a sandbox false-clean). `codex exec --json` nests item kinds under `.item.type`, not top-level `.type`, so test:
+    ```bash
+    # set -e-safe: `jq -e` exits non-zero on no match, so branch on it (never run it bare).
+    if ! jq -e 'select(.type=="item.completed") | select(.item.type=="command_execution")' "$round" >/dev/null; then
+      :  # zero command_execution items ⇒ non-review (handle per below)
+    fi
+    ```
+    Corroborate with text markers `sandbox prevented reading|repository sandbox|filesystem sandbox failed|not available in the connected GitHub repository`; treat a bare `confidence is low` as a non-review **only** alongside one of those markers. **Embedded-diff rounds are exempt** — the diff is in the prompt, so zero `command_execution` is expected and *not* a failure; judge them by reading the review (text markers only as a sanity check). On a **non-review**, retry with the embedded-diff form; if that still can't produce a real review, **degrade to Claude-only with a surfaced note** ("Codex couldn't read the target locally — proceeding Claude-only for the Codex gate") — never a silent clean. Otherwise Claude reads the review and classifies it into T1/T2/T3 or judges "no remaining problems," exactly as for its own subagent review.
   - **Non-zero *with* a limit message in `$err`** (matching `usage limit|rate limit|quota|too many requests|try again later`) → **usage-limited.** **Stop the Codex sub-loop**, note "Codex hit its usage limit — falling back to Claude-only local review (+ Copilot if this is a GitHub target)," and continue without Codex.
   - **Non-zero *without* a limit match → "Codex failed"** (bad flag, invalid base, auth failure, etc.). Do **not** silently fold this into the usage-limit fallback — **surface it to the author** with a stderr summary (`tail "$err"`), then degrade to Claude-only. (A read-only review in an untrusted/first-run directory was verified to *proceed* — rc=0 — not hard-fail, so no dedicated trust branch is needed; any future trust-gate non-zero exit lands here.)
 
-- **Convergence rounds — resume the same session (plain, no `--json`).** Use the `thread_id` captured from the first round (the `--json` stream's `thread_id` field — not `session_id`) and resume so Codex remembers its prior comments. No `--json` here — `resume` produces readable output and there's no new id to capture (`resume`'s trailing `-` for the follow-up prompt is valid — only `review` target flags conflict with a prompt):
+- **Convergence rounds — resume the same session, with `--json`.** Use the `thread_id` captured from the first round (the `--json` stream's `thread_id` field — not `session_id`) and resume so Codex remembers its prior comments. **Keep `--json`** so the post-round detector (above) can still run on the resume round — read the review text from the assistant/agent-message events, exactly as on the first round (`resume`'s trailing `-` for the follow-up prompt is valid — only `review` target flags conflict with a prompt):
   ```bash
   round="$(mktemp "${TMPDIR:-/tmp}/review-loop-codex.XXXXXX")"
   rc=0
   printf '%s\n' "I applied these fixes: <summary>. Are your earlier points resolved? Any new concerns?" \
-    | codex exec --sandbox read-only resume "$thread_id" - >"$round" 2>"$err" || rc=$?
+    | codex exec --json --sandbox read-only resume "$thread_id" - >"$round" 2>"$err" || rc=$?
   cat "$round" >>"$log"   # feed the watch pane; Claude reads "$round" (this round only)
   ```
-  **Fallbacks, in order:** no id captured (e.g. `jq` absent — the `thread_id` parse needs it) → `resume --last` (caveat: `--last` is cwd-scoped, so an unrelated `codex` session started in this repo mid-loop becomes the new "last"); `resume` fails (session expired/missing) → a **fresh** `codex exec --sandbox read-only review -` (freeform, no target flag) with the prior findings restated, so a round never silently loses the review.
+  **Fallbacks, in order:** no id captured (e.g. `jq` absent — the `thread_id` parse needs it) → `resume --last` (caveat: `--last` is cwd-scoped, so an unrelated `codex` session started in this repo mid-loop becomes the new "last"); `resume` fails (session expired/missing) → a **fresh** `codex exec --json --sandbox read-only review -` (freeform, no target flag) with the prior findings restated, so a round never silently loses the review.
+
+- **Sticky embedded-diff convergence.** If the run is on the embedded-diff path (routed there, or moved there by the detector), keep **all** convergence rounds on it — re-embed the *complete* current target diff each round (`git show <sha>` / `git diff "$base"...HEAD`), **not** just the latest fix commit (a delta would hide regressions in earlier hunks). Resume against `thread_id` is fine only when the full current diff is embedded. **On the embedded path, the resume-failure fallback is a *fresh embedded-diff* call carrying the complete diff — not the generic fresh native `review -`** (which would re-trigger the sandbox false-clean on a broken host). Keep `--json` for `thread_id` + parsing; the structural detector does not apply to embedded-diff rounds (their guarantee is inherent — the diff is in the prompt). Any unavoidably plain-text round falls back to text markers alone.
 
 - **Loop Codex until clean or its usage limit:** each round classify its findings into tiers, resolve picks, fix, then `resume` for re-review. Repeat until **either** Codex reports no remaining problems (Codex gate clean) **or** it hits the usage-limit outcome above.
 
 - **Freeform plain-exec fallback (rare).** Drop to `codex exec "<instructions + diff>"` only when (a) the installed `codex` is too old to have `exec review`, or (b) the target is **not** a git diff (e.g. a pasted artifact outside any repo) — in case (b) **only**, add `--skip-git-repo-check` (unnecessary on the normal `review`/`resume` paths).
+
+- **Local, unpushed commits on `main` are a first-class case, not an edge case.** Under the docs-to-`main` convention, design-artifact reviews routinely target a freshly-committed, unpushed commit on `main`. On a `broken`/`unknown` host that is exactly where native `review` silently false-cleans (it falls back to the remote, which lacks the commit) — which is why A2 routes these to the embedded-diff form and guards every native round with the post-round detector.
+- **Host fixes (optional).** If you want the native `review` path back on a host where the preflight reports `broken`, see `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/references/codex-sandbox-host-fixes.md` — a menu (bwrap-userns-restrict, legacy-landlock, …). The skill never applies these; embedded-diff already works with no host change.
 
 **A3. Converge the local gate** — re-run A1/A2 after fixes until Claude is clean **and** Codex is clean *when available*. "Done" for Codex means any of: clean review, **or** Codex was unavailable this run — the `codex` CLI is absent, it stopped at its usage limit, or it **failed for a non-limit reason** (§4 "Codex failed": surfaced to the author, then degraded to Claude-only). In every unavailable case the gate proceeds on Claude alone; only an *available, not-yet-clean* Codex blocks. Only then proceed.
 

--- a/plugins/review-loop/skills/review-loop/references/codex-sandbox-host-fixes.md
+++ b/plugins/review-loop/skills/review-loop/references/codex-sandbox-host-fixes.md
@@ -1,0 +1,111 @@
+# Codex sandbox host fixes (optional)
+
+`review-loop` works correctly **without any of these** — its embedded-diff fallback
+sidesteps a broken sandbox entirely (option 5). These fixes are only for restoring
+the *native* `codex exec review` path on a host where bubblewrap can't build its
+sandbox (Ubuntu 23.10+/24.04 default `kernel.apparmor_restrict_unprivileged_userns=1`).
+The skill **never** applies any of them — pick what fits your machine.
+
+Symptom: `sandbox-preflight.sh` prints `broken`, and `codex … review --commit <unpushed-sha>`
+returns a false-clean ("…not available in the connected GitHub repository").
+
+| # | Fix | sudo / scope | Trade-off | Prefer when |
+|---|-----|--------------|-----------|-------------|
+| 1 | `bwrap-userns-restrict` AppArmor profile | sudo; all bwrap callers | durable; also blocks nested-ns escape | you want the native path back, durably |
+| 2 | `features.use_legacy_landlock=true` | none; codex only | **deprecated** in recent codex | a quick, no-sudo stopgap |
+| 3 | hand-rolled `/etc/apparmor.d/bwrap` (`flags=(unconfined)` + a `userns` rule) | sudo; all bwrap callers | least strict (nested-escape hole) | only if #1 unavailable |
+| 4 | `sysctl …apparmor_restrict_unprivileged_userns=0` | sudo; whole system | drops the hardening globally | last resort |
+| 5 | skill-side embedded-diff | none | n/a — already automatic | always available; zero config |
+
+## 1. `bwrap-userns-restrict` (recommended durable default)
+
+Ships in Ubuntu's `apparmor-profiles` (default in 25.04; backportable to 24.04). Restores
+bwrap's userns under an AppArmor profile **and** denies a sandboxed child from creating
+further namespaces (closing the nested-escape gap that option 3 leaves open).
+
+```bash
+sudo apt install apparmor-profiles   # if not present
+sudo systemctl reload apparmor
+```
+
+Verify:
+
+```bash
+bwrap --ro-bind / / --unshare-user --unshare-net --dev /dev echo OK   # prints OK
+```
+
+## 2. `features.use_legacy_landlock=true` (temporary compatibility workaround)
+
+No sudo, scoped to codex; uses the Landlock LSM instead of bwrap, with the read-only
+sandbox preserved. **Recent `codex` marks this deprecated and slated for removal** — treat
+it as a stopgap, not a long-term default. If it is removed, fall back to #1 or rely on
+the skill-side embedded-diff path.
+
+```toml
+# ~/.codex/config.toml
+[features]
+use_legacy_landlock = true
+```
+
+Verify:
+
+```bash
+codex exec --sandbox read-only review --commit <unpushed-sha>   # produces a real review
+```
+
+## 3. Hand-rolled `/etc/apparmor.d/bwrap` (inferior to `bwrap-userns-restrict`)
+
+Works, but is the **least strict** variant: sandboxed children also get userns (the
+nested-escape hole that `bwrap-userns-restrict` closes). Use only if option 1 is unavailable.
+
+Create the profile and load it:
+
+```bash
+sudo tee /etc/apparmor.d/bwrap >/dev/null <<'EOF'
+abi <abi/4.0>,
+include <tunables/global>
+
+profile bwrap /usr/bin/bwrap flags=(unconfined) {
+  userns,
+  include if exists <local/bwrap>
+}
+EOF
+sudo apparmor_parser -r /etc/apparmor.d/bwrap
+```
+
+Verify:
+
+```bash
+bwrap --ro-bind / / --unshare-user --unshare-net --dev /dev echo OK   # prints OK
+```
+
+## 4. `sysctl …=0` (last resort — drops hardening system-wide)
+
+```bash
+echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/99-userns.conf
+sudo sysctl --system
+```
+
+This disables the 24.04 unprivileged-userns hardening for **every** process. Not recommended.
+
+Verify:
+
+```bash
+sysctl kernel.apparmor_restrict_unprivileged_userns                  # = 0
+bwrap --ro-bind / / --unshare-user --unshare-net --dev /dev echo OK  # prints OK
+```
+
+## 5. Skill-side embedded-diff (no host change)
+
+This is what `review-loop` does automatically on a `broken`/`unknown` host: it embeds the
+diff in the prompt (`git show <sha>` / `git diff <base>...HEAD`), so Codex needs no
+sandboxed subprocess to read the tree. Zero config; always available. The other options
+only matter if you specifically want the native `review` path back.
+
+Verify (no host change — confirm the fallback itself yields a real review):
+
+```bash
+sha=$(git rev-parse HEAD)
+printf '%s\n\n%s\n' "Review this diff for correctness and risk:" "$(git show "$sha")" \
+  | codex exec --sandbox read-only -        # produces a real review with no native sandbox
+```

--- a/plugins/review-loop/skills/review-loop/scripts/sandbox-preflight.sh
+++ b/plugins/review-loop/skills/review-loop/scripts/sandbox-preflight.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# sandbox-preflight.sh — probe whether Codex's local command sandbox (bubblewrap)
+# can build on this host. Prints one status word + matching exit code:
+#   usable  (0)  bwrap built the sandbox
+#   broken  (1)  bwrap failed at userns/loopback setup with a permission error
+#                (EPERM "Operation not permitted" or EACCES "Permission denied")
+#   unknown (2)  bwrap absent on PATH, or any other (non-permission) failure — can't conclude
+#
+# This is a ROUTING HINT only. review-loop's post-round structural detector is the
+# real guarantee. Caveat: if the user set features.use_legacy_landlock=true, Codex
+# uses Landlock and never calls bwrap, so this may report `broken` while native
+# `review` actually works — harmless, since the skill then routes to embedded-diff.
+set -euo pipefail
+
+if ! command -v bwrap >/dev/null 2>&1; then
+  echo unknown
+  exit 2
+fi
+
+# Match the namespaces Codex's own bwrap invocation creates (issue #41 strace):
+# --unshare-user --unshare-net. Capture bwrap's stderr; discard its stdout.
+rc=0
+errout="$(bwrap --ro-bind / / --unshare-user --unshare-net --dev /dev true 2>&1 1>/dev/null)" || rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo usable
+  exit 0
+fi
+
+# Userns/loopback permission error (EPERM/EACCES) on a bwrap setup line (Ubuntu
+# apparmor_restrict_unprivileged_userns) ⇒ broken. Scope to bwrap's own diagnostics
+# (the `bwrap:` prefix) so an unrelated permission error from elsewhere stays
+# `unknown`, per spec Component 1 ("in a bwrap setup line").
+pat='bwrap:.*(Operation not permitted|Permission denied)'
+if [[ "$errout" =~ $pat ]]; then
+  echo broken
+  exit 1
+fi
+
+# Non-EPERM failure (e.g. bad flags, other bwrap error) ⇒ can't conclude.
+echo unknown
+exit 2

--- a/tools/review-loop/test-sandbox-preflight.sh
+++ b/tools/review-loop/test-sandbox-preflight.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREFLIGHT="$SCRIPT_DIR/../../plugins/review-loop/skills/review-loop/scripts/sandbox-preflight.sh"
+BASH_BIN="$(command -v bash)"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/review-loop-test.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+make_stub() { # $1=dir name, $2=exit code, $3=stderr line
+  mkdir -p "$tmp/$1"
+  cat >"$tmp/$1/bwrap" <<EOF
+#!/usr/bin/env bash
+echo "$3" >&2
+exit $2
+EOF
+  chmod +x "$tmp/$1/bwrap"
+}
+
+make_stub usable 0 ""
+make_stub broken 1 "bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted"
+make_stub other  1 "bwrap: something unrelated went wrong"
+make_stub noctx  1 "some-tool: Operation not permitted"   # EPERM but no bwrap: context
+
+run() { # $1=PATH to use ; prints "<stdout> <exit>"
+  local out rc=0
+  out="$(PATH="$1" "$BASH_BIN" "$PREFLIGHT" 2>/dev/null)" || rc=$?
+  printf '%s %s' "$out" "$rc"
+}
+
+echo "Test 1: usable sandbox -> usable/0"
+[ "$(run "$tmp/usable:$PATH")" = "usable 0" ] || fail "expected 'usable 0'"
+pass "usable"
+
+echo "Test 2: broken sandbox (EPERM) -> broken/1"
+[ "$(run "$tmp/broken:$PATH")" = "broken 1" ] || fail "expected 'broken 1'"
+pass "broken"
+
+echo "Test 3: bwrap absent -> unknown/2"
+[ "$(run "/nonexistent-preflight-dir")" = "unknown 2" ] || fail "expected 'unknown 2'"
+pass "absent"
+
+echo "Test 4: non-EPERM failure -> unknown/2"
+[ "$(run "$tmp/other:$PATH")" = "unknown 2" ] || fail "expected 'unknown 2'"
+pass "non-EPERM"
+
+echo "Test 5: EPERM without a bwrap: setup line -> unknown/2"
+[ "$(run "$tmp/noctx:$PATH")" = "unknown 2" ] || fail "expected 'unknown 2'"
+pass "EPERM-without-bwrap-context"
+
+echo "All sandbox-preflight tests passed."

--- a/tools/review-loop/test-skill-content.sh
+++ b/tools/review-loop/test-skill-content.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL="$SCRIPT_DIR/../../plugins/review-loop/skills/review-loop/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+need() { # $1=regex, $2=description
+  grep -Eq "$1" "$SKILL" || fail "SKILL.md missing: $2"
+  pass "$2"
+}
+
+need 'sandbox-preflight\.sh'                              "preflight script reference"
+need 'Route by sandbox state'                            "sandbox-state routing rule"
+need 'Embedded-diff form'                                "embedded-diff form"
+need '\.item\.type=="command_execution"'                 "detector jq predicate (nested .item.type)"
+need 'Embedded-diff rounds are exempt'                   "detector exemption for embedded-diff"
+need 'references/codex-sandbox-host-fixes\.md'           "host-fix reference link"
+
+echo "All SKILL.md content checks passed."


### PR DESCRIPTION
Implements spec 009 (`docs/superpowers/specs/009-review-loop-codex-sandbox-fix-design.md`).

Closes #41.

## What
- New `sandbox-preflight.sh` probe (usable/broken/unknown) — routing hint.
- SKILL.md A2: route by sandbox state (usable → native review; broken/unknown → embedded-diff with the diff in the prompt); post-round structural detector (zero `command_execution` native round ⇒ non-review, not a clean pass; jq at `.item.type`); embedded-diff rounds exempt; sticky embedded-diff convergence; doc fixes (local-unpushed-on-main first-class, stdin `-` = prompt not diff).
- New `references/codex-sandbox-host-fixes.md` host-fix menu (skill never applies these).
- Tests under `tools/review-loop/` (stubbed-bwrap unit test + SKILL content guard).
- review-loop 0.2.0 → 0.3.0.

## Verified (this host: Ubuntu 24.04, codex 0.139.0)
- preflight → `broken` / exit 1.
- native `review --commit <unpushed>` (legacy-landlock disabled) → **zero `command_execution`** ⇒ detector classifies non-review (detector exit 4).
- embedded-diff → real review, planted overdraft/unchecked-withdrawal bug found.
- regression: native `review` with legacy-landlock active → **3 `command_execution`** ⇒ detector does not misfire (treats it as a real review).

Unit suite: `test-sandbox-preflight.sh` 5/5, `test-skill-content.sh` 6/6.

Built via subagent-driven execution of plan 009 (one implementer + spec/quality review per task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)