### PR TITLE
review-loop 0.5.0: enrolled reviewer roster + adversarial panel

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,8 +54,8 @@
     {
       "name": "review-loop",
       "source": "./plugins/review-loop",
-      "description": "Assisted multi-reviewer review loop — local Claude + Codex gate first, then GitHub Copilot for PRs; never merges autonomously",
-      "version": "0.4.0"
+      "description": "Assisted adversarial review panel — reviewers answer blind, attack each other's findings, then converge; enrolled roster via /review-loop:init; never merges autonomously",
+      "version": "0.5.0"
     },
     {
       "name": "tsugu",

--- a/docs/superpowers/plans/014-review-loop-adversarial-panel.md
+++ b/docs/superpowers/plans/014-review-loop-adversarial-panel.md
@@ -620,7 +620,7 @@ learn the loop is alive buys nothing.
   printf '%s\n' "$brief" | codex exec --json --sandbox read-only review -
   ```
   **An inferred diff may not be the same diff, and R1 is the blind round.** So the
-  brief names the exact range `<base>..<head-sha>`, requires the review to state the
+  brief names the exact range `<base>...<head-sha>`, requires the review to state the
   commit range and file list it actually reviewed as its first line, and the
   facilitator compares that against `git diff --name-only "$base"..."$head"`. A
   mismatch → re-run once with the diff embedded (which cannot be inferred wrong); a
@@ -1393,7 +1393,7 @@ Expected: `codex present`, `gh present`, the rest `absent` on this host. Confirm
 
 Confirm by reading `SKILL.md`:
 - A1 says panelists review **blind**, on the same **unfixed** diff, and R1 findings are shown to the author as `proposed`.
-- The freeform-native R1 pins `<base>..<head-sha>` and checks the echoed file list against `git diff --name-only`.
+- The freeform-native R1 pins `<base>...<head-sha>` and checks the echoed file list against `git diff --name-only`.
 - R2's prompt asks for the claim you "tried hardest to break" and **does not** mandate a disagreement.
 - The R2 detector exemption's stated reason is the **category error** (an R2's subject is the findings), not "critique rounds read no files".
 - The gate is `survived ∨ reproduced`; a single-panelist run auto-fixes on `reproduced` alone.

--- a/docs/superpowers/plans/014-review-loop-adversarial-panel.md
+++ b/docs/superpowers/plans/014-review-loop-adversarial-panel.md
@@ -1,0 +1,1474 @@
+# review-loop Reviewer Roster + Adversarial Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `review-loop` a discovered, calibrated reviewer roster (`/review-loop:init`) and turn its serial reviewers into an adversarial panel — blind parallel round 1, one cross-critique round, per-finding confidence + falsification, and an auto-fix gate that reproduction outranks — per [spec 014](../specs/014-review-loop-adversarial-panel-design.md).
+
+**Architecture:** `SKILL.md` is an LLM-read system prompt, so most "behavior" is wording. **No new script ships.** The only new programs are dev tooling: a `need_new()` harness helper that fails any regression anchor which already matches the pre-change `SKILL.md`, and a fixture suite pinning the detector exemption. Everything else is prose edits plus a new namespaced command (`/review-loop:init`), guarded by content anchors.
+
+**Tech Stack:** Markdown (system prompt), Bash (`set -euo pipefail`), `git`, `jq`, `codex` CLI, `gh`. No build system — plugin/skill repo.
+
+## Global Constraints
+
+Copied verbatim from the spec; every task's requirements implicitly include these.
+
+- **Never trust a model where a check can run.** Anchors guarding new behavior use `need_new`; a prose citation is `reproduced` only after the facilitator runs the check. (Spec, "The second principle".)
+- **Materialize critical knowledge only.** A shipped script must encode something an agent would get wrong or skip — GraphQL bot-ids, pagination, building a sandbox. A `command -v` loop does not qualify: wrapping it calcifies a decision that a more capable model will make correctly without help. Prefer prose the agent executes. (Spec, "Its corollary".)
+- **The skill encodes no environment.** Nothing assumed present, nothing assumed callable, nothing ships that we cannot exercise. (Spec, "The governing principle".)
+- **No secrets, ever.** The config stores names, never a url, never an `api_key_env`, never a token.
+- **Dev tooling stays out of `plugins/<name>/`** (repo `CLAUDE.md`). Tests and fixtures live in `tools/review-loop/`. No new file is added under `plugins/review-loop/skills/review-loop/scripts/`.
+- **Bash scripts use `set -euo pipefail`.**
+- Conventional commits, scoped: `feat(review-loop):`, `docs(review-loop):`, `test(review-loop):`, `chore(review-loop):`.
+- Repo-facing text (commits, code comments, SKILL.md, README) is **English**.
+- Target version: `review-loop` `0.4.0` → `0.5.0` in `.claude-plugin/marketplace.json`.
+- **Never merges autonomously**; the author decides T2/T3 and the merge. Unchanged.
+
+## Scope & Conventions
+
+- **Implementation must go on a feature branch in a worktree, never `main`.** Branch: `feat/review-loop-adversarial-panel`, worktree already at `/dev/shm/dong3/review-loop-panel`. Run **every** git command from inside it (`git -C /dev/shm/dong3/review-loop-panel`) — a wrong cwd lands commits on the main checkout's branch.
+- The spec is the source of truth. Where this plan and the spec disagree, the spec wins; report the discrepancy rather than guessing.
+- All `SKILL.md` edits use the **Edit tool** with the verbatim "Find" anchors below as `old_string`. Anchors were captured from `SKILL.md` at `0.4.0`. **If an Edit fails to match, re-read the live file and report — do not guess a replacement.**
+- Line numbers in "Files" are advisory; the Find anchors are authoritative.
+
+## File Structure
+
+**Create:**
+- `plugins/review-loop/commands/init.md` — the `/review-loop:init` command doc.
+- `tools/review-loop/fixtures/*.jsonl` + `tools/review-loop/test-detector-predicate.sh` — dev tooling pinning the R2 detector exemption.
+
+**Deliberately NOT created:** no `panel-detect.sh`. The presence probe is a `command -v` loop the agent runs inline (spec §A.2); a script for it would buy a maintenance burden and a JSON schema whose only consumer is the agent.
+
+**Modify:**
+- `tools/review-loop/test-skill-content.sh` — add `need_new()`; add spec-014 anchors.
+- `plugins/review-loop/skills/review-loop/SKILL.md` — roster, calibration, Phase A restructure, finding record, gate, verdicts, forge slot.
+- `plugins/review-loop/commands/review-loop.md` — invariant lines.
+- `plugins/review-loop/skills/review-loop/README.md` — `init`, config path, Copilot-as-adapter.
+- `.claude-plugin/marketplace.json` — version + description.
+
+**Deliberately unchanged:** `scripts/copilot.sh`, `scripts/pr-comments.sh`, `scripts/sandbox-preflight.sh`, the detector's jq predicate, the embedded-diff form, the sticky-embedded rule, exit-code triage.
+
+---
+
+## Task 0: Baseline, and fixture coverage for the detector exemption
+
+Task 4 adds an exemption to the `command_execution` detector for R2 critique rounds. On a host whose preflight reports `broken`, every Codex round routes to the embedded-diff form, so that native branch never executes here — a **testing** gap, not a running one.
+
+**The coverage is a recorded event-stream fixture, not a change to anyone's machine.** The detector is a real `jq` predicate over `codex --json`'s output, so a fixture tests it deterministically with no sandbox involved.
+
+**Nothing in this plan asks for `sudo`.** Restoring the native path means editing the host's AppArmor/sysctl policy — system-wide, affecting every `bwrap` caller. `/review-loop:init` may *suggest* it and point at `references/codex-sandbox-host-fixes.md`; the author may then do it, with an agent's help if they like, **as its own task in its own session**. Suggesting is not owning. It is not a prerequisite for this plan, and its absence is a configuration, not a defect (spec §A.3, §B.12).
+
+**Files:**
+- Create: `tools/review-loop/fixtures/codex-native-false-clean.jsonl`
+- Create: `tools/review-loop/fixtures/codex-native-real-review.jsonl`
+- Create: `tools/review-loop/fixtures/codex-r2-critique.jsonl`
+- Create: `tools/review-loop/test-detector-predicate.sh`
+
+**Interfaces:**
+- Produces: `classify_round <kind> <file>` semantics pinned by test — `kind` ∈ {`review`, `critique`}; a `review` round with zero `command_execution` items is a **non-review**; a `critique` round with zero is a **review** (exempt).
+
+- [ ] **Step 1: Record the baseline (informational; no human, no commit)**
+
+Run:
+```bash
+cd /dev/shm/dong3/review-loop-panel
+plugins/review-loop/skills/review-loop/scripts/sandbox-preflight.sh || true
+codex --version
+bash tools/review-loop/test-skill-content.sh
+bash tools/review-loop/test-sandbox-preflight.sh
+```
+Expected: a verdict (`usable` / `broken` / `unknown`) — **record it, act on nothing** — then both suites exit 0. A pre-existing suite failure is reported, not fixed here.
+
+If the verdict is `usable`, also exercise the real native path in Task 10 Step 3. If it is not, the fixtures below are the coverage and Task 11's PR body discloses the residue.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tools/review-loop/test-detector-predicate.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Pins the post-round detector's decision, using recorded `codex --json` streams.
+# No sandbox, no network, no codex binary required.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIX="$SCRIPT_DIR/fixtures"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+# The predicate, verbatim from SKILL.md's detector.
+ran_a_command() {
+  jq -e 'select(.type=="item.completed") | select(.item.type=="command_execution")' "$1" >/dev/null 2>&1
+}
+
+# The routing decision the skill must make.
+#   review  round + zero commands -> non-review (sandbox false clean)
+#   critique round + zero commands -> review (exempt: its subject is the findings)
+classify_round() { # $1=kind ($2=file)
+  if ran_a_command "$2"; then echo "review"; return; fi
+  case "$1" in
+    critique) echo "review" ;;
+    *)        echo "non-review" ;;
+  esac
+}
+
+for f in codex-native-false-clean codex-native-real-review codex-r2-critique; do
+  [ -f "$FIX/$f.jsonl" ] || fail "missing fixture: $f.jsonl"
+  jq -e . "$FIX/$f.jsonl" >/dev/null || fail "fixture is not valid JSONL: $f"
+done
+pass "fixtures present and parse as JSONL"
+
+[ "$(classify_round review "$FIX/codex-native-false-clean.jsonl")" = "non-review" ] \
+  || fail "a sandbox-blocked native review must be a non-review, never a silent clean"
+pass "native review + zero commands -> non-review"
+
+[ "$(classify_round review "$FIX/codex-native-real-review.jsonl")" = "review" ] \
+  || fail "a native review that ran commands must be a review"
+pass "native review + commands -> review"
+
+# The exemption. This is the branch that cannot execute on a `broken` host.
+ran_a_command "$FIX/codex-r2-critique.jsonl" \
+  && fail "the critique fixture must have ZERO command_execution items to test the exemption"
+[ "$(classify_round critique "$FIX/codex-r2-critique.jsonl")" = "review" ] \
+  || fail "an R2 critique round with zero commands must be EXEMPT, not a non-review"
+pass "R2 critique + zero commands -> review (exempt)"
+
+# The false-clean fixture must also carry a corroborating text marker.
+grep -q 'sandbox prevented reading' "$FIX/codex-native-false-clean.jsonl" \
+  || fail "false-clean fixture lacks its corroborating text marker"
+pass "false-clean fixture carries a text marker"
+
+# thread_id is parseable from every fixture (resume depends on it).
+for f in "$FIX"/*.jsonl; do
+  jq -re 'select(.type=="thread.started") | .thread_id' "$f" >/dev/null \
+    || fail "no thread_id in $(basename "$f")"
+done
+pass "thread_id parseable from every fixture"
+
+echo "All detector-predicate checks passed."
+```
+
+`chmod +x tools/review-loop/test-detector-predicate.sh`
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `bash tools/review-loop/test-detector-predicate.sh`
+Expected: `FAIL: missing fixture: codex-native-false-clean.jsonl`
+
+- [ ] **Step 4: Create the fixtures**
+
+Event shapes are taken from real `codex-cli 0.139.0 --json` output: items nest their kind under `.item.type`, not top-level `.type`.
+
+`tools/review-loop/fixtures/codex-native-false-clean.jsonl` — the sandbox blocked the round, so it never read the tree:
+```
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-00000000face"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"The sandbox prevented reading the working tree, so I reviewed the connected GitHub repository instead. I found no issues, but my confidence is low."}}
+{"type":"turn.completed"}
+```
+
+`tools/review-loop/fixtures/codex-native-real-review.jsonl` — it read the tree and found something:
+```
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-00000000beef"}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"git diff main...HEAD","status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"sed -n '1,80p' src/ttl.ts","status":"completed"}}
+{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"src/ttl.ts:41 - expiry comparison uses `<`, so an entry expiring exactly now survives one extra get(). confidence: high. not a bug if expiry is intended to be exclusive."}}
+{"type":"turn.completed"}
+```
+
+`tools/review-loop/fixtures/codex-r2-critique.jsonl` — a cross-critique round arguing from what is already in its session. Zero commands, and correct:
+```
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-00000000cafe"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"Attacking the other panelist's finding #2: it claims `opts` may be null, but their own quoted hunk shows `opts: Options = {}` on the line above. REFUTED. My own finding #1 I keep, at high confidence."}}
+{"type":"turn.completed"}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bash tools/review-loop/test-detector-predicate.sh`
+Expected: six `PASS:` lines, then `All detector-predicate checks passed.`, exit 0.
+
+Sanity-check that the exemption is the thing being tested — remove it and watch the suite go red:
+```bash
+sed -i.bak 's/    critique) echo "review" ;;/    critique) echo "non-review" ;;/' tools/review-loop/test-detector-predicate.sh
+bash tools/review-loop/test-detector-predicate.sh; echo "exit=$?"
+mv tools/review-loop/test-detector-predicate.sh.bak tools/review-loop/test-detector-predicate.sh
+```
+Expected: `FAIL: an R2 critique round with zero commands must be EXEMPT` and a non-zero exit, then the file is restored. If it still passes, the test is not testing the exemption — fix it before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/review-loop/fixtures tools/review-loop/test-detector-predicate.sh
+git commit -m "test(review-loop): cover the R2 detector exemption with recorded fixtures
+
+The exemption Task 4 adds cannot execute on a host whose codex sandbox preflight
+reports broken -- every round routes to the embedded-diff form. That is a testing
+gap, not a running one, and it does not warrant touching anyone's machine: restoring
+the native path is an AppArmor/sysctl policy change, system-wide and privileged, and
+a review skill has no business asking for sudo.
+
+The detector is a real jq predicate over codex --json's event stream, so a recorded
+stream pins it deterministically with no sandbox involved. Three fixtures: a
+sandbox-blocked native review (zero commands -> non-review, never a silent clean), a
+native review that read the tree, and an R2 critique arguing from session context
+(zero commands -> exempt). Step 5 flips the exemption and requires the suite to go
+red, so the test is known to be capable of failing.
+
+Empirically the exemption is a safety net rather than the common case: this spec's
+own R2 ran five command_execution items, because refuting by reproduction means
+opening the file at the cited line.
+
+Implements spec 014 §B.12."
+```
+
+---
+
+## Task 1: `need_new()` — make the harness prove an anchor can fail
+
+This lands **before** any `SKILL.md` edit. Three anchors proposed during spec 014's own review rounds were vacuous (`need 'confidence'`, `need 'invocation'`, `refute '^## Phase B — GitHub Copilot'`), each asserted by a model that had not run `grep` against the file it was describing. A test that cannot fail is not a test.
+
+**Files:**
+- Modify: `tools/review-loop/test-skill-content.sh`
+
+**Interfaces:**
+- Produces: `need_new <regex> <description>` — passes only if the regex matches the working `SKILL.md` **and does not match** `SKILL.md` at `$BASE_REF`. Used by Tasks 3–10.
+
+- [ ] **Step 1: Add the repo/base plumbing and the helper**
+
+Find (verbatim):
+
+```
+refute() { # $1=regex, $2=description — fails if the regex IS present
+  ! grep -Eq "$1" "$SKILL" || fail "SKILL.md still contains (should be gone): $2"
+  pass "no longer present: $2"
+}
+```
+
+Replace with:
+
+```
+refute() { # $1=regex, $2=description — fails if the regex IS present
+  ! grep -Eq "$1" "$SKILL" || fail "SKILL.md still contains (should be gone): $2"
+  pass "no longer present: $2"
+}
+
+# Novelty-checked anchor. An anchor that already matches the PRE-CHANGE SKILL.md
+# guards nothing: it passes before the work is done. Three such anchors were
+# proposed during spec 014's review and none of their authors had run grep.
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_REL="plugins/review-loop/skills/review-loop/SKILL.md"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+BASE_REF="${BASE_REF:-$(git -C "$REPO" merge-base HEAD "$DEFAULT_BRANCH" 2>/dev/null || true)}"
+
+need_new() { # $1=regex, $2=description — must match now, must NOT match at $BASE_REF
+  grep -Eq "$1" "$SKILL" || fail "SKILL.md missing: $2"
+  if [ -z "$BASE_REF" ]; then
+    echo "WARN: no BASE_REF (not a git checkout?) — novelty unchecked for: $2" >&2
+    pass "$2"
+    return
+  fi
+  local base_content
+  base_content="$(git -C "$REPO" show "$BASE_REF:$SKILL_REL" 2>/dev/null)" || \
+    fail "cannot read baseline $BASE_REF:$SKILL_REL for: $2"
+  if grep -Eq "$1" <<<"$base_content"; then
+    fail "vacuous anchor (already present at $BASE_REF): $2"
+  fi
+  pass "$2"
+}
+```
+
+- [ ] **Step 2: Prove `need_new` actually catches a vacuous anchor**
+
+This is the step that makes the helper trustworthy. Run, **without committing**:
+
+The probe copy must live **beside** the real harness: `test-skill-content.sh` derives
+`SCRIPT_DIR` from `${BASH_SOURCE[0]}` and `REPO` from `$SCRIPT_DIR/../..`, so a copy run
+from `/tmp` would resolve `REPO` to `/` and the novelty check would silently no-op —
+the step meant to prove the guard can fail would itself fail open.
+
+```bash
+cd /dev/shm/dong3/review-loop-panel
+probe=tools/review-loop/.tsc-probe.sh          # beside the real harness, so SCRIPT_DIR resolves
+cp tools/review-loop/test-skill-content.sh "$probe"
+printf "\nneed_new 'Codex' 'deliberately vacuous anchor'\n" >> "$probe"
+bash "$probe"; echo "exit=$?"
+rm -f "$probe"
+```
+Expected: the run ends with
+`FAIL: vacuous anchor (already present at <sha>): deliberately vacuous anchor` and a **non-zero** exit.
+(`Codex` appears throughout the unmodified `SKILL.md`, so a working `need_new` must reject it.)
+If it instead PASSES, `need_new` is broken — fix it before continuing. Do not commit `.tsc-probe.sh`.
+
+- [ ] **Step 3: Run the real suite to confirm nothing regressed**
+
+Run: `bash tools/review-loop/test-skill-content.sh`
+Expected: all existing checks pass, exit 0 (no `need_new` calls yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/review-loop/test-skill-content.sh
+git commit -m "test(review-loop): add need_new(), an anchor that must be able to fail
+
+Three anchors proposed during spec 014's review rounds were vacuous -- they
+matched the unmodified SKILL.md, so they passed before any work was done. Each
+was asserted by a model that had not run grep against the file it described.
+need_new asserts the regex matches the working file and does NOT match the file
+at the merge-base, so a guard that cannot fail is itself a test failure.
+
+Implements spec 014 § Testing."
+```
+
+---
+
+## Task 2: `SKILL.md` — reviewer roster, requirements, loop-start reconciliation
+
+**Files:**
+- Modify: `plugins/review-loop/skills/review-loop/SKILL.md` (Requirements ~16–22; "Reviewer roster & priority" ~32–36)
+
+- [ ] **Step 1: Reword Requirements so Codex is enrolled, not assumed**
+
+Find (verbatim):
+
+```
+- **Always usable:** the Claude subagent reviewer needs nothing extra.
+```
+
+Replace with:
+
+```
+- **Always usable:** the Claude subagent reviewer needs nothing extra.
+- **The roster is enrolled, not assumed.** Which reviewers this host can field is
+  answered by a `command -v` sweep at loop start (presence) plus
+  `~/.claude/review-loop.local.md` (enrollment + the invocation recipe
+  `/review-loop:init` learned by actually calling each CLI). With no config
+  the loop fields the same roster it always did and hints at `init` once; `init` is
+  never a precondition.
+```
+
+- [ ] **Step 2: Replace the roster section**
+
+Find (verbatim):
+
+```
+## Reviewer roster & priority
+
+1. **Local Claude subagent** — always. Dispatch a subagent (Task tool) to do the review.
+2. **Local Codex** (headless `codex exec review`) — when `codex` is on `PATH`. tmux is not required; it adds a live-watch pane **only when you ask to watch** (and you're in tmux). See A2.
+3. **GitHub Copilot** — only for GitHub PR targets, after the PR is open.
+```
+
+Replace with:
+
+````
+## Reviewer roster
+
+Panelists are ranked by **heterogeneity** — decorrelated error modes are the only
+reason a second reviewer catches anything the first missed:
+
+1. **Tier 1 — a different model family**, actually called: `codex`, or another
+   enrolled coding CLI, or a user-declared OpenAI-compatible endpoint (which is
+   always `trust: user-asserted` and never counts as heterogeneous evidence).
+2. **Tier 2 — a different Claude model**, via the `Task` tool's `model` parameter.
+   Same family, so convergence here is weak evidence.
+3. **Fresh-context only** — a Claude subagent on the session's own model. This is
+   what a zero-config host gets, and the gate says so.
+
+`tier` is **derived from `kind`, not declared**: writing `tier: 1` on an endpoint is
+a lie the loop ignores.
+
+**Forge reviewers are a separate slot** (Phase B) — they live on the code-hosting
+platform, appear only once a PR/MR exists, and are never panelists. GitHub Copilot
+is the one built-in adapter.
+
+### Roster reconciliation at loop start
+
+Probe presence inline — no script; a `command -v` loop is not knowledge worth
+materializing. Then compare against the config and **surface every disagreement —
+never silently follow a stale config**:
+
+```bash
+for cli in codex gemini cursor-agent opencode aider crush amp llm gh; do
+  command -v "$cli" >/dev/null 2>&1 && echo "$cli present" || echo "$cli absent"
+done
+```
+
+(`<cli> --version` is `/review-loop:init`'s business, not a review's: it spawns a real
+subprocess per CLI and only drift detection needs it.)
+
+- **Enrolled but absent** → degrade, note it, and lower the gate's evidential tier.
+- **Present but unenrolled** (e.g. `codex` installed after `init` ran) → note once:
+  "`codex` is on `PATH` but not enrolled — run `/review-loop:init` to add it."
+  Do **not** auto-enroll; enrollment is the author's decision.
+- **Recipe drift** — the CLI's version differs from `invocation.verified_with`, or
+  the preflight contradicts `invocation.form`. The stored recipe is a **learned
+  default, not gospel**: preflight and the post-round detector still run and still
+  win. Follow this run's evidence, then suggest re-running `init`. A recipe must
+  never suppress a detector.
+- **`claude-alt.model` equals the session model** → the panel is **fresh-context
+  only**, whatever the config asked for.
+````
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+S=plugins/review-loop/skills/review-loop/SKILL.md
+for phrase in 'Roster reconciliation' 'derived from `kind`' 'Fresh-context only'; do
+  printf '%-24s %s\n' "$phrase" "$(grep -c "$phrase" "$S")"
+done
+grep -c '^## Reviewer roster & priority' "$S"
+awk '/^```/{n++} END{print "fences:", n, (n%2==0 ? "balanced" : "UNBALANCED")}' "$S"
+```
+Expected: each phrase counts `1` or more — check them **individually**, never as one `grep 'A\|B\|C'`, because an OR match hides a miss in any single branch. Note `Fresh-context only` is capitalised. Then `0` (old heading gone) and `balanced`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/review-loop/skills/review-loop/SKILL.md
+git commit -m "feat(review-loop): roster is enrolled and reconciled, not assumed
+
+Ranks panelists by heterogeneity, derives tier from kind so a config file cannot
+buy the heterogeneous verdict, and reconciles the probe against the config at loop
+start. All three drift cases are surfaced; none is silently followed. A stored
+invocation recipe never suppresses the preflight or the command_execution detector
+-- a recipe that silently false-cleans is exactly what spec 009 exists to prevent.
+
+Implements spec 014 §A.1, §A.6, and the roster half of §B.9."
+```
+
+---
+
+## Task 3: `/review-loop:init` — the command, and README
+
+**Files:**
+- Create: `plugins/review-loop/commands/init.md`
+- Modify: `plugins/review-loop/skills/review-loop/README.md`
+
+- [ ] **Step 1: Create the command doc**
+
+Create `plugins/review-loop/commands/init.md`:
+
+```markdown
+---
+description: Discover which coding CLIs this host has, verify how to call each one by actually calling it, and record the enrolled reviewer roster — idempotent; re-run whenever the host changes
+---
+
+# /review-loop:init
+
+Invoke the `review-loop` skill and run the **init** routine. Pass `$ARGUMENTS`
+through as free-form context.
+
+**Usage:** `/review-loop:init`
+
+Load-bearing invariants the skill enforces:
+
+- **Probes presence, verifies invocation, asks for the rest.** The probe is a
+  `command -v` sweep plus `<cli> --version` — no script, no network, no credentials,
+  no other plugin's config. Everything it cannot probe is asked, not guessed.
+- **Verifies by trying.** Knowing `codex` exists tells you nothing about how to
+  drive it. `init` calls each enrolled CLI once, on a **throwaway fixture diff —
+  never your real working tree** — and stores the literal command line that worked
+  in `invocation.command`. Bounded to two attempts per CLI. A CLI whose invocation
+  cannot be established is **detected but not enrolled**, with the reason shown.
+- **Never asks for `sudo`, and never fixes your host.** If Codex's native sandbox is
+  blocked, `init` records `form: embedded` — a fully supported path — and may point
+  once at `references/codex-sandbox-host-fixes.md`. Restoring the native path is an
+  AppArmor/sysctl change affecting every `bwrap` caller on the machine: **separate
+  work, in its own session, which you own.** review-loop never gates on it, never
+  blocks for it, and never re-raises it.
+- **Presence is not authentication.** `gh` on `PATH` only *offers* a GitHub Copilot
+  enrollment; `gh auth status` decides it. An unauthenticated `gh` is detected and
+  not enrolled, rather than enrolled-and-broken.
+- **Endpoints are declared, never discovered.** `init` does not go looking through
+  other plugins' registries. Name one and it records the name — url and
+  `api_key_env` stay in `chat-subagent`'s files. **No secrets are ever written.**
+- **Idempotent.** Re-running re-probes, prints a diff of what changed, and preserves
+  explicit opt-outs (`enabled: false` is a decision, not an absence), declared
+  endpoints, and forge reviewers.
+- **Never a precondition.** With no config the loop works exactly as it does today
+  and hints at `init` once.
+
+Writes `~/.claude/review-loop.local.md` (global), overridden per project by
+`<project-root>/.claude/review-loop.local.md`. Offers to add `.claude/*.local.md`
+to `.gitignore` if absent.
+```
+
+- [ ] **Step 2: Update the README's roster**
+
+The README's roster is its own list — **not** the one in `SKILL.md`; the two are worded
+differently. Find (verbatim, `README.md` lines ~15–20):
+
+```
+## Reviewer roster (in priority order)
+
+1. **Claude subagent** — always; needs nothing extra.
+2. **Codex** (headless `codex exec review`) — when `codex` is on `PATH`; tmux
+   opens a live-watch pane only when you ask (never by default).
+3. **GitHub Copilot** — only for GitHub PR targets, after the local gate is clean.
+```
+
+Replace with:
+
+```
+## Reviewer roster (by heterogeneity)
+
+Decorrelated error modes are the only reason a second reviewer catches what the first
+missed, so panelists are ranked by how different they are — not by how good they are.
+
+1. **Tier 1 — a different model family**, actually called: `codex`, another enrolled
+   coding CLI, or a user-declared endpoint (always `trust: user-asserted`, and never
+   counted as heterogeneous evidence).
+2. **Tier 2 — a different Claude model**, pinned by `/review-loop:init`. Same family,
+   so agreement here is *weak* evidence and the gate says so.
+3. **Fresh-context only** — a Claude subagent on the session's own model. What a
+   zero-config host gets. The weakest verdict there is.
+
+Panelists answer **blind and in parallel** on the same unfixed diff, then attack each
+other's findings. A **forge reviewer** (Phase B) is not a panelist: it appears only once
+a PR/MR exists. GitHub Copilot is the one built-in adapter.
+```
+
+Then append to the README's end:
+
+```markdown
+## `/review-loop:init` (optional)
+
+Discovers which coding CLIs this host has, works out **how to call each one by
+actually calling it**, and records the result in `~/.claude/review-loop.local.md`
+(project override: `<project-root>/.claude/review-loop.local.md`). Re-run it
+whenever the host changes; it is idempotent and preserves your opt-outs.
+
+It never writes a secret: endpoints are stored by name, and their url and
+`api_key_env` stay in the `chat-subagent` registry.
+
+**Copilot is one adapter, not the only possible remote reviewer.** Phase B is a
+forge-reviewer slot with three operations — request, poll, recognize a clean pass.
+GitHub Copilot ships as the built-in binding of those operations. Other forges have
+review agents; this skill names none and implements none, because an adapter nobody
+here can run would poll forever or report a clean pass that never happened. Declare
+one, supply its three commands and an unambiguous `clean_when`, and the loop drives
+it. With no forge reviewer enrolled, Phase B is skipped and the local panel is the
+whole loop.
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+test -f plugins/review-loop/commands/init.md && echo "command exists"
+grep -n 'review-loop:init' plugins/review-loop/skills/review-loop/README.md
+head -3 plugins/review-loop/commands/init.md
+```
+Expected: the file exists; README mentions `init`; the command doc opens with `---` frontmatter carrying exactly one `description:` key.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/review-loop/commands/init.md plugins/review-loop/skills/review-loop/README.md
+git commit -m "feat(review-loop): add /review-loop:init and document the forge slot
+
+init probes CLI presence, then VERIFIES INVOCATION BY TRYING -- one real call per
+enrolled CLI against a throwaway fixture diff, never the user's working tree, since
+calibrating an unenrolled third-party CLI on real changes would ship their code to
+a service they have not agreed to enroll. It stores the literal command line that
+worked. A CLI whose invocation cannot be established is detected but not enrolled.
+
+gh presence only offers Copilot; gh auth status decides it. Presence is not
+authentication (SKILL.md requires 'the authenticated gh CLI').
+
+Implements spec 014 §A.3, §A.4, §A.8."
+```
+
+---
+
+## Task 4: `SKILL.md` — Phase A restructured into a blind panel
+
+The heart of the change. §B.2, §B.2.1–§B.2.4.
+
+**Files:**
+- Modify: `plugins/review-loop/skills/review-loop/SKILL.md` (Phase A, ~57–63)
+
+- [ ] **Step 1: Replace A1/A2's serial preamble with the blind panel**
+
+Find (verbatim):
+
+```
+**A1. Claude subagent review** — dispatch a subagent to review the diff. Classify findings into T1/T2/T3, post the grouped list, resolve T2/T3 picks, then apply fixes (per *Tiers*). Commit fixes; push only if a remote/PR branch exists, otherwise commit locally.
+```
+
+Replace with:
+
+````
+**A1. Round 1 — blind, parallel, on the same unfixed diff.** Every live panelist
+reviews *before any fix is applied*, and **no panelist sees another's findings**. A
+reviewer shown another's output anchors on it, and the panel's whole value is that
+their error modes differ.
+
+Post the R1 findings to the author as soon as they land, marked
+`proposed — not yet critiqued, none actionable`. The independence invariant binds
+*panelists*, not the human; making the author wait through two silent rounds to
+learn the loop is alive buys nothing.
+
+**How each panelist is invoked:**
+
+- **Codex, native path — the *freeform* form, not the targeted one.** A target flag
+  takes no prompt (`review --uncommitted -` errors rc=2), and without a prompt Codex
+  cannot be asked for the finding record, so its findings could never pass the
+  auto-fix gate. The freeform native form does take a prompt:
+  ```bash
+  printf '%s\n' "$brief" | codex exec --json --sandbox read-only review -
+  ```
+  **An inferred diff may not be the same diff, and R1 is the blind round.** So the
+  brief names the exact range `<base>..<head-sha>`, requires the review to state the
+  commit range and file list it actually reviewed as its first line, and the
+  facilitator compares that against `git diff --name-only "$base"..."$head"`. A
+  mismatch → re-run once with the diff embedded (which cannot be inferred wrong); a
+  second mismatch → §B.7 panelist failure: drop, continue, disclose.
+- **Codex, embedded path** — unchanged, and it carries a prompt too. Both paths
+  request the same record format.
+- **Claude subagent** — a `Task` dispatch under the enrolled `claude-alt.model`. The
+  brief **stands alone** (the subagent sees none of this conversation): the diff, the
+  tier definitions, the finding-record format, the falsification-condition
+  instruction, "state your model id on the first line", and "your final message is
+  the review record; no preamble".
+- **Other enrolled CLIs / endpoints** — the stored `invocation.command`, with the
+  diff and the record format in the prompt.
+
+**A2. Round 2 — cross-critique, parallel.** Runs whenever **≥ 2 panelists are live**
+(true on a zero-config host that has `codex`). Each panelist receives the *others'*
+findings **verbatim** and is asked to attack them, then to restate its own, dropping
+any it now believes wrong.
+
+Do **not** mandate a disagreement. "You disagree with at least one central claim;
+find it" manufactures a refutation when the other panelist is right, and an invented
+refutation is worse than a missed one. Ask instead: *"name the central claim you
+tried hardest to break, and either break it or say why it held."* A round that
+refutes nothing is a legitimate outcome; a round that **attacks** nothing is the
+failed one. Refute by reproduction — "this fails on input X", not "I doubt this".
+
+- **Codex R2:** `codex exec --json --sandbox read-only resume "$thread_id" -` — the
+  trailing `-` reads the prompt from stdin and is valid on `resume`. On the embedded
+  path, a fresh embedded call carrying the complete current diff plus the other
+  findings (the sticky-embedded rule).
+- **Claude R2 is a *fresh* dispatch** — `Task` subagents are one-shot, so there is no
+  instance to resume. Its brief carries the same diff, its own R1 findings quoted
+  back to it, and the others' findings. A fresh instance defending text it did not
+  produce is a weaker epistemic act than a panelist answering for its own argument.
+  It is what the tool allows; say so rather than pretending otherwise.
+- **Round 3** (each panelist answering critiques of its *own* findings) runs only
+  with **≥ 3 live panelists**. With two, R2 is the merged "critique, then restate".
+
+**R2 critique rounds are EXEMPT from the post-round `command_execution` detector.**
+Not because a critique round reads no files — a good one reads many, since
+reproduction means opening the file at the cited line. The detector's inference is
+"zero commands ⇒ never read the tree ⇒ the sandbox false-cleaned a **review**", and
+that is sound only when the round's job *is* to review the tree. An R2's subject is
+the findings. Convicting it of a false clean is a category error, and the
+sticky-embedded rule would then demote a `usable` host for the rest of the loop.
+Every other native round keeps the detector, and its guarantee, unchanged.
+
+**A panelist that dies between R1 and R2** (usage limit, or a §B.7 double failure)
+leaves its R1 findings at `proposed`: surfaced, never auto-fixed *while proposed*,
+but not exiled — if the facilitator later reproduces one, it becomes `reproduced`
+and is auto-fixable like any other. A successful attack on a dead panelist's finding
+yields **`refuted-undefended`**, never `refuted`. Report the panel **per round**
+("R1 heterogeneous; R2 and convergence same-family — Codex hit its usage limit").
+
+**A3. Adjudicate → tier → resolve → fix.** Classify the surviving findings into
+T1/T2/T3, resolve T2/T3 with the author, then apply fixes per *Tiers*, gated by the
+auto-fix rule below. Commit fixes; push only if a remote/PR branch exists.
+
+**A4. Convergence.** Resume the **same `thread_id`** used by R1 and R2 (R2 used
+`resume`, so it did not fork). Verify against the **post-R2 restated list**, not the
+raw R1 list — a finding its own author dropped is not resurrected. `claude-alt`
+cannot resume: its convergence round is a fresh dispatch restating its surviving
+findings. **Every live panelist blocks**; a panelist dropped under §B.7 stops
+blocking the moment it is disclosed as dropped, and one that went clean then died
+does not un-clean the gate.
+
+**Output volume.** An auto-fixed finding prints as **one line** (claim, location,
+commit). A `refuted` finding prints as one line plus who refuted it and why. A
+**`refuted-undefended` finding prints as a live disagreement, never a one-liner** —
+a "refuted by X" one-liner hides that nobody checked. The full record is reserved
+for findings the author must judge: T2/T3, live disagreements, and anything that
+failed the auto-fix gate.
+````
+
+- [ ] **Step 2: Relabel the old serial steps the new Phase A replaced**
+
+Step 1 inserts a new `A1`–`A4`. The **old** `**A2. Codex review**` and
+`**A3. Converge the local gate**` bullets are still below it, so the file would carry
+two `A2` labels and two `A3` labels — and the old ones still tell the agent to have
+Claude review and fix, then let Codex read the already-fixed tree. Their bodies must
+NOT be deleted: they hold the sandbox routing, the embedded-diff form, the
+`command_execution` detector, `thread_id` resume, exit-code triage and usage-limit
+handling, all of which spec 014 keeps unchanged. Relabel them into shared mechanics.
+
+Replace the `**A2. Codex review** (only if …` line with a `#### Codex mechanics — how
+the Codex panelist is driven (used by R1, R2 and A4)` heading, opening "This section is
+**not a step**." Replace the `**A3. Converge the local gate**` line with
+`#### Availability, not cleanliness — when a panelist stops blocking`, keeping its
+availability rules and dropping "re-run A1/A2 after fixes".
+
+Then **repoint the cross-references the relabel orphans.** Two sentences say `see A2`
+and `the embedded-diff form (A2)`; both meant the old Codex step and now point at the
+cross-critique round. Send them to *Codex mechanics*. Find them with:
+```bash
+grep -n 'see A2\|(A2)\|A1/A2\|§A2' plugins/review-loop/skills/review-loop/SKILL.md
+```
+Expected after the fix: no matches. `SKILL.md` is read by an agent, and an agent goes
+where it is sent.
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+grep -c '^\*\*A2\.' plugins/review-loop/skills/review-loop/SKILL.md   # exactly 1
+grep -c '^\*\*A3\.' plugins/review-loop/skills/review-loop/SKILL.md   # exactly 1
+grep -n 'blind\|cross-critique\|refuted-undefended\|git diff --name-only' plugins/review-loop/skills/review-loop/SKILL.md
+awk '/^```/{n++} END{print "fences:", n, (n%2==0 ? "balanced" : "UNBALANCED")}' plugins/review-loop/skills/review-loop/SKILL.md
+```
+Expected: matches for all four; fences **balanced**.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/review-loop/skills/review-loop/SKILL.md
+git commit -m "feat(review-loop): blind parallel round 1 + one cross-critique round
+
+Reviewers were serial gates: Claude reviewed, fixes were committed, then Codex
+reviewed the already-fixed tree -- so Codex could never dispute Claude's reading of
+a finding, and neither ever critiqued the other's findings. Now both review the
+same unfixed diff blind, then attack each other's lists.
+
+R1 uses Codex's freeform native form because the targeted form takes no prompt, and
+without a prompt Codex cannot be asked for the finding record, which would make the
+panel's only tier-1 reviewer the one that can never be auto-fixed. Freeform infers
+its diff, so the brief pins the range and the facilitator checks the echoed file
+list against git diff --name-only: an inference is not a guarantee, and R1's whole
+value is that every panelist saw the same diff.
+
+R2 is exempt from the command_execution detector -- not because a critique round
+reads no files (a good one reads many; reproduction means opening the cited line)
+but because the detector's inference only holds for a round whose job is reviewing
+the tree. An R2's subject is the findings.
+
+The R2 prompt does not mandate a disagreement. Manufacturing a refutation when the
+other panelist is right is worse than missing one.
+
+Implements spec 014 §B.1, §B.2, §B.2.1-§B.2.4."
+```
+
+---
+
+## Task 5: `SKILL.md` — finding record, status ladder, auto-fix gate, reproduction
+
+**Files:**
+- Modify: `plugins/review-loop/skills/review-loop/SKILL.md` (the *Tiers* section, ~47–53)
+
+- [ ] **Step 1: Extend Tiers with the record, the ladder, and the gate**
+
+Find (verbatim):
+
+```
+Per round: post the grouped findings, **resolve T2/T3 with the author first** (quote the comment, draft 2–3 approaches with trade-offs, recommend one, wait for their pick), **then** apply the fixes — T1 auto-fixed, T2/T3 done as chosen. One commit per item, TDD, and reply/note the commit hash. (TDD and one-commit-per-item apply to executable changes; for prose/doc targets there are no tests to write first — prefer one logical edit per finding and review for clarity, consistency, structure, and factual accuracy.) Architectural decisions always land before mechanical edits are committed.
+```
+
+Replace with:
+
+````
+Per round: post the grouped findings, **resolve T2/T3 with the author first** (quote the comment, draft 2–3 approaches with trade-offs, recommend one, wait for their pick), **then** apply the fixes — T1 auto-fixed **only through the gate below**, T2/T3 done as chosen. One commit per item, TDD, and reply/note the commit hash. (TDD and one-commit-per-item apply to executable changes; for prose/doc targets there are no tests to write first — prefer one logical edit per finding and review for clarity, consistency, structure, and factual accuracy.) Architectural decisions always land before mechanical edits are committed.
+
+### The finding record
+
+**Scope: this and the auto-fix gate govern the local panel only.** A forge reviewer
+is not a panelist — it never enters R1 or R2, so its comments can never reach
+`survived`, and Copilot cannot be asked for a confidence. Phase B keeps the rule
+above unchanged: T1 auto-fixed, T2/T3 to the author.
+
+Every finding **from a local panelist** carries: `reviewer` (Codex's text quoted
+**verbatim**, never paraphrased into Claude's voice), `claim`, `location`, `tier`,
+`confidence`, `falsification`, `status`.
+
+- **`tier`** is the cost and scope of the fix. **`confidence`** is whether the
+  finding is *true*. They are different axes — a T1 typo can simply be wrong.
+- **`falsification`** is a concrete, checkable condition under which this is *not* a
+  bug ("not a bug if `cfg` is non-null at every call site"). A generic one — "if
+  evidence emerges to the contrary" — is calibration theater and counts as **absent**.
+- **`confidence` authorizes nothing on its own.** The reviewer that raised the
+  finding assigns it, because nobody else can — a self-assessment by the same weights
+  that produced the finding. Its job is to inform the author and to be *attacked* in
+  R2. **The facilitator never imputes these fields**: filling them in for Codex would
+  be Claude judging whether Codex's finding is true and dressing the judgement as
+  Codex's.
+
+**Status ladder:**
+
+| Status | Means | Auto-fix? |
+|--------|-------|-----------|
+| `proposed` | raised, not yet critiqued | never |
+| `survived` | attacked in R2, and the attack failed | eligible |
+| `refuted` | attacked, and its author conceded or lost | never |
+| `refuted-undefended` | attacked, but its author never answered | never — **live disagreement** |
+| `reproduced` | a failing test (code), or a facilitator-verified citation (prose) | eligible |
+| `unreproduced` | a correctness finding nobody attempted to reproduce | never; withholds "gate clean" |
+
+### The auto-fix gate
+
+```
+tier == T1  ∧  ( status == reproduced
+               ∨ (status == survived ∧ confidence == high ∧ falsification present) )
+```
+
+`survived`, **not** `!= refuted`: an uncritiqued finding sits at `proposed`, which is
+trivially "not refuted", so gating on that would let a lone same-family reviewer grade
+its own finding `high` and auto-commit it. **A single-panelist run therefore auto-fixes
+on `reproduced` alone** — a lone reviewer has not earned the right to commit
+unsupervised.
+
+### Refute by reproduction
+
+- **Executable target:** a correctness finding is `reproduced` once a failing test
+  demonstrates it. (`codex exec review` is read-only and cannot run one — reproduction
+  is the facilitator's job, before the fix.) An `unreproduced` correctness finding does
+  not block automatic convergence but **withholds the "gate clean" verdict** until the
+  author waives it. Otherwise the facilitator — the party motivated to converge — could
+  walk past a real finding simply by never attempting a repro.
+- **Prose target:** there is nothing to run, so `reproduced` requires two mechanical
+  conditions, both **obligations**, not capabilities:
+  1. **The facilitator confirms the quote** occurs at the cited location — a `grep`,
+     not a reading. A fabricated or mis-located quotation is a known model failure, and
+     "a reader *can* check it" is capability, not a check.
+  2. **The defect's fix is itself mechanically checkable** — a typo, a stale line
+     reference, a regex that does not match the file it claims to guard.
+
+  "Line 152 already contains `confidence`, so this anchor passes against the unmodified
+  file" satisfies both. "This section is unclear" satisfies neither and goes to the
+  author. **A citation plus the reviewer's interpretation is model judgement wearing
+  evidence's clothes.**
+````
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n 'refuted-undefended\|facilitator confirms the quote\|survived' plugins/review-loop/skills/review-loop/SKILL.md`
+Expected: matches for each. Then re-check fence balance as in Task 4 Step 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/review-loop/skills/review-loop/SKILL.md
+git commit -m "feat(review-loop): finding record, status ladder, and an auto-fix gate
+
+confidence is a self-report by the same weights that produced the finding, so it
+authorizes nothing alone; what authorizes an automatic fix is surviving an adversary
+or being reproduced. Gating on '!= refuted' would have admitted `proposed` -- an
+uncritiqued finding -- which on a Claude-only run reduces to a same-family reviewer
+grading its own finding high and auto-committing it. That is the pre-014 failure mode
+with extra paperwork. The gate now turns on `survived`.
+
+refuted is split: an attack its author never answered is `refuted-undefended`, a live
+disagreement, never a verdict the facilitator may act on.
+
+Prose `reproduced` requires the FACILITATOR to verify the citation with a command and
+the fix to be mechanically checkable. 'A reader can check it' is capability, not a
+check, and a lone reviewer quoting a passage then attaching its own interpretation
+would otherwise auto-commit in the one configuration with no adversary.
+
+Implements spec 014 §B.3, §B.4, §B.5."
+```
+
+---
+
+## Task 6: `SKILL.md` — non-leading convergence, ghost gate, facilitator discipline
+
+**Files:**
+- Modify: `plugins/review-loop/skills/review-loop/SKILL.md` (Convergence rounds ~156–166; add a Facilitator subsection)
+
+- [ ] **Step 1: Replace the leading convergence prompt**
+
+Find (verbatim):
+
+```
+  printf '%s\n' "I applied these fixes: <summary>. Are your earlier points resolved? Any new concerns?" \
+```
+
+Replace with:
+
+```
+  printf '%s\n' "Here is the current diff. For each point you raised, verify it AGAINST THE CODE and state resolved or unresolved, with the evidence you used. Do not treat the author's description of the fix as evidence. Then state any new concerns." \
+```
+
+- [ ] **Step 2: Add the sycophancy guard and the facilitator rules**
+
+Find (verbatim):
+
+```
+## Learning capture
+```
+
+Replace with:
+
+```
+## Facilitator discipline
+
+The facilitator (this session) frames, dispatches, validates, adjudicates, and fixes.
+It may not put its own arguments in a panelist's mouth.
+
+- Findings are **attributed** in the round output — `[codex]`, `[claude-fable]` — and a
+  panelist's wording is preserved **verbatim**.
+- The facilitator's own observations go under a separate, labelled **Facilitator**
+  heading. They never count as panel findings and never gate anything.
+- **Merged duplicates retain both verbatim texts and both attributions.** "These two are
+  the same issue, I'll keep one phrasing" is the laundering the verbatim rule exists to
+  stop. Two panelists slicing one problem into different buckets are **not** agreeing;
+  recording them as one finding manufactures consensus.
+- Any **downgrade, merge, or dismissal of a tier-1 panelist's finding is surfaced** with
+  its reason. The facilitator may propose it; the author sees it.
+- **An unexplained full reversal is a sycophancy flag.** A panelist that abandons a
+  finding without a reason, or concedes every attack, is asked for the grounds before the
+  reversal is accepted. This ask is one extra panelist call and is the single sanctioned
+  exception to "cross-critique is one round" (the other being Round 3 with ≥3 panelists).
+
+Tiering (T1/T2/T3) remains facilitator judgement: scope-of-fix is not something a
+reviewer can assess for a repo it does not own.
+
+## Ghost panelist gate
+
+A status line, an empty result, or an error dump is **not a contribution**. If one enters
+the record, R2 critiques thin air and the panel degrades silently.
+
+- **Codex, native path:** the existing structural `command_execution` detector, unchanged.
+  Embedded-diff rounds stay exempt; **R2 critique rounds are now exempt too** (A2).
+- **Every other panelist:** the return must be a substantive review — findings, or an
+  explicit "no remaining problems". Re-run once; on a second failure **drop the panelist,
+  continue, and disclose which panel actually ran**.
+- **External CLIs run in the foreground** with a generous timeout (≈10 min). A wrapper
+  that backgrounds the call and returns early manufactures ghosts.
+
+## Learning capture
+```
+
+- [ ] **Step 3: Extend Learning capture with the R2 cost data**
+
+Find (verbatim):
+
+```
+- Repeat-issue escalations (these = gaps in the project's conventions; candidates for the project's guidelines doc)
+```
+
+Replace with:
+
+```
+- Repeat-issue escalations (these = gaps in the project's conventions; candidates for the project's guidelines doc)
+- **R2's kill rate and rounds consumed.** Cross-critique costs one extra call per panelist before the first fix, and usage limits are a first-class outcome — so the marginal cost is not "one more call" but "one fewer convergence round before the limit". That R2 pays for itself (false positives dying before they become a commit, a test, and a convergence round) is a **hypothesis**. Record the data so it can be checked.
+```
+
+- [ ] **Step 4: Verify**
+
+Run:
+```bash
+grep -c 'Are your earlier points resolved' plugins/review-loop/skills/review-loop/SKILL.md
+grep -n 'retains both verbatim texts\|Do not treat the author' plugins/review-loop/skills/review-loop/SKILL.md
+```
+Expected: first prints `0`; second prints both matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/review-loop/skills/review-loop/SKILL.md
+git commit -m "feat(review-loop): non-leading convergence, ghost gate, facilitator discipline
+
+The convergence prompt asked Codex to accept Claude's own summary of Claude's own
+fixes as evidence, phrased so that 'yes' was the cooperative answer. It now hands over
+the diff and asks for verification against the code, explicitly refusing the author's
+description as evidence.
+
+Facilitator capture was unguarded: Claude is both panelist and adjudicator, and nothing
+stopped it quietly downgrading a Codex finding it disliked. Attribution moves into the
+round output, the facilitator's own views get a labelled section that gates nothing, and
+merged duplicates keep both verbatim texts -- deduplication was the largest capture
+surface and attribution alone does not close it. Two panelists slicing one problem
+differently are not agreeing.
+
+Implements spec 014 §B.6, §B.7, §B.8."
+```
+
+---
+
+## Task 7: `SKILL.md` — report the panel that actually ran; degradation
+
+**Files:**
+- Modify: `plugins/review-loop/skills/review-loop/SKILL.md` (Exit conditions ~199–201)
+
+- [ ] **Step 1: Replace the local-gate exit bullet**
+
+Find (verbatim):
+
+```
+- **Local gate clean + (for GitHub) Copilot clean pass** (matches "generated no comments." / "generated no new comments.") → stop and surface to the author. This is the primary, explicit stop signal — prefer it over inferring doneness from "no new comments for N polls".
+```
+
+Replace with:
+
+```
+- **Local gate clean + (for a forge target) the enrolled forge reviewer's clean pass** → stop and surface to the author. This is the primary, explicit stop signal — prefer it over inferring doneness from "no new comments for N polls".
+- **"Clean" is not one verdict.** State the panel's composition and the evidential weight of its agreement:
+  - **Heterogeneous** — at least one live tier-1 **CLI** panelist alongside Claude → convergence is meaningful evidence.
+  - **User-asserted** — the only non-Claude panelist is a declared endpoint (`trust: user-asserted`). Report it as such; a config file must not buy the heterogeneous tier.
+  - **Same-family** — Claude plus a different Claude model → "gate clean at tier 2 — same-family panel, shared blind spots possible; this is **weak evidence**."
+  - **Fresh-context only** — the subagent's echoed model id equals the session model, is absent, or the requested model was not dispatchable. The weakest verdict there is. Say it.
+  - Report the panel that **actually ran, verified**: the model that actually *differed* (the subagent echoes its model id on the first line of its record — a self-report, weak, and still better than asserting a tier from a config field), the CLI that actually returned findings. Where the composition changed mid-run, report it **per round**, not by its best round.
+  - Any `unreproduced` correctness finding withholds "gate clean": report "clean except N unreproduced correctness findings" and let the author waive them.
+- **Degradation.** Only Claude available → single reviewer, no cross-critique, and the same-family caveat above. Two or more Claude panelists and no external CLI → force **method-level divergence**, not tone (first principles / base rates / disconfirming evidence only); a role name like "Red Team" does not decorrelate errors, a different method or an actual reproduction does — and the verdict stays same-family either way.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n 'weak evidence\|Fresh-context only\|per round' plugins/review-loop/skills/review-loop/SKILL.md`
+Expected: matches for each.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/review-loop/skills/review-loop/SKILL.md
+git commit -m "feat(review-loop): the gate verdict names the panel that actually ran
+
+'Local gate clean' was reported identically whether Codex participated or not, though
+the two verdicts carry very different evidential weight. Same-family convergence is now
+labelled weak evidence, a user-asserted endpoint cannot buy the heterogeneous tier, and
+a claude-alt that turns out to equal the session model degrades to fresh-context only.
+
+'Verified' means the model actually DIFFERED and the CLI actually returned findings --
+not that a config field was set. The subagent echoes its model id; that is a model's
+self-report and a weak check, and it is still strictly better than asserting a tier from
+a config file. Where a check is weak, report the verdict it supports and no stronger.
+
+Implements spec 014 §B.9, §B.10."
+```
+
+---
+
+## Task 8: `SKILL.md` — Phase B becomes a forge slot
+
+**Files:**
+- Modify: `plugins/review-loop/skills/review-loop/SKILL.md` (Phase B heading ~177; Non-goals ~232–237)
+
+- [ ] **Step 1: Retitle Phase B and frame Copilot as an adapter**
+
+Find (verbatim):
+
+```
+### Phase B — GitHub Copilot (only for GitHub PR targets)
+```
+
+Replace with:
+
+```
+### Phase B — Forge reviewer (only when one is enrolled and the target is a PR/MR)
+
+A **forge reviewer** lives on the code-hosting platform and is reachable only once the
+change is a pull/merge request. It has three operations: **request**, **poll for
+comments**, and **recognize a clean pass**. It is **not a panelist** — it never enters
+R1 or R2, so the finding record and the auto-fix gate do not govern it; the *Tiers*
+rules apply unchanged (T1 auto-fixed, T2/T3 to the author).
+
+**No forge reviewer enrolled → skip Phase B silently.** The local panel is the whole
+loop.
+
+**GitHub Copilot is the one built-in adapter** (`adapter: builtin`), because
+`scripts/copilot.sh` and `scripts/pr-comments.sh` implement those three operations and
+have been exercised across many PRs. Steps B0–B5 below *are* that adapter.
+
+**Other forges have review agents. This skill names none and implements none.** An
+adapter written from documentation for a service nobody here can run is a ghost
+panelist one layer up: it would poll forever, or report a clean pass that never
+happened. A user with access declares the reviewer and supplies its commands —
+`request`, `poll`, and a `clean_when` regex.
+
+`clean_when` is load-bearing, and an unpinned regex *is* the false clean it exists to
+prevent. A declared reviewer inherits the builtin's contract: `poll` must emit reviews
+newest-first, one JSON object per line, each with a `body`; `clean_when` is a POSIX ERE
+applied with `grep -Eq` to the **newest item's `body` only**, never to the whole poll
+dump — matching the dump false-cleans forever the first time the bot ever said "no
+comments". A `poll` that cannot satisfy the interface is declared wrong: say so at
+enrollment and fall back to surface-and-ask. **If a declared reviewer has no unambiguous
+clean signal, the loop polls, surfaces its comments, and hands the stop decision to the
+author rather than inventing one.**
+```
+
+- [ ] **Step 2: Correct the Non-goals that the rest of the spec repudiates**
+
+Find (verbatim):
+
+```
+- The Copilot path is GitHub-only (uses `gh` + GitHub GraphQL). For other forges, the local Claude + Codex gate still applies; the remote-reviewer phase does not.
+```
+
+Replace with:
+
+```
+- The **built-in** forge adapter is GitHub-only (it uses `gh` + GitHub GraphQL). Other forges are reachable by declaring a reviewer and its three commands; none ships. With no forge reviewer, the local panel gate is the whole loop.
+- **Not changing:** the sandbox routing, the embedded-diff form, the `command_execution` detector's **jq predicate**, exit-code triage, the Copilot adapter's behavior, or the never-merge rule. Two things *do* change and are named so nobody can satisfy this list by ignoring them: the detector's **scope** gains an R2-critique exemption (A2), and Phase B's *framing* becomes a forge slot while its Copilot behavior is preserved verbatim.
+- **Not a debate machine.** With the default two-panelist panel, cross-critique is **one round**. Two bounded additions: a separate Round 3 with **≥ 3** panelists, and the reversal-grounds ask. Panelist disagreement about executable code is settled by a test, not by more rounds.
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+grep -c '^### Phase B — GitHub Copilot' plugins/review-loop/skills/review-loop/SKILL.md
+grep -n 'forge reviewer\|clean_when' plugins/review-loop/skills/review-loop/SKILL.md | head -5
+```
+Expected: first prints `0` (heading gone — note it was an **h3**, so a `^## ` regex would never have matched it); second prints matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/review-loop/skills/review-loop/SKILL.md
+git commit -m "feat(review-loop): Phase B is a forge slot, not a Copilot phase
+
+Phase B was an adapter masquerading as an architecture: gh, a GraphQL mutation and a
+Copilot stop-regex written straight into the skill. It becomes three operations --
+request, poll, recognize a clean pass -- with GitHub Copilot as the one built-in
+adapter, because its scripts exist and have been exercised. Not 'tested': nothing in
+tools/ touches copilot.sh or pr-comments.sh, and that word was load-bearing in the
+argument for why this adapter ships and others do not.
+
+Other forges have review agents. This skill names none and implements none. An adapter
+written from documentation for a service nobody here can run is a ghost panelist one
+layer up -- it would poll forever, or report a clean pass that never happened. A
+declared reviewer with no unambiguous clean signal gets none invented for it.
+
+Also corrects two Non-goals bullets that the rest of the spec repudiates.
+
+Implements spec 014 §B.11."
+```
+
+---
+
+## Task 9: Command doc invariants, content anchors, version bump
+
+**Files:**
+- Modify: `plugins/review-loop/commands/review-loop.md`
+- Modify: `tools/review-loop/test-skill-content.sh`
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Refresh `SKILL.md`'s frontmatter and intro — they still describe 0.4.0**
+
+Three lines still tell the reader the loop is serial. The `description` drives when the
+skill triggers, so a stale one misleads users, and the "Why this loop exists" paragraph
+now flatly contradicts Tasks 4–8.
+
+Find (verbatim, line 3):
+
+```
+description: General assisted review loop for changes — code or design artifacts (specs, plans, docs). Prefers local reviewers (Claude subagent + headless Codex via `codex exec review`) as the first gate; for GitHub PR targets, also requests Copilot after the PR is open. Loops each reviewer until clean or its usage limit, classifies comments into tiers, auto-fixes mechanical ones, pauses on architectural ones for user judgment. Never merges autonomously.
+```
+
+Replace with:
+
+```
+description: General assisted review loop for changes — code or design artifacts (specs, plans, docs). Runs an adversarial panel of local reviewers: every live panelist answers blind on the same unfixed diff, then attacks the others' findings, before any fix is applied. Reviewers are discovered at loop start and may be enrolled by `/review-loop:init`, which is never a precondition; the gate names the panel that actually ran and calls same-family agreement weak evidence. For PR/MR targets an enrolled forge reviewer (GitHub Copilot is the built-in adapter) runs after the local gate is clean. Findings carry a confidence and a falsification condition; a finding no adversary examined is never auto-fixed. Never merges autonomously.
+```
+
+Find (verbatim, line 10):
+
+```
+**Local reviewers are preferred and run first.** A Claude subagent and Codex (headless, via `codex exec review`) cost nothing extra and are fast, so they are the first gate. Codex runs wherever the `codex` CLI is on `PATH` — no tmux needed; tmux only adds a live-watch pane **when the user asks to watch** (never by default). GitHub Copilot is added only when the target is a GitHub PR, and only after the local gate is clean.
+```
+
+Replace with:
+
+```
+**Local reviewers run first, and they run as a panel.** Every live panelist reviews the same **unfixed** diff blind — none sees another's findings — and then cross-critiques. Codex runs wherever the `codex` CLI is on `PATH` — no tmux needed; tmux only adds a live-watch pane **when the user asks to watch** (never by default). A forge reviewer (GitHub Copilot is the built-in adapter) is added only when the target is a PR/MR, and only after the local gate is clean.
+```
+
+Find (verbatim, line 14):
+
+```
+Claude and Codex reviewing **together** produces noticeably better output than either model alone — they catch different classes of issues, and Codex's pass tightens the diff before it ever reaches GitHub. The downstream payoff: by the time Copilot sees the PR, there's much less for it to complain about, so review rounds converge faster. Front-loading combined local Claude+Codex review as the first gate is the entire reason this loop exists.
+```
+
+Replace with:
+
+```
+A reviewer catches what the author missed only when their failure modes differ. A model asked to critique its own output draws that critique from the same weights that produced the blind spot, so a same-family panel agreeing is weaker evidence than it looks. Running Claude and Codex **blind and in parallel**, then having each attack the other's findings, is what decorrelates the errors — and it kills false positives before they become commits, tests, and convergence rounds. Serial review cannot do this: a reviewer shown the already-fixed tree is anchored on the first reviewer's judgement and can no longer dispute it. That is the entire reason this loop exists.
+```
+
+- [ ] **Step 2: Verify the intro no longer describes a serial gate**
+
+```bash
+S=plugins/review-loop/skills/review-loop/SKILL.md
+grep -c 'as the first gate is the entire reason' "$S"   # expect 0
+grep -c 'run as a panel' "$S"                            # expect 1
+grep -c 'adversarial panel of local reviewers' "$S"      # expect 1
+```
+Expected: `0`, `1`, `1`. Do **not** check these with one `grep 'A\|B\|C'` — an OR match hides a miss in any single branch.
+
+- [ ] **Step 3: Update the command doc's invariants**
+
+Find (verbatim):
+
+```
+- **Copilot is GitHub-only** — requested only for PR targets, after the local gate.
+```
+
+Replace with:
+
+```
+- **Blind round 1, then one cross-critique round** — every live panelist reviews the
+  same unfixed diff without seeing the others, then attacks their findings. Never
+  auto-fixes a finding that no adversary examined.
+- **Forge reviewers are enrolled, not assumed** — GitHub Copilot is the one built-in
+  adapter, requested only for PR targets after the local gate. With none enrolled,
+  Phase B is skipped.
+- **`/review-loop:init`** — optional; discovers which coding CLIs this host has and
+  verifies how to call each one by actually calling it.
+```
+
+- [ ] **Step 4: Add the spec-014 anchors**
+
+Find (verbatim):
+
+```
+echo "All SKILL.md content checks passed."
+```
+
+Replace with:
+
+```
+# spec 014 Part A — roster, init, calibration
+need_new 'Roster reconciliation'                         "roster reconciled at loop start"
+need_new 'review-loop\.local\.md'                        "enrollment config path"
+need_new 'derived from `kind`'                           "tier is derived, not declared"
+
+# spec 014 Part B — the adversarial panel
+need_new 'blind'                                         "round 1 is blind"
+need_new 'cross-critique'                                "round 2 exists"
+need_new 'refuted-undefended'                            "the status that had to exist"
+need_new 'survived'                                      "gate turns on survived, not != refuted"
+need_new 'falsification'                                 "finding record carries a falsification condition"
+need_new 'facilitator confirms the quote'                "prose reproduction is a check, not a capability"
+need_new 'retain both verbatim texts'                    "dedup cannot launder attribution"
+need_new 'weak evidence'                                 "same-family convergence is labelled weak"
+need_new 'critique rounds are now exempt'                "R2 detector exemption"
+need_new 'forge reviewer'                                "Phase B is a slot"
+need_new 'clean_when'                                    "declared reviewers pin their stop signal"
+
+# the leading convergence prompt is gone
+refute 'Are your earlier points resolved'                "leading convergence prompt"
+# the old Copilot-only Phase B heading is gone (note: it was an h3, not an h2)
+refute '^### Phase B — GitHub Copilot'                   "Copilot-only Phase B heading"
+
+echo "All SKILL.md content checks passed."
+```
+
+- [ ] **Step 5: Close the cross-link between the fixture test and SKILL.md**
+
+Task 0's `test-detector-predicate.sh` pins `critique → review`, but nothing ties that
+to the exemption prose Task 4 wrote into `SKILL.md`. Both could be green while
+disagreeing. Add the link now that both exist.
+
+In `tools/review-loop/test-detector-predicate.sh`, find (verbatim):
+
+```
+echo "All detector-predicate checks passed."
+```
+
+Replace with:
+
+```
+# Cross-link: the exemption this test pins must actually be stated in SKILL.md.
+# Without this, Task 4 could land an exemption that contradicts these fixtures and
+# both suites would still pass.
+SKILL="$SCRIPT_DIR/../../plugins/review-loop/skills/review-loop/SKILL.md"
+grep -Eqi 'R2 critique rounds are [a-z ]*exempt' "$SKILL" \
+  || fail "SKILL.md does not state the R2 critique exemption this test pins"
+grep -Eq 'zero .*command_execution' "$SKILL" \
+  || fail "SKILL.md no longer describes the zero-command detector condition"
+pass "SKILL.md states the exemption these fixtures pin"
+
+echo "All detector-predicate checks passed."
+```
+
+Run: `bash tools/review-loop/test-detector-predicate.sh`
+Expected: seven `PASS:` lines, exit 0.
+
+Prove the link can fail — temporarily break the prose, confirm red, restore:
+```bash
+cp plugins/review-loop/skills/review-loop/SKILL.md /tmp/skill.bak
+sed -i 's/R2 critique rounds are EXEMPT/R2 critique rounds are handled normally/; s/R2 critique rounds are now exempt/R2 critique rounds are handled normally/' plugins/review-loop/skills/review-loop/SKILL.md
+bash tools/review-loop/test-detector-predicate.sh; echo "exit=$?"
+cp /tmp/skill.bak plugins/review-loop/skills/review-loop/SKILL.md; rm /tmp/skill.bak
+bash tools/review-loop/test-detector-predicate.sh >/dev/null && echo "restored green"
+```
+Expected: `FAIL: SKILL.md does not state the R2 critique exemption this test pins`, non-zero exit, then `restored green`. The `sed` must break **both** phrasings — Task 4 writes "R2 critique rounds are EXEMPT from the post-round…" and Task 6 writes "R2 critique rounds are now exempt too" — so the grep is case-insensitive. If the break does not turn the suite red, the grep does not match what Tasks 4/6 actually wrote: **fix the grep to match the prose, never the prose to match the grep.**
+
+- [ ] **Step 6: Bump the version and the description**
+
+Find (verbatim):
+
+```
+      "description": "Assisted multi-reviewer review loop — local Claude + Codex gate first, then GitHub Copilot for PRs; never merges autonomously",
+      "version": "0.4.0"
+```
+
+Replace with:
+
+```
+      "description": "Assisted adversarial review panel — reviewers answer blind, attack each other's findings, then converge; enrolled roster via /review-loop:init; never merges autonomously",
+      "version": "0.5.0"
+```
+
+- [ ] **Step 7: Run the full harness**
+
+Run: `bash tools/review-loop/test-skill-content.sh`
+Expected: every check passes, including each `need_new`, ending `All SKILL.md content checks passed.`
+
+If a `need_new` reports **`vacuous anchor (already present at <sha>)`**, the anchor phrase
+already existed in `0.4.0`. **Fix the anchor, never the harness** — pick a phrase unique to
+the new behavior. This is the failure mode the helper exists to catch.
+If `refute '^### Phase B — GitHub Copilot'` fails, Task 8 Step 1 did not land.
+
+- [ ] **Step 8: Validate the manifest**
+
+Run:
+```bash
+jq -r '.plugins[] | select(.name=="review-loop") | .version' .claude-plugin/marketplace.json
+jq . .claude-plugin/marketplace.json >/dev/null && echo "valid json"
+```
+Expected: `0.5.0`, then `valid json`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add plugins/review-loop/commands/review-loop.md tools/review-loop/test-skill-content.sh .claude-plugin/marketplace.json
+git commit -m "chore(review-loop): bump to 0.5.0; anchor spec 014 with need_new
+
+Every anchor guarding new behavior is novelty-checked, so a guard that would pass
+against the unmodified SKILL.md fails the suite instead. The Phase B refute is anchored
+on '^### ' -- the heading is an h3, and the h2-anchored regex proposed during review
+could never have matched it.
+
+Implements spec 014 § Testing."
+```
+
+---
+
+## Task 10: Full gate and manual verification
+
+- [ ] **Step 1: Run everything**
+
+Run:
+```bash
+bash tools/review-loop/test-skill-content.sh
+bash tools/review-loop/test-detector-predicate.sh
+bash tools/review-loop/test-sandbox-preflight.sh
+```
+Expected: three suites, all exit 0.
+
+- [ ] **Step 2: Clean tree, no conflict markers, no secrets**
+
+Run:
+```bash
+git status --short
+git diff --cached --check
+git grep -nE 'api_key|Authorization|ghp_|sk-' -- plugins/review-loop || echo "no secrets"
+```
+Expected: clean tree; no whitespace/conflict errors; `no secrets` (or only the *names*
+`api_key_env` in prose that forbids storing keys — read each hit, do not assume).
+
+- [ ] **Step 3: Exercise the probe for real**
+
+Run:
+```bash
+for cli in codex gemini cursor-agent opencode aider crush amp llm gh; do
+  command -v "$cli" >/dev/null 2>&1 && echo "$cli present" || echo "$cli absent"
+done
+```
+Expected: `codex present`, `gh present`, the rest `absent` on this host. Confirm `SKILL.md` carries this loop and that **no** new file exists under `plugins/review-loop/skills/review-loop/scripts/`.
+
+- [ ] **Step 4: Manual read-through**
+
+Confirm by reading `SKILL.md`:
+- A1 says panelists review **blind**, on the same **unfixed** diff, and R1 findings are shown to the author as `proposed`.
+- The freeform-native R1 pins `<base>..<head-sha>` and checks the echoed file list against `git diff --name-only`.
+- R2's prompt asks for the claim you "tried hardest to break" and **does not** mandate a disagreement.
+- The R2 detector exemption's stated reason is the **category error** (an R2's subject is the findings), not "critique rounds read no files".
+- The gate is `survived ∨ reproduced`; a single-panelist run auto-fixes on `reproduced` alone.
+- Prose `reproduced` requires the **facilitator** to verify the citation.
+- Phase B is titled for the forge reviewer; Copilot's B0–B5 behavior is intact.
+
+- [ ] **Step 5: Record results** for the PR body (no commit).
+
+Note Task 0's recorded preflight verdict: whether the native path was exercisable here, or whether the fixtures are the coverage.
+
+---
+
+## Task 11: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/review-loop-adversarial-panel
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --base main --head feat/review-loop-adversarial-panel \
+  --title "review-loop 0.5.0: enrolled reviewer roster + adversarial panel" \
+  --body "$(cat <<'EOF'
+Implements [spec 014](docs/superpowers/specs/014-review-loop-adversarial-panel-design.md).
+
+## Part A — the roster is enrolled, not assumed
+- `/review-loop:init` probes which coding CLIs exist, then **verifies how to call each one by actually calling it**, on a throwaway fixture diff — never your real working tree. A CLI whose invocation cannot be established is detected but not enrolled.
+- The presence probe is a `command -v` sweep the agent runs inline. **No new script ships**: wrapping `command -v` in a program buys a maintenance burden and calcifies a decision a more capable model will make correctly without help. `<cli> --version` runs during `init` only.
+- `gh` presence only *offers* Copilot; `gh auth status` decides it. Presence is not authentication.
+- Drift (enrolled-but-absent, present-but-unenrolled, stale recipe) is always surfaced, never silently followed. A recipe never suppresses the preflight or the `command_execution` detector.
+
+## Part B — reviewers become adversaries
+- **Blind parallel round 1** on the same unfixed diff, then **one cross-critique round**. Previously Codex only ever saw the tree Claude had already fixed, so it could never dispute Claude's reading of a finding.
+- Findings carry attribution, tier, **confidence**, and a concrete **falsification condition**. `confidence` is a self-report and authorizes nothing; what authorizes an auto-fix is `survived` (faced an adversary) or `reproduced`.
+- `refuted` split: an attack its author never answered is `refuted-undefended` — a live disagreement, not a verdict.
+- Prose targets get a `reproduced` analogue, but the **facilitator** must verify the citation with a command.
+- The gate verdict names the panel that actually ran and labels same-family convergence as weak evidence.
+- Phase B becomes a forge slot; Copilot is its one built-in adapter. Other forges' agents are neither named nor shipped — we cannot exercise what we have no access to.
+
+## Tests
+- New: `tools/review-loop/test-detector-predicate.sh` + recorded `codex --json` fixtures, covering the R2 detector exemption — the one branch that cannot execute on a host routed to embedded-diff. The suite is demonstrated to go red when the exemption is removed.
+- New: `need_new()` in `tools/review-loop/test-skill-content.sh` — an anchor that already matches the pre-change `SKILL.md` now **fails the suite**. Three such vacuous anchors were proposed during this spec's own review rounds.
+
+## Known coverage gap
+<!-- Fill from Task 0's recorded verdict. If the preflight reported `broken`/`unknown`: -->
+This host's Codex sandbox preflight reports `broken`, so every Codex round routes to the embedded-diff form — a **fully supported path**, not a degradation. The consequence is a testing gap, not a running one.
+
+`tools/review-loop/test-detector-predicate.sh` covers the R2 detector exemption with recorded `codex --json` fixtures: the predicate and the routing decision are pinned deterministically, and the test is shown to be capable of failing. What the fixtures do **not** prove is that `codex exec resume` behaves as documented against a live `usable` sandbox. That residue is disclosed here rather than implied.
+
+Restoring the native path is an AppArmor/sysctl change affecting every `bwrap` caller on the machine. It is **separate work that the author owns**, not a prerequisite for this PR, and nothing here asks for `sudo`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Gate the PR**
+
+Run `/review-loop <PR#>` to add the forge-reviewer phase. **Never merge autonomously** — the author decides. Prefer a merge commit over a squash.
+
+---
+
+## Self-Review (completed by plan author)
+
+**1. Spec coverage.** §A.1 → Task 2. §A.2 (inline probe, no script) → Task 2. §A.3 → Task 3. §A.4 (asks, forge slot, `clean_when`) → Tasks 3, 8. §A.5 (config shape) → Tasks 2, 3 — the file is written by `init` at runtime, not committed; its schema is documented in `init.md` and `SKILL.md`. §A.6 → Task 2. §A.7 → Task 2 (zero-config hint) + Task 10 Step 4. §A.8 → Tasks 2, 3. §B.1–§B.2.4 → Task 4. §B.3–§B.5 → Task 5. §B.6–§B.8 → Task 6. §B.9–§B.10 → Task 7. §B.11 → Task 8. §B.12 → Task 0 (fixture coverage; never a host change) and the PR's "Known coverage gap". §B.13 (files) → Tasks 2–9. § Testing → Tasks 0, 1, 9, 10. Version bump → Task 9.
+
+**2. Placeholder scan.** No TBD/TODO. Every `SKILL.md` edit carries verbatim Find/Replace text; the fixtures and both new test scripts are given in full; the one intentional fill-in (the PR's coverage-gap paragraph) is explicitly sourced from Task 0's recorded preflight verdict.
+
+**3. Name consistency.** `need_new` (never `needNew`); `invocation.command` / `invocation.form` / `invocation.verified_with`; statuses `proposed` / `survived` / `refuted` / `refuted-undefended` / `reproduced` / `unreproduced` — used identically in Tasks 4, 5, 7 and in the Task 9 anchors. Every anchor phrase in Task 9 is quoted verbatim from the replacement text in Tasks 2, 4, 5, 6, 7, 8, and each was checked against the unmodified `SKILL.md` to confirm it does not already match.
+
+**4. Ordering.** `need_new` (Task 1) lands before every anchor that uses it (Task 9) and before every `SKILL.md` edit it guards (Tasks 2, 4–8). Task 0's fixtures land before Task 4 adds the exemption they cover. Task 0 gates nothing on a human and never touches the host.
+
+**5. No new shipped script.** Spec's "materialize critical knowledge only": the presence probe is prose the agent runs. The only new programs are dev tooling under `tools/review-loop/`, which never reaches a user's disk.
+
+**6. Branch discipline.** All work on `feat/review-loop-adversarial-panel` in the worktree at `/dev/shm/dong3/review-loop-panel`; every git command runs from inside it.

--- a/docs/superpowers/specs/014-review-loop-adversarial-panel-design.md
+++ b/docs/superpowers/specs/014-review-loop-adversarial-panel-design.md
@@ -1,0 +1,1493 @@
+# 014 — review-loop: reviewer roster (`/review-loop:init`) + adversarial panel protocol
+
+**Status:** Design
+**Plugin:** `review-loop`
+**Extends:** [002](002-review-loop-plugin-design.md), [003](003-review-loop-headless-codex-design.md), [009](009-review-loop-codex-sandbox-fix-design.md), [010](010-review-loop-explicit-ux-design.md)
+**Source:** author request, prompted by [makinux/adversarial-panel](https://github.com/makinux/adversarial-panel) (MIT) and its design essay, ["adversarial-panel:多モデル敵対的レビューという品質保証"](https://x.com/wayama_ryousuke/status/2075147624806813800) (Ryousuke Wayama, 2026-07-09)
+**Target version:** `review-loop` 0.4.0 → 0.5.0 (behavior change)
+
+## Motivation
+
+`review-loop` already runs more than one reviewer, which is most of the way to
+the right idea. It gets two things wrong about *how* they run, and one thing
+wrong about *who* they are.
+
+**Self-review is a conflict of interest.** An LLM's answer is most dangerous
+when it is confidently wrong, and a model asked to critique its own output
+draws its critique from the same weights that produced the blind spot. The
+`adversarial-panel` skill names the two properties that make multi-reviewer
+setups actually work, neither of which follows from merely having more than
+one reviewer:
+
+- **Decorrelation** — a reviewer only catches what the generator missed when
+  their failure modes differ. Same-family panels share blind spots, so
+  confident convergence is weaker evidence than it looks.
+- **Verification advantage** — refuting a claim is cheaper than producing one.
+  Point reviewers at *verifiable* claims and make them refute by reproduction
+  ("fails on input X"), not by assertion ("this looks wrong").
+
+Against that standard, the current loop has four gaps:
+
+1. **Reviewers are serial gates, not adversaries.** 0.4.0 §A1 has Claude review,
+   apply fixes, and commit; 0.4.0 §A2 then has Codex review the *already-fixed* tree.
+   Codex never sees the pre-fix diff, so it can never dispute Claude's reading
+   of a finding or its choice of fix — it is anchored on Claude's output. The
+   two reviewers also never critique *each other's findings*, which is where a
+   heterogeneous panel earns its cost: cross-critique kills false positives
+   before they turn into commits.
+2. **Facilitator capture is unguarded.** Claude is simultaneously a panelist
+   (the 0.4.0 §A1 subagent) and the facilitator (it tiers findings, relays Codex's
+   review, drafts approaches, applies fixes). Nothing prevents it from quietly
+   downgrading a Codex finding it disagrees with, or presenting its own opinion
+   as the panel's. Attribution exists only in the review journal, not in the
+   round output the author reads.
+3. **The panel is same-family by default.** The 0.4.0 §A1 subagent is Claude
+   reviewing Claude's own diff, decorrelated by fresh context but not by
+   weights. The `Task` dispatch does not set a `model`, so the free
+   heterogeneity upgrade (review under a different Claude model) is unused. And
+   "local gate clean" is reported identically whether Codex participated or
+   not, even though those two verdicts carry very different evidential weight.
+4. **Convergence prompts invite agreement.** 0.4.0 §A2 resumes with `"I applied these
+   fixes: <summary>. Are your earlier points resolved?"` — a leading question
+   that asks Codex to accept *Claude's own summary of Claude's own fixes* as
+   evidence. Sycophantic convergence (agreement without a new argument) is the
+   expected failure.
+
+**And the roster is assumed, not discovered.** `codex` and an authenticated
+`gh` happen to exist on the author's machines. On someone else's, the loop
+silently degrades to Claude-only — which is exactly the same-family weak-evidence
+case above, reported as if it were a clean gate. The loop should know which
+reviewers this host can actually field, and say so.
+
+Two parts, in dependency order. Part A gives the loop a roster and a way to
+learn what this host can actually do. Part B makes the reviewers on that roster
+adversaries rather than a queue.
+
+Where review-loop is **already ahead of** `adversarial-panel`, we keep what we
+have and say so: the 0.4.0 §A2 post-round `command_execution` detector is a
+*structural* validation gate (a native round that ran zero commands never read
+the tree), strictly stronger than the panel's text-marker check for the same
+failure — and the "never a silent clean" rule is exactly the panel's
+"disclose the tier that actually ran".
+
+## The governing principle: the skill encodes no environment
+
+`review-loop` 0.4.0 is written around one person's machines. `codex` is assumed
+on `PATH`; GitHub Copilot is hardcoded as *the* remote reviewer, with `gh` and
+GraphQL baked into Phase B; the Codex invocation is a fixed recipe that happens
+to suit the author's sandbox. Every one of those is a fact about a host, not
+about reviewing.
+
+Three rules follow, and they constrain everything below:
+
+1. **Nothing is assumed present.** Reviewers, forges, models: all *enrolled*,
+   never presumed. A host with no `codex` and no forge is a first-class case.
+2. **Nothing is assumed callable.** Knowing a CLI exists does not tell you how to
+   drive it correctly. `init` **verifies by trying** (§A.3) and records what
+   actually worked, rather than shipping a recipe that works on one laptop.
+3. **Nothing ships that we cannot exercise.** Other forges have their own review
+   agents; we neither name nor implement them, because an adapter no one here can
+   run is a ghost reviewer at the forge level — the §B.7 anti-pattern, one layer
+   up. We ship the **slot**, plus the one adapter (GitHub Copilot) whose scripts
+   already exist and are tested. Anyone with access to another forge's reviewer
+   declares it and supplies its commands (§A.4).
+
+## The second principle: never trust a model where a check can run
+
+A model's capability drifts — new versions, changed defaults, a provider's quota,
+a sandbox policy shipped by an OS update. None of it is under this skill's
+control. So wherever a claim can be **checked by running something**, the skill
+runs it and believes the result; wherever it cannot, the claim goes to the author.
+Model judgement is never the last word on a question a command could settle.
+
+This spec has already violated its own principle three times, in the same way:
+
+- Round 0 proposed `need 'confidence'` as a regression anchor. `SKILL.md:152`
+  already contains "treat a bare `confidence is low` as a non-review". The anchor
+  passes against the *unmodified* file.
+- Round 1 then proposed `need 'invocation'` (`SKILL.md:119` — "a `review`
+  invocation") and `refute '^## Phase B — GitHub Copilot'` (the real heading is
+  `### Phase B`, so the regex never matched and the refute always passed).
+
+Three vacuous anchors, each asserted by a model that had not run `grep` against
+the file it was making a claim about. The fix is not to correct three regexes. It
+is to **make the harness prove novelty**: an anchor guarding a new behavior must
+*fail* against the pre-change `SKILL.md`, and the harness can check that itself
+(§ Testing, `need_new`). A test that cannot fail is not a test.
+
+The same rule decides several open design questions below, and it decides them
+against the more flattering answer:
+
+- A reviewer's `confidence` is a self-report and authorizes nothing (§B.4).
+- A prose finding's citation is auto-fixable only when *both* the quote's existence
+  **and** the fix are mechanically checkable (§B.5). "I quoted a passage and I
+  say it contradicts" is model judgement wearing evidence's clothes.
+- `init` verifies a CLI by calling it, not by recognizing its name (§A.3).
+- The gate reports the panel that ran, verified — the model that actually differed,
+  the CLI that actually returned findings (§B.9).
+
+Where no check exists — *is this contradiction real? is this abstraction right?* —
+the answer is surfaced to the author. That is not a limitation to be engineered
+away. It is the line between what the loop may do alone and what it may not.
+
+### Its corollary: materialize critical knowledge only
+
+"Run a check instead of trusting a model" is not "wrap everything in a script". The
+two rules pull in opposite directions and the tension is the point.
+
+**A shipped script earns its keep by encoding something the agent would get wrong, or
+would find tedious enough to skip.** `copilot.sh` earns it: the GraphQL bot-id dance
+and the first-review 422 are knowledge nobody rediscovers pleasantly. `pr-comments.sh`
+earns it: silent single-page truncation. `sandbox-preflight.sh` earns it: it actually
+builds a sandbox. The `command_execution` jq predicate earns being written down,
+because it has been mis-transcribed (`.item.type`, not `.type`) and its *rationale* was
+wrong in this spec's own first draft.
+
+A `command -v` loop earns nothing. Wrapping it buys a maintenance burden, a test, and
+a JSON schema whose only consumer is an agent that could have read the plain output.
+Worse, it **calcifies** — the models reading this skill get more capable every year,
+and a script is a decision frozen at the moment it was written. Prose the agent
+executes adapts; a script the agent calls does not.
+
+So: **materialize the knowledge that is critical and easily lost. Leave the rest as
+prose.** When unsure, ask what a stronger model six months from now would need told —
+not what today's model finds convenient.
+
+**Notation.** `0.4.0 §A1` / `0.4.0 §A2` name steps of the *current* `SKILL.md`
+Phase A. The *new* pipeline's steps are `A0`–`A4` in §B.2's diagram, and its
+rounds are `R1` (blind) / `R2` (cross-critique) / `R3` (final positions, ≥3
+panelists only). An unqualified `§A.n` is a section of this spec.
+
+## Part A — Reviewer roster and `/review-loop:init`
+
+### A.1 Scope: probe presence cheaply, verify invocation once, ask for the rest
+
+Three kinds of knowledge, three homes. Conflating them is what makes a config
+either useless or a stale cache.
+
+| Kind | Example | Cost | Where it lives |
+|------|---------|------|----------------|
+| **Presence** | is `codex` on `PATH`? | ~1 ms | probed **every run**; never trusted from disk |
+| **Invocation** | does native `review` work here, or must the diff be embedded? is `-m` needed? | seconds — a real subprocess | learned **once by `init`**, stored as a recipe (§A.3) |
+| **Intent** | may this reviewer be used, at which tier? which forge reviewer? which Claude model? | unaskable of the machine | asked by `init`, stored |
+
+`command -v codex` is free, so caching its answer buys nothing and goes stale the
+day another CLI is installed. But **knowing a CLI exists tells you nothing about
+how to drive it**: on this author's Ubuntu host `codex` is present, `bwrap` is
+present, and native `codex exec review` still cannot read the tree, because
+`bwrap-userns-restrict` blocks it — the loop must embed the diff in the prompt
+instead. No amount of `command -v` reveals that. It costs one real call to find
+out, which is exactly the kind of thing worth doing once and remembering.
+
+So the config records **intent + a verified invocation recipe**, and nothing that
+a millisecond of `command -v` can re-derive.
+
+The runtime contract follows directly (§A.6): the config says *"you may use X at
+tier N, and here is how X is actually called on this host"*; the run says *"X is
+here right now"*. When they disagree, the loop **surfaces the drift and points at
+`/review-loop:init`** — it never silently follows a stale config.
+
+### A.2 What `init` probes
+
+**No script.** The probe is `command -v` over a candidate list, run inline:
+
+```bash
+for cli in codex gemini cursor-agent opencode aider crush amp llm gh; do
+  command -v "$cli" >/dev/null 2>&1 && echo "$cli present" || echo "$cli absent"
+done
+```
+
+An earlier draft shipped this as `scripts/panel-detect.sh`, emitting JSON. It should
+not exist. A shipped script earns its keep by encoding something an agent would get
+wrong or find tedious — `copilot.sh`'s GraphQL bot-id dance and its first-review 422,
+`pr-comments.sh`'s pagination, `sandbox-preflight.sh` actually building a sandbox. A
+`command -v` loop is none of those. Wrapping it buys a maintenance burden, a test, and
+a JSON schema whose only consumer is an agent that could have read the plain output —
+and it calcifies a decision that a more capable model will make correctly without
+help. **Prefer prose the agent executes over a script the agent calls, wherever the
+script would only be transcribing what the agent already knows.**
+
+**Versions are `init`-only.** `<cli> --version` spawns a real subprocess — some coding
+CLIs take hundreds of milliseconds — and only `init` needs the result (it feeds
+`verified_with` drift detection, §A.6). The loop's start-up reconciliation asks
+presence and nothing else.
+
+Two groups, because they feed different enrollments:
+
+- **Panelist CLIs** — `codex`, `gemini`, `cursor-agent`, `opencode`, `aider`,
+  `crush`, `amp`, `llm`.
+- **Forge CLIs** — `gh`, and any other forge client a user later declares. Their
+  presence is what lets `init` *offer* a forge reviewer (§A.4). Omitting `gh` here
+  while triggering Copilot enrollment on it would force the skill to re-derive
+  presence outside its one specified probe.
+
+It reads no config file, touches no network, and inspects no credentials.
+**Presence of `gh` is not authentication** — the current skill needs
+"the authenticated `gh` CLI" (`SKILL.md:20`), and a host with an unauthenticated
+`gh` would otherwise enroll a forge reviewer that can neither request nor poll.
+Authentication is a real call, so it belongs to calibration (§A.3), not here.
+
+This answers *presence*. It deliberately does **not** answer *invocation* — that
+needs a real call, a judgement about what came back, and possibly a retry under a
+different form (§A.3). Both halves are agent work; neither is script work.
+
+### A.3 What `init` verifies by trying
+
+**Detecting that `codex` exists is not the same as knowing how to call it.** After
+the presence probe, `init` *uses* each enrolled CLI once, on a throwaway target,
+and writes down what actually worked. This is the one expensive thing `init` does,
+and it is expensive exactly once.
+
+For **`codex`**, the skill already knows the shape of the question and mostly
+knows how to answer it — `sandbox-preflight.sh` plus the 0.4.0 §A2 post-round detector
+exist for this. `init` runs that machinery deliberately instead of rediscovering
+it mid-review:
+
+1. Run `sandbox-preflight.sh` → `usable | broken | unknown`.
+2. Issue one real `codex exec --json --sandbox read-only review --base <base>`
+   against a trivial diff and apply the existing `command_execution` detector: a
+   native round that ran zero commands never read the tree.
+3. Record the form that produced a real review — `native` or `embedded` — plus
+   anything the call revealed it needs: a `-m <model>` pin when the account's
+   default model is unavailable, a longer timeout, `--skip-git-repo-check`.
+4. **Record the form that worked and move on.** If native did not work, `init` writes
+   `form: embedded` and says so once, in one line. It may add one more line — *"the
+   native path can be restored; see `references/codex-sandbox-host-fixes.md`"* — and
+   then it stops.
+
+**Fixing the host is separate work, not part of this skill.** Codex's
+`--sandbox read-only` uses `bwrap`, which needs unprivileged user namespaces; Ubuntu
+23.10+ ships `kernel.apparmor_restrict_unprivileged_userns=1` and blocks it. Restoring
+that is an AppArmor/sysctl policy change — `sudo`, system-wide, affecting every
+`bwrap` caller on the machine. **A review skill does not own that decision and never
+performs it as part of a review.** `init` may *suggest* it, and the author may go do
+it — with an agent's help if they like — as its own task, in its own session. The
+distinction that matters: **suggesting is not owning.** review-loop never gates on it,
+never blocks for it, never re-raises it, and treats its absence as a configuration
+rather than a defect.
+
+**`embedded` is a supported path, not a degradation.** The diff goes in the prompt, no
+sandbox is involved, and the §B.7 guarantee is inherent rather than detected. What
+native buys is *ambient context* — Codex can read the code around the diff — which is
+a quality gain, not a correctness gate. A host that routes to embedded is not broken
+from the loop's point of view; it is configured. The loop therefore **never narrates
+the preflight verdict on a normal run**. It speaks only when the verdict *changes
+something the author must decide*: a recipe that stopped working (§A.6), or a native
+round that turned out to be a false clean. Announcing "sandbox broken" before every
+review is noise about a condition that has a recorded answer.
+
+For **any other CLI**, the skill has no prior recipe, and must not pretend to.
+`init` works it out, bounded and out loud: does it have a review-like subcommand
+(`--help`)? a read-only mode? does it take a prompt on stdin? does it return in
+the foreground, or fork and exit (the ghost-panelist manufacturer, §B.7)? The
+resulting recipe goes in the same **structured `invocation:` block** every enrolled
+CLI gets (§A.5) — *not* the free-form `## Notes` body, which the loop would have to
+parse a command out of prose to use. `## Notes` is for humans; `invocation.command`
+is what runs.
+
+**The scratch target, defined.** Calibration needs a diff, and where it comes from
+is a decision with a leak in it:
+
+- **The target is a fixture, not the user's work.** `init` writes a two-line
+  temporary file under `$TMPDIR`, commits nothing, and produces a diff of it with
+  `git diff --no-index`. For `codex`, whose native form needs a repo, `init` uses a
+  throwaway `git init` in `$TMPDIR` with one commit.
+- **Never the current repo's real diff.** Calibrating an unenrolled third-party CLI
+  against the user's actual changes ships their code to a service they have not yet
+  agreed to enroll. The consent (§ below) is for the calibration call, not for the
+  working tree.
+- **It leaves nothing behind.** No branch, no commit, no file in the repo.
+
+**Forge reviewers calibrate too.** `gh` on `PATH` proves nothing; `gh auth status`
+proves it can talk to GitHub. Calibration is the one phase permitted to make that
+call, and it does so with the author present. An unauthenticated `gh` means the
+forge reviewer is **detected but not enrolled**, with the reason shown — never
+enrolled-and-broken, discovered mid-review when a poll hangs.
+
+Four rules keep this from becoming an unbounded agent excursion:
+
+- **Bounded.** Two attempts per CLI, then stop and report. A CLI whose invocation
+  cannot be established is **detected but not enrolled**, with the reason shown.
+  Never enroll a reviewer you have not successfully called.
+- **Read-only and throwaway.** Calibration reviews a scratch diff — a temporary
+  commit on a scratch branch, or a `git diff` of a fixture file, in *this* repo.
+  It never runs a CLI in a mode that can write to the tree, and it leaves no
+  branch, commit, or file behind.
+- **Consented.** Calibration runs subprocesses and, for a forge CLI, one
+  authenticated call. `init` says what it is about to run before it runs it.
+- **Transcribed, not summarized.** Store the command line that worked, **verbatim,
+  for every enrolled CLI including `codex`** — in the `invocation.command` field
+  (§A.5). "codex works" is not a recipe; `codex exec --json --sandbox read-only -`
+  is. A built-in adapter is not exempt: the built-in is a *default to try*, and
+  what gets stored is what actually returned a review on this host.
+
+The recipe is a **learned default, not gospel**. The loop still runs its own
+preflight at start (§A.6): a kernel or AppArmor update can invalidate a `usable`
+verdict overnight, and a stale recipe that silently false-cleans is precisely the
+failure mode 009 was written to kill.
+
+### A.4 What `init` asks
+
+`init` shows what it found, proposes an enrollment, and takes the rest from the
+author. It never enrolls anything silently, and it asks nothing about a
+candidate that is absent.
+
+- **Enrolled by default:** `codex` (tier 1, cross-family CLI); a Claude subagent
+  at a **different model from the session** (tier 2) — `init` asks which model.
+- **Offered, default off:** any other detected coding CLI (tier 1 — the
+  strongest decorrelation available, but each brings its own auth, sandbox and
+  timeout semantics, and none has a `review` subcommand, so the diff must be
+  embedded in the prompt; this is the highest ghost-panelist risk).
+- **Never discovered, only declared:** an OpenAI-compatible endpoint as a
+  panelist. If the author wants one, they say so and name it; `init` records the
+  name. Where that name is an alias in the `chat-subagent` registry, the entry
+  is marked `via: chat-subagent` and **the url and `api_key_env` stay in that
+  plugin's files** — review-loop stores neither. A local 7B model enrolled as a
+  reviewer produces **noise, not decorrelation**; the diversity illusion runs in
+  this direction too, so this stays opt-in and per-endpoint.
+
+#### Forge reviewers are a slot, not a hardcoded Copilot
+
+Today Phase B *is* GitHub Copilot: `gh`, a GraphQL `requestReviews` mutation, and
+a `generated no comments.` stop signal, written straight into the skill. That is
+an adapter masquerading as an architecture. Generalize it:
+
+- A **forge reviewer** is a reviewer that lives on the code-hosting platform,
+  reachable only once the change is a pull/merge request. It has three operations:
+  **request**, **poll for comments**, and **recognize a clean pass**.
+- `init` offers to enroll one **when the corresponding CLI is present** — `gh` on
+  `PATH` prompts *"GitHub PRs can request a Copilot review. Enroll it?"* Presence
+  of the forge CLI is the trigger; enrollment is still the user's answer.
+- **One adapter ships: GitHub Copilot**, because `scripts/copilot.sh` and
+  `scripts/pr-comments.sh` already implement its three operations — `request` /
+  `rerequest`, `fetch`, and `clean-pass` — and have been **exercised in real use**
+  across many PRs. Not "tested": `tools/review-loop/` contains only
+  `test-sandbox-preflight.sh` and `test-skill-content.sh`, and nothing anywhere
+  tests these two scripts. The word matters, because "tested" was doing load-bearing
+  work in the argument for why this adapter ships and others do not. What actually
+  justifies it is that we can run it and watch it fail.
+- **Other forges have review agents. This spec names none of them and implements
+  none of them.** We cannot exercise what we have no access to, and an adapter
+  written from documentation is a ghost reviewer at the forge level — it would
+  poll forever, or report a clean pass that never happened. A user with access
+  declares the reviewer and supplies its three commands; the skill drives them.
+  Until someone does that, the slot sits empty and Phase B is skipped.
+
+```yaml
+forge:
+  - id: copilot
+    host: github
+    adapter: builtin              # scripts/copilot.sh + scripts/pr-comments.sh
+    enabled: true
+  # A user-declared forge reviewer supplies its own commands; nothing is
+  # assumed about the platform:
+  # - id: <name>
+  #   host: <forge>
+  #   adapter: commands
+  #   request:   "<command that asks the reviewer to review PR/MR $ID>"
+  #   poll:      "<command that prints its comments as text>"
+  #   clean_when: "<regex that matches only a clean pass>"
+  #   enabled: false
+```
+
+`clean_when` is load-bearing and must be supplied by whoever declares the
+reviewer: an absent or over-broad stop signal turns Phase B into an infinite
+poll, or worse, a false clean. If a declared reviewer has no unambiguous clean
+signal, the loop **polls, surfaces its comments, and hands the stop decision to
+the author** rather than inventing one.
+
+**How `clean_when` is evaluated, pinned — because an unpinned regex is the false
+clean it exists to prevent.** The builtin adapter's contract is concrete
+(`pr-comments.sh clean-pass`: POSIX ERE, matched against the **newest** Copilot
+review's body). A declared reviewer inherits exactly that contract and must meet
+its precondition:
+
+- The `poll` command **must** emit reviews newest-first, one JSON object per line,
+  each with a `body` field. That is the adapter interface, not a suggestion.
+- `clean_when` is a POSIX ERE, applied with `grep -Eq` to the **`body` of the
+  newest item only** — never to the whole poll dump. Matching the dump means the
+  first historical round in which the bot ever said "no comments" false-cleans the
+  loop forever.
+- A `poll` command that cannot satisfy the interface is declared wrong. The loop
+  says so at enrollment and falls back to surface-and-ask.
+
+`init` is **idempotent and re-runnable**. Re-running re-probes the CLI list,
+re-verifies invocation recipes only when a CLI's version changed or its recipe
+failed at run time, prints a diff of what changed, preserves existing opt-outs
+(an explicit `enabled: false` is a decision, not an absence), user-declared
+endpoints and forge reviewers, and migrates the schema stamp.
+
+### A.5 Where the config lives, and its shape
+
+Machine-scoped, uncommitted, and **outside the plugin directory** — `plugins/review-loop/`
+is the install boundary (dong3 `CLAUDE.md`), so anything written there is lost
+on the next plugin update.
+
+Follow the resolution order `chat-subagent` already established in this repo, so
+there is one house convention rather than two:
+
+1. `<project-root>/.claude/review-loop.local.md` — per-project overrides
+2. `~/.claude/review-loop.local.md` — global defaults
+
+Merge by `id`; the project entry wins. The `.local.md` suffix marks it
+uncommitted; `init` offers to add `.claude/*.local.md` to `.gitignore` if absent.
+
+```markdown
+---
+review-loop-config: 1          # schema stamp; init migrates older values
+panel:
+  - id: codex
+    kind: cli
+    tier: 1                     # cross-family CLI
+    enabled: true
+    invocation:                 # learned by trying, once (§A.3) — never assumed
+      form: embedded            # native | embedded
+      command: "codex exec -m gpt-5.5 --json --sandbox read-only -"
+      why: "preflight=broken; a native review ran 0 command_execution items"
+      verified_with: "codex-cli 0.139.0"
+  - id: claude-alt
+    kind: claude-model
+    tier: 2                     # different Claude model — same family, weak decorrelation
+    model: fable
+    enabled: true
+  - id: deepseek                # user-declared; init never discovers endpoints
+    kind: endpoint              # no `tier:` — it is derived from kind, not declared
+    trust: user-asserted        # never counts as heterogeneous evidence (§B.9)
+    via: chat-subagent          # name resolved from the chat-subagent registry
+    alias: deepseek
+    enabled: false
+
+forge:                          # see §A.4 — a slot, empty until a reviewer is enrolled
+  - id: copilot
+    host: github
+    adapter: builtin            # scripts/copilot.sh + scripts/pr-comments.sh
+    enabled: true
+    verified_with: "gh auth status ok"   # presence is not authentication (§A.2)
+---
+
+## Notes
+Free-form. Why a panelist is disabled, host quirks, and the literal command line
+that `init` verified for any CLI without a built-in recipe.
+```
+
+`panel` is a list, not a map: **more than one `kind: claude-model` entry is
+legal** (`claude-alt`, `claude-alt-2`, …), which is what §B.10's method-divergent
+degradation mode needs. Entries merge project-over-global by `id`.
+
+**`invocation` is a learned recipe, not a permission.** It answers *how* to call
+an enrolled CLI on this host — the one thing `command -v` cannot tell you and a
+real call can (§A.3). `invocation.command` is the literal line that returned a
+review; `form` and `why` explain it to a human. It is re-verified when the CLI's
+version changes or when the recipe fails at run time; it is never silently trusted
+past a failure (§A.6).
+
+**`tier` is derived from `kind`, and a config file may not raise it.** An earlier
+draft let an endpoint be written `tier: 1` and thereby buy the heterogeneous
+verdict §A.4 warns against; an over-correction then declared `tier` inert, which is
+also wrong — §B.9 really does key on "a tier-1 **CLI** panelist". The rule that
+survives both objections:
+
+| `kind` | `tier` | Can reach §B.9's heterogeneous verdict? |
+|--------|--------|------------------------------------------|
+| `cli` | 1 | yes — a different model family, actually called |
+| `claude-model` | 2 | no — same family; tier 2 is the *panel* tier, not evidence of decorrelation |
+| `endpoint` | — | no. `trust: user-asserted` by construction (§A.4) |
+
+`tier` is therefore **derived, not declared**: writing `tier: 1` on an endpoint is
+a lie the loop ignores. The field stays in the file because a human reading it
+wants to see the claimed heterogeneity at a glance; it decides nothing that `kind`
+and `trust` do not already decide. §A.5's `deepseek` example carries no `tier` for
+exactly this reason.
+
+There is still no `sandbox:` block. The sandbox *verdict* is not a stored fact —
+it is a **consequence** recorded inside `codex`'s `invocation.form`, and the loop
+re-runs its own preflight every start regardless (§A.6).
+
+**No secrets, ever.** Endpoint entries carry a name, never a url and never an
+`api_key_env` — those stay in the `chat-subagent` registry, which already
+forbids raw keys. A user-declared `forge` reviewer's commands are command lines,
+not credentials; if one would need a token inline, it is declared wrong.
+
+### A.6 Runtime contract: liveness check and drift
+
+At loop start the skill runs the §A.2 presence probe and reconciles it against the
+config. Two cases, both **surfaced once, never silent**:
+
+- **Enrolled but absent** (`codex` enrolled, not on `PATH`). Degrade, note it,
+  and mark the gate's evidential tier accordingly (§B.9). The existing "Codex
+  failed → surface + degrade" path already handles the mid-run variant.
+- **Present but unenrolled** (`codex` installed after `init` ran). This is the
+  genuinely harmful drift — a stale config would silently deny the loop its only
+  tier-1 panelist. Note once: *"`codex` is on `PATH` but not enrolled — run
+  `/review-loop:init` to add it."* Do not auto-enroll: enrollment is the user's
+  decision (§A.1).
+- **Recipe drift** — the CLI's version differs from `invocation.verified_with`, or
+  the loop's own preflight now contradicts `invocation.form` (a kernel or AppArmor
+  update can flip `broken` → `usable` overnight, and the reverse). The stored
+  recipe is a **learned default, not gospel**: the preflight and the post-round
+  detector still run and still win. Follow the evidence for this run, then say
+  *"`codex`'s recorded invocation no longer matches this host — re-run
+  `/review-loop:init` to re-verify."* A recipe that silently false-cleans is the
+  exact failure spec 009 exists to prevent, so the recipe never suppresses a
+  detector.
+
+A user-declared endpoint panelist has no cheap liveness probe, by design (§A.2).
+It is simply invoked; if it fails twice it is dropped and disclosed (§B.7).
+
+**One more reconciliation, and it is not about presence.** If `claude-alt.model`
+equals the model the session is *already* running, the tier-2 panelist is the
+session's own weights with a fresh context — decorrelation by context only, not
+by weights. §B.9 must then report the panel as **"fresh-context only"**, not as
+tier 2. Verifying that the `model` parameter was *set* is not the same as
+verifying it *differs*, and the difference is the entire reason tier 2 exists.
+
+### A.7 The zero-config path stays
+
+`SKILL.md` today advertises itself as self-contained and portable. With no config
+file the loop fields the **same roster** it does today — Claude subagent + Codex
+if present + Copilot for PR targets — and mentions once that `/review-loop:init`
+can enroll more reviewers. `init` is never a precondition and never blocks.
+
+**The roster is what `init` changes; the protocol is not.** A zero-config host
+with `codex` present has two live panelists, so it runs the Part B protocol
+(blind round 1, cross-critique) exactly like a configured host. Part B is gated
+on **panelist liveness, never on the presence of a config file** — 0.5.0 changes
+how any ≥2-reviewer run behaves, with or without `init`.
+
+**Zero config means the Claude panelist runs on the session's own model.** There
+is no `claude-alt.model` to dispatch under, and the skill must not invent one: a
+model name it guesses may not be dispatchable, and §B.9's verdict tier would then
+rest on a guess. So the subagent runs on the session model, and the gate reports
+**fresh-context only** — the weakest tier, honestly earned. That is the concrete
+incentive to run `init`: one answer upgrades the panel from fresh-context to
+tier 2, and the loop says so when it hints at `init`.
+
+### A.8 Files (Part A)
+
+- `plugins/review-loop/commands/init.md` — **new.** `/review-loop:init`,
+  mirroring `plugins/tsugu/commands/init.md`'s shape (namespaced command, one
+  frontmatter `description`, invariants restated).
+- `plugins/review-loop/skills/review-loop/SKILL.md` — new "Reviewer roster"
+  section replacing *Reviewer roster & priority*; the §A.6 reconciliation step at
+  loop start; the *Requirements* section reworded so Codex is an **enrolled
+  capability**, not an assumed one; **Phase B generalized from "GitHub Copilot" to
+  "the enrolled forge reviewer, if any"** (§B.11).
+- `plugins/review-loop/skills/review-loop/README.md` — document `init`, the
+  config path, that it is optional, and that Copilot is one adapter rather than
+  the only possible remote reviewer.
+- **No new shipped script.** The presence probe is prose the agent runs (§A.2); the
+  only new dev tooling is the detector fixture suite (§ Testing).
+
+## Part B — Adversarial panel protocol
+
+### B.1 Invariants (borrowed wholesale; they are the point)
+
+- **Independence.** Round-1 findings are produced blind, against the *same
+  unfixed diff*. A reviewer that has seen another's findings anchors on them.
+- **Adversariality.** Agreement without a new argument is a failed round.
+- **Adjudication, not averaging.** Disagreements are resolved on evidence
+  strength and recorded; they are never split down the middle.
+
+And one that is ours, because our target has something a debate does not — a
+runnable ground truth:
+
+- **Reproduction outranks argument.** review-loop reviews a *diff*, not a claim.
+  Where a finding is executable, a failing test settles it. Disagreement between
+  panelists about executable code is converted into a test, never into another
+  round.
+
+### B.2 Restructured Phase A
+
+Current: `A0 author pass → A1 Claude review → fix → A2 Codex review (fixed tree) → A3 converge`.
+
+Proposed:
+
+```
+A0  author pass (unchanged)
+A1  Round 1 — blind, parallel, same unfixed diff
+      ├─ Claude subagent   (Task, model from config: claude-alt)
+      ├─ codex exec review (if enrolled + live)
+      └─ … any other enrolled + live panelist
+    validation gate: is each return a substantive review? (§B.7)
+A2  Round 2 — cross-critique, parallel (only when ≥ 2 live panelists)
+      each panelist receives the OTHER panelists' finding lists verbatim:
+      attack specific findings; then restate your own, dropping any you now
+      believe are wrong.
+A3  Adjudicate → tier (T1/T2/T3) → resolve T2/T3 with the author → fix
+      (per the existing Tiers rules; auto-fix gated by §B.4)
+A4  Converge — re-review the new diff (§B.6) until clean or usage limit
+```
+
+**Round 3 is folded into Round 2** (the source skill sanctions this merge for
+the cheap 2-panelist case: "critique, then restate your final position"). With
+≥ 3 live panelists, a separate Round 3 — each panelist answering the critiques
+of *its own* findings — becomes worthwhile; the skill runs it only then.
+
+**Cross-critique runs on Round 1 only.** Convergence rounds (A4) are
+verification against the code, not debate; they need no second adversary.
+
+#### B.2.1 How each panelist is actually invoked
+
+This is the part that does not follow from the source skill, because `codex exec
+review` is not a chat interface.
+
+- **R1, Codex, native path — use the *freeform* native form, not the targeted
+  one.** An earlier draft of this spec asserted "the native form cannot carry a
+  prompt". That is **false**, and the error mattered. What cannot carry a prompt is
+  the *target-flag* form (`review --base` / `--uncommitted`; SKILL.md:119 —
+  "`review --uncommitted -` errors rc=2"). SKILL.md:129–137 documents a second
+  native form that **does** take one:
+  ```bash
+  printf '%s\n' "<focus prompt>" | codex exec --json --sandbox read-only review -
+  ```
+  It is native, it reads the tree, it captures `thread_id`, and Codex infers the
+  diff itself. So R1's prompt names the base in prose *and* requests the §B.3
+  record format, and **Codex's findings arrive with `confidence` and
+  `falsification` in R1, on every host**.
+
+  **The trade-off, stated plainly:** freeform gives up the explicit `--base` flag,
+  so the target is named in prose and Codex infers it. SKILL.md's current guidance
+  ("use the targeted form by default; reach for freeform only when custom focus is
+  worth giving up the explicit target flag") therefore **changes** — the record
+  format *is* that custom focus, and it is worth it, because a finding with no
+  falsification condition can never be auto-fixed (§B.4).
+
+  **And the trade-off has a cost the first draft of this paragraph missed: an
+  inferred diff may not be the same diff.** R1 is the *blind* round; its whole
+  value rests on every panelist reviewing the **same unfixed diff** (§B.1,
+  independence). A freeform Codex infers its target, and an inference is not a
+  guarantee. Do not trust it — check it:
+
+  - The R1 prompt names the exact range, `<base>..<head-sha>`, not "this branch".
+  - The prompt requires the review to **state the commit range and the file list it
+    actually reviewed**, as its first line.
+  - The facilitator compares that against `git diff --name-only <base>...<head>`. A
+    mismatch means the panelist reviewed something else: **re-run once with the
+    diff embedded** (which cannot be inferred wrong), then treat a second mismatch
+    as a §B.7 panelist failure — drop, continue, disclose.
+
+  Losing the explicit flag costs precision that prose plus a check can restore.
+  Losing the record format costs the panel's only tier-1 reviewer its auto-fix
+  eligibility. Losing the *shared* diff would cost the independence invariant, and
+  that one is not for sale — hence the check.
+- **R1, Codex, embedded-diff path:** unchanged. It carries a prompt too, so the
+  record format is requested the same way. Both paths now behave alike.
+- **R1, Claude subagent:** a `Task` dispatch. The brief must **stand alone** —
+  the subagent sees none of this conversation. It carries: the exact diff
+  snapshot (or how to obtain it), the tier definitions, the §B.3 record format,
+  the falsification-condition instruction, and "your final message is the review
+  record; no preamble". Two implementers writing this brief differently is
+  precisely how the "comparable format across panelists" property §B.3 assumes
+  gets lost, so the brief is specified once in `SKILL.md`, not improvised.
+- **R2, Codex:** `codex exec --json --sandbox read-only resume "$thread_id" -`.
+  The trailing `-` reads the *prompt* from stdin and is valid on `resume`
+  (only `review`'s target flags conflict with a prompt). The prompt carries the
+  other panelists' findings verbatim and asks Codex to attack them, then to
+  restate its own surviving findings. On the embedded-diff path, R2 is a fresh
+  embedded call carrying the complete current diff plus the other findings (per
+  the existing sticky-embedded rule).
+- **R2, `claude-alt` — a fresh dispatch, and say so.** `Task` subagents are
+  one-shot; there is no instance to resume. R2's Claude side is a **new subagent**
+  whose standalone brief carries: the same diff, *its own* R1 findings quoted back
+  to it, the other panelists' findings, and the instruction to attack the others
+  and restate its own. Be honest about what this is: a fresh instance defending
+  text it did not itself produce is a weaker epistemic act than a panelist
+  answering for its own argument. It is what the tool allows. The brief is
+  specified once in `SKILL.md`, not improvised per run.
+- **R2, other `kind: cli` panelists:** no resume protocol is assumed. Their R2 is a
+  fresh call using the stored `invocation.command`, with the diff and the other
+  findings in the prompt — the embedded shape, generalized.
+- **`kind: endpoint` panelists, R1 and R2.** The loop resolves `alias` against the
+  `chat-subagent` registry **at run time** — the loop reading that registry is
+  sanctioned coupling; only `init` is forbidden to go looking (open question 5).
+  It then posts an OpenAI-compatible chat completion whose prompt is the diff plus
+  the §B.3 record format (R1), or the diff plus the other panelists' findings (R2).
+  Findings are read from the response text. There is no resume; every round is a
+  fresh completion carrying the full current diff. An endpoint that returns
+  anything but a substantive review twice is dropped per §B.7.
+
+**Every R1 form now carries a prompt, so the §B.3 record arrives in R1 on every
+host.** An earlier draft built a whole "fields arrive at different rounds on
+different hosts" edge case on the false premise above. It is gone: freeform native
+and embedded both take a prompt, and the targeted form is no longer used for R1.
+A panelist that dies before R2 therefore leaves findings that are *field-complete
+but uncritiqued* — `proposed`, ineligible for auto-fix on status alone (§B.2.2),
+which is the correct and intended outcome.
+
+**Consequence — the detector needs one exemption, so §B.13's "untouched" is
+wrong as first written.** SKILL.md's post-round detector treats *all* native
+rounds, `resume` explicitly included, as non-reviews when they run zero
+`command_execution` items.
+
+**The reason for the exemption is not that a critique round reads no files.** An
+earlier draft said exactly that, and this spec's own R2 refuted it: the
+cross-critique round run against this document executed **five** `command_execution`
+items, because the panelist was asked to *refute by reproduction* and reproduction
+means opening the file at the cited line. A good R2 reads the tree constantly.
+
+The real reason is narrower and does not depend on behavior. The detector's
+inference is "zero commands ⇒ this round never read the tree ⇒ the sandbox silently
+false-cleaned a **review**". That inference is sound only when the round's job *is*
+to review the tree. **An R2 critique round's subject is the findings, not the
+tree** — so a zero-command R2 carries no information about sandbox health, and
+convicting it of a false clean is a category error. A panelist that refutes an
+argument purely from what is already in its session has done its job.
+
+**R2 critique rounds are therefore exempt from the `command_execution` detector.**
+Empirically the detector would rarely misfire — a reproduction-driven R2 runs
+commands — so the exemption is a safety net for the legitimate zero-command case,
+not a workaround for the common one. Left unexempted, such a round would be routed
+to the embedded-diff form and, via the sticky-embedded rule, permanently demote a
+`usable` host for the rest of the loop. Every other native round (initial `review`,
+A4 `resume` verification, fresh native fallback) reviews the tree, keeps the
+detector unchanged, and keeps its guarantee.
+
+#### B.2.2 When a panelist dies mid-panel
+
+Doubling the pre-fix Codex calls means the usage limit can now land *between*
+R1 and R2, which today's rules do not cover. Disposition, for a limit or a
+double-failure (§B.7) of any panelist after its R1 findings are already recorded:
+
+- The dead panelist's **R1 findings stay in the record**, at `status: proposed` —
+  they were never critiqued and never restated, so they cannot be `survived`.
+- They are **surfaced to the author**, and they cannot be auto-fixed **while they
+  remain at `proposed`**. They are not exiled from §B.4: if the facilitator
+  reproduces one (a failing test, or a verified citation), it becomes `reproduced`
+  and is auto-fixable like any other. Reproduction outranks argument (§B.1), and
+  it does not care who raised the finding or whether that reviewer is still alive.
+- The surviving panelists still cross-critique what exists, but a successful attack
+  on a dead panelist's finding yields **`refuted-undefended`**, never `refuted`
+  (§B.3). The dead cannot answer, so the attack is one-sided evidence: it becomes a
+  live disagreement for the author, not a verdict the facilitator may act on.
+- **§B.9 reports the panel that ran per round**, e.g. "R1 heterogeneous, R2 and
+  convergence same-family (Codex hit its usage limit after R1)". Reporting the
+  whole run as heterogeneous because R1 was is exactly the overclaim §B.9 exists
+  to prevent.
+
+#### B.2.3 What A4 converges against
+
+Four decisions an implementer would otherwise guess:
+
+1. **Thread.** A4 resumes the **same `thread_id` as R1 and R2** — R2 used
+   `resume`, so it did not fork a session. If no `thread_id` was captured, the
+   existing `--last` / fresh-review fallbacks apply unchanged.
+2. **Baseline.** Convergence verifies the **post-R2 restated list** (findings
+   each panelist still stood behind), not the raw R1 list. A finding its own
+   author dropped in R2 is not resurrected.
+3. **The `claude-alt` panelist cannot resume** — `Task` subagents are one-shot.
+   Its convergence round is a **fresh dispatch** whose brief restates its own
+   surviving findings and the new diff. Say so, or an implementer will hunt for
+   a resume API that does not exist.
+4. **Blocking.** Today "only an available, not-yet-clean Codex blocks". With N
+   panelists: **every live panelist blocks**, and a panelist dropped under §B.7
+   stops blocking the moment it is disclosed as dropped. A panelist that went
+   clean and then died does not un-clean the gate.
+
+#### B.2.4 What the author sees, and when
+
+Two UX consequences of inserting a round, both found by walking a simulated run
+rather than by reading the protocol.
+
+**Show R1 before R2 runs.** Blind-parallel plus cross-critique roughly doubles the
+silence before the author sees anything: 0.4.0 printed a tier list the moment A1
+returned. So the loop **posts the R1 findings as soon as they land**, clearly
+marked `proposed — not yet critiqued, none actionable`. The independence invariant
+constrains *panelists*, not the author: they cannot see each other's findings, but
+showing them to the human anchors nobody. Do not make the author wait through two
+rounds of silence to learn the loop is working.
+
+**Do not print the full record for findings the author never has to judge.** Five
+fields × seventeen findings is a wall, and a wall is where real T3 decisions go to
+die. So: an **auto-fixed finding gets one line** (claim, location, commit hash); a
+**`refuted` finding gets one line** plus who refuted it and why; the **full record —
+attribution, tier, confidence, falsification, status — is reserved for findings
+that need the author**: T2/T3, live disagreements, and anything that failed the
+§B.4 gate. Verbatim reviewer text (§B.8) is preserved in the journal regardless of
+what the round output elides.
+
+**`refuted-undefended` prints as a live disagreement, never as a one-liner.** It is
+both refuted and unresolved, and the two renderings collide. The tie goes to the
+author: a finding whose author never answered the attack is exactly the case where
+a one-line "refuted by X" hides the fact that nobody checked. This is a display
+rule, not an auto-fix rule — under §B.4 neither `proposed` nor `refuted` nor
+`refuted-undefended` was ever eligible, so nothing about eligibility was ever
+ambiguous. The ambiguity was only ever about **what the author gets to see**, which
+is the part that decides whether they can catch the facilitator.
+
+**Cost — and it is a real one, not a rounding error.** Before the first fix,
+Codex is called twice (R1 + R2) instead of once. Usage limits are a first-class
+outcome in this skill, so the true marginal cost of R2 is not "one more call" but
+**one fewer convergence round before the limit** — on a limit-bound day, R2 can
+turn a converging run into a degraded Claude-only tail. The claim that R2 pays
+for itself (false positives dying before they become a commit, a test, and a
+convergence round) is a **hypothesis, not a measurement**. §B.8's journal capture
+must therefore record R2's kill rate and rounds consumed, so open question 1 has
+data rather than taste to revisit on.
+
+### B.3 The finding record
+
+**Scope: §B.3 and §B.4 govern the local panel's findings only.** A forge reviewer
+is not a panelist (§B.11): it never enters R1 or R2, so its comments can never
+reach `survived`, and Copilot cannot be asked for a `confidence` or a
+falsification condition. Phase B therefore keeps 0.4.0's rule unchanged —
+`SKILL.md:53`, T1 auto-fixed, T2/T3 to the author. Applying the panel gate to
+Copilot's comments would silently revoke an auto-fix that works today, for no
+gain: the gate's purpose is to make a reviewer face an adversary, and there is no
+adversary to face after the local gate has already closed.
+
+Every finding **from a local panelist** carries:
+
+| Field | Rule |
+|-------|------|
+| `reviewer` | panelist id. Codex's text is quoted **verbatim**, never paraphrased into Claude's voice. |
+| `claim` | one sentence: what is wrong. |
+| `location` | `file:line`. |
+| `tier` | T1 / T2 / T3 — **cost and scope of the fix**, unchanged from today. |
+| `confidence` | high / medium / low — **whether the finding is true**. Orthogonal to tier; today the loop has no field for it. |
+| `falsification` | a concrete, checkable condition under which this finding is *not* a bug — e.g. "not a bug if `cfg` is non-null at every call site". |
+| `status` | see the ladder below |
+
+**The status ladder.** `refuted` had to be split: a finding whose author answered
+the attack and lost is settled; a finding whose author was never asked is not.
+
+| Status | Means | Auto-fix? | Shown as |
+|--------|-------|-----------|----------|
+| `proposed` | raised, not yet critiqued by anyone | never | R1 list |
+| `survived` | attacked in R2, and the attack failed | eligible (§B.4) | tier list |
+| `refuted` | attacked in R2, and its author **conceded or lost** | never | one line, with who and why |
+| `refuted-undefended` | attacked, but its author never answered — it was dropped mid-panel (§B.2.2), or R2 was merged so no defense round existed | never | **live disagreement**, surfaced to the author |
+| `reproduced` | a failing test (code) or a mechanically checkable citation (prose) — §B.5 | eligible (§B.4) | tier list |
+| `unreproduced` | a correctness finding nobody attempted to reproduce | never; withholds "gate clean" (§B.5) | tier list |
+
+`refuted-undefended` is the state that did not exist and had to. Without it, a
+one-sided attack on a dead panelist's finding looks identical to a settled
+refutation, and the facilitator — the party motivated to converge — gets to
+adjudicate on evidence only one side supplied. It is never silently dropped and
+never auto-fixed; it goes to the author as a disagreement the panel could not
+resolve.
+
+**A generic falsification condition is a missing one.** "If evidence emerges to
+the contrary" is calibration theater and is treated as absent (§B.4). A
+confidence number without a falsification condition means nothing: it does not
+say what observation would retract it.
+
+`tier` and `confidence` being different axes is the whole point — a T1 typo
+finding can be simply wrong, and today T1 findings are auto-fixed.
+
+**Who assigns `confidence`, and why it cannot be trusted alone.** The reviewer
+that raised the finding assigns it, because nobody else can. That is a
+self-assessment by the same weights that produced the finding — the very
+self-preference conflict of interest this spec's Motivation names. A confidently
+wrong model reports `high` and writes a plausible-sounding falsification string;
+checking that the field is *present* is not checking that anyone *evaluated* it.
+
+Therefore **`confidence` never authorizes anything on its own** (§B.4). Its job
+is to inform the author and to be *attacked* in R2. What authorizes an automatic
+fix is a finding having **survived an adversary** or having been **reproduced**.
+
+**The facilitator never imputes these fields.** A Codex finding from a native R1
+arrives with no `confidence` and no `falsification` (§B.2.1). Claude filling them
+in would be Claude judging whether Codex's finding is true and dressing the
+judgement as Codex's — facilitator capture (§B.8), and a violation of the verbatim
+rule. Codex attaches its own fields in R2, the round that carries a prompt. Until
+then the fields are simply absent, and absence blocks auto-fix rather than
+inviting a guess.
+
+### B.4 The auto-fix gate
+
+Auto-fix a finding without asking the author only when:
+
+```
+tier == T1  ∧  ( status == reproduced
+               ∨ (status == survived ∧ confidence == high ∧ falsification present) )
+```
+
+Two properties, both load-bearing:
+
+- **`survived`, not `!= refuted`.** A finding that no adversary ever examined
+  sits at `proposed`, which is trivially "not refuted". Gating on `proposed`
+  would let a single same-family reviewer grade its own finding `high` and
+  auto-commit it — the pre-014 failure mode with extra paperwork. `survived`
+  means the finding was put in front of another panelist and was not refuted.
+- **Reproduction outranks confidence.** A failing test demonstrating the finding
+  makes its confidence label moot, and needs no adversary.
+
+**Single-panelist runs (Claude-only) therefore auto-fix on `reproduced` only.**
+There is no R2, so nothing can reach `survived`. This is the honest consequence:
+a lone same-family reviewer has not earned the right to commit unsupervised.
+Everything else is surfaced with its confidence and falsification condition
+attached, and handled per the existing *Tiers* rules.
+
+The cost is that a real typo occasionally bounces back for a one-word
+confirmation. The benefit is that a false positive can no longer become a silent
+commit — the class of harm the loop exists to prevent.
+
+### B.5 Refute by reproduction
+
+The skill already mandates TDD for fixes. That rule is promoted from *how you
+fix* to *how a finding earns blocking status*:
+
+- **Executable target.** A correctness finding is `reproduced` once a failing
+  test demonstrates it. (Codex's `review` subcommand is read-only by construction
+  and cannot run a repro — reproduction is the facilitator's job, before the fix.)
+- **`unreproduced` does not silently vanish.** An `unreproduced` correctness
+  finding does not block *automatic* convergence, but it **withholds the "gate
+  clean" verdict**: the loop reports *"clean except N unreproduced correctness
+  findings"* and the author waives them explicitly. Without this, the facilitator
+  — the party motivated to converge — could converge past a real Codex finding
+  simply by never attempting a reproduction. That would be a new facilitator-capture
+  channel opened by the anti-capture spec, and it would quietly weaken today's
+  rule that an available, not-yet-clean Codex blocks.
+- **Prose target** (specs, plans, docs — a first-class target since 002). There
+  is nothing to run, so `reproduced` needs an analogue or the gate strands every
+  finding. Without one, §B.4 has a hole exactly where this skill dogfoods itself:
+  a Claude-only run against a spec reaches neither `survived` (no adversary) nor
+  `reproduced` (no test), so **not one finding is auto-fixable — every typo asks
+  the author**. More friction than 0.4.0, none of the added safety.
+
+  **A prose finding reaches `reproduced` only when the facilitator has run the
+  check.** Two conditions, both mechanical, both obligations rather than
+  capabilities:
+
+  1. **The citation is verified.** The reviewer supplies the quoted text and its
+     location; the facilitator confirms the quote occurs there — a `grep`, not a
+     reading. A fabricated or mis-located quotation is a known model failure, and
+     "a reader *can* check it" is capability, not a check. Nobody's word, including
+     a panelist's, promotes a finding to `reproduced`.
+  2. **The defect's fix is mechanically checkable.** A typo, a broken cross-
+     reference, a stale line number, a regex that does not match the file it claims
+     to guard: the fix either holds or does not, and a command says which.
+
+  "Line 152 already contains `confidence`, so this anchor passes against the
+  unmodified file" satisfies both — and did, three times, in this spec's own review
+  rounds. "This section contradicts §B.4" satisfies neither on its own: the quote
+  may exist while the contradiction is a matter of reading. **A citation plus the
+  reviewer's interpretation is model judgement wearing evidence's clothes**; it
+  goes to the author, where judgement belongs. This is the second principle applied
+  where it is least convenient — closing the loophole costs us the easy win.
+
+Cross-critique inherits the same standard: *"this fails on input X"*, not
+*"I doubt this"*.
+
+### B.6 Non-leading convergence
+
+Replace the 0.4.0 §A2 resume prompt. Today:
+
+> `I applied these fixes: <summary>. Are your earlier points resolved? Any new concerns?`
+
+This asks a reviewer to accept the author's own summary of the author's own
+fixes as evidence, and phrases the question so that "yes" is the cooperative
+answer. Instead, hand it the new diff and ask it to check the code:
+
+> The fixes are applied. For each point you raised, verify it **against the
+> code** and state resolved or unresolved, with the evidence you used. Do not
+> treat the author's description of the fix as evidence. Then state any new
+> concerns.
+
+Two sycophancy guards, both from the source skill's observed anti-patterns:
+
+- **Cross-critique (R2)** must demand effort without mandating a verdict. The
+  source skill's phrasing — *"you disagree with at least one central claim; find
+  it"* — manufactures a disagreement when the other panelist happens to be right,
+  and an invented refutation is worse than a missed one: it either inflates live
+  disagreements or kills a true finding. Ask instead: *"name the central claim you
+  tried hardest to break, and either break it or say why it held."* A round in
+  which nothing was refuted is a legitimate outcome; a round in which nothing was
+  **attacked** is the failed one.
+- **An unexplained full reversal** — a panelist abandoning a finding without a
+  reason, or conceding every attack — is a sycophancy flag. Ask that panelist
+  for the grounds before accepting the reversal. This ask is **one extra
+  panelist call**, and it is the single sanctioned exception to "cross-critique
+  is one round" (Non-goals). Budget it: it fires only on a detected reversal,
+  never routinely.
+
+**Undefended refutations are disagreements, not verdicts.** In the merged
+2-panelist R2 both panelists attack in parallel, so nobody answers the attacks on
+their *own* findings (that was the source skill's Round 3, which we folded away).
+A finding marked `refuted` on a critique its author never got to answer is
+**surfaced as a live disagreement**, not silently dropped — the facilitator
+adjudicating one-sided evidence is exactly the capture §B.8 forbids. With ≥ 3
+panelists the separate Round 3 runs and this caveat does not apply.
+
+### B.7 Ghost panelist: generalize the detector we already have
+
+A status line, an empty result, or an error dump is **not a contribution**. If
+one enters the record, Round 2 critiques thin air and the panel degrades
+silently.
+
+review-loop already implements the strongest version of this gate for one
+reviewer: the 0.4.0 §A2 post-round detector (a native Codex round with zero
+`command_execution` items never read the tree ⇒ non-review). Generalize the
+*rule*, keeping the strongest available evidence per panelist:
+
+- **Codex, native path:** the existing structural `command_execution` detector.
+  Unchanged. Embedded-diff rounds stay exempt (the diff is in the prompt).
+- **Every other panelist:** the return must be a substantive review — findings
+  or an explicit "no remaining problems". Re-run once on failure; on a second
+  failure, **drop the panelist, continue, and disclose** which panel actually
+  ran.
+- **External CLIs must run in the foreground** with a generous timeout (≈10 min).
+  A wrapper that backgrounds the call and returns early manufactures ghosts.
+
+### B.8 Facilitator capture
+
+The facilitator (the main session) frames, dispatches, validates, adjudicates,
+and fixes. It may not put its own arguments in a panelist's mouth.
+
+- Findings in the round output are **attributed** — `[codex]`, `[claude-sonnet]`
+  — and Codex's wording is preserved verbatim.
+- The facilitator's own observations go in a separate, explicitly labelled
+  **Facilitator** section. They are never counted as panel findings and never
+  gate anything.
+- Adjudications are recorded with their reason: which critique was accepted or
+  rejected, and why. This is the audit trail; it is also exactly what the
+  existing review-journal step wants (§ *Learning capture*), now available at
+  round time rather than reconstructed afterward. The journal additionally
+  records **R2's kill rate and rounds consumed**, so the §B.2.4 cost hypothesis
+  can be checked against reality.
+
+**Deduplication is the largest capture surface, and attribution alone does not
+close it.** With two reviewers on one diff, the facilitator must merge duplicate
+findings — and "these two are the same issue, I'll keep one phrasing" is the
+laundering the verbatim rule exists to stop. Rules:
+
+- A merged finding **retains both verbatim texts and both attributions**. It
+  never collapses into the facilitator's paraphrase.
+- **Distinguish a real duplicate from a taxonomy difference.** Two panelists
+  slicing one problem into different buckets are not agreeing; recording them as
+  one finding manufactures consensus.
+- Any **downgrade, merge, or dismissal of a tier-1 panelist's finding is surfaced
+  in the round output** with its reason. The facilitator may propose it; the
+  author sees it.
+
+§B.8 is honest about what it buys: attribution plus a mandatory surfacing rule
+is *structural* only for the tier-1 downgrade case. Tiering (T1/T2/T3) remains
+facilitator judgement, because scope-of-fix is not something a reviewer can
+assess for a repo it does not own.
+
+### B.9 Report the tier that actually ran
+
+"Local gate clean" is not one verdict. State the panel's composition and the
+evidential weight of its agreement:
+
+- **Heterogeneous** — at least one live tier-1 **CLI** panelist (Codex, or
+  another coding CLI) alongside Claude → convergence is meaningful evidence.
+- **User-asserted heterogeneity** — the only non-Claude panelist is a declared
+  endpoint (`trust: user-asserted`). Report it as such and **do not claim the
+  heterogeneous tier**. §A.4 warns that a local 7B model is noise rather than
+  decorrelation; a config file must not be able to upgrade the verdict that
+  warning exists to prevent.
+- **Same-family** — Claude subagent only, or Claude + a different Claude model →
+  *"gate clean at tier 2 — same-family panel, shared blind spots possible; this
+  is weak evidence."*
+- **Fresh-context only** — `claude-alt.model` turned out to equal the session
+  model (§A.6). The weakest verdict there is. Say it.
+
+Report the panel that **actually ran**, verified. "Verified" means the model
+actually *differed*, the CLI actually *ran a review*, the panelist actually
+*returned findings* — not that a config field was set to the intended value, and
+not the panel the config described. Where the composition changed mid-run (§B.2.2),
+report it **per round** rather than by its best round.
+
+**Verifying `claude-alt` needs a mechanism, or "verified" is a word.** A `model`
+parameter can be ignored or silently substituted, and the skill has no way to
+observe what a `Task` dispatch actually ran. So the R1 brief requires the subagent
+to **state its own model id in the first line of its review record**, and the
+facilitator compares that against both the requested model and the session model:
+
+- Echo matches the requested model, and it differs from the session's → **tier 2**.
+- Echo equals the session model → **fresh-context only** (§A.6), whatever the
+  config asked for.
+- No echo, or a model the session could not dispatch (the dispatch errors, or
+  returns under a substitute) → **fresh-context only**, and say why.
+
+A self-reported model id is itself a model's claim, and a weak one. It is what the
+tool permits; the alternative is asserting a tier from a config field, which is
+strictly worse. Where a check is weak, report the verdict it supports and no
+stronger — that is the second principle's whole content.
+
+### B.10 Degradation
+
+- **Only Claude available** → single reviewer, no cross-critique, and the
+  same-family caveat in §B.9. This is today's Claude-only fallback, now labelled
+  honestly.
+- **≥ 2 Claude panelists, no external CLI** → force **method-level divergence**,
+  not tone: one reviews from first principles, one from base rates ("what
+  usually breaks in changes shaped like this"), one hunts only for disconfirming
+  evidence. A role name ("Red Team") does not decorrelate errors; a different
+  method or an actual reproduction does. Reachable two ways, both legal: several
+  `kind: claude-model` entries (§A.5), or one enrollment the facilitator
+  dispatches under several method briefs. The gate verdict stays **same-family**
+  either way — method divergence buys cross-critique, not decorrelated weights.
+- **A panelist fails twice** → drop, continue, disclose (§B.2.2 governs findings
+  it already contributed).
+
+### B.11 Phase B is a forge slot, not a Copilot phase
+
+Phase B in 0.4.0 is titled "GitHub Copilot" and its every step names `gh`. Retitle
+it **"Forge reviewer (only when one is enrolled and the target is a PR/MR)"** and
+rewrite its steps against the three operations of §A.4 — *request*, *poll*,
+*recognize a clean pass*. GitHub Copilot becomes the `adapter: builtin` binding of
+those operations to `scripts/copilot.sh` and `scripts/pr-comments.sh`; the existing
+B0–B5 behavior (including the first-review 422 caveat and the repeat-comment guard)
+is preserved **verbatim as that adapter's implementation**, not as the loop's
+definition of Phase B.
+
+Consequences worth stating, because they are the point of the exercise:
+
+- **No forge reviewer enrolled → Phase B is skipped**, silently and correctly. The
+  local panel gate is the whole loop. This is already true for non-GitHub forges
+  today, but by accident rather than by design.
+- **A forge reviewer is not a panelist.** It does not participate in R1's blind
+  round or R2's cross-critique — it cannot, since it only exists once a PR is open.
+  It reviews after the local gate is clean, exactly as Copilot does now.
+- **A declared reviewer with no unambiguous clean signal never gets one invented
+  for it** (§A.4). The loop polls, surfaces, and asks the author. Inventing a stop
+  regex for a bot we have never watched is how a false clean is manufactured.
+- **We ship one adapter because we can run one adapter.** Other forges have review
+  agents; naming them here without an account to test against would put a
+  ghost reviewer (§B.7) in the skill's own roster documentation.
+
+### B.12 Covering the native branch without owning a native host
+
+The author's Linux host routes Codex to the embedded-diff form. **This is not a
+problem to be fixed.** The agent calls `codex`; embedding the diff is the tool we
+built for exactly this host, and it works. A `broken` preflight is a *configuration*,
+not an incident, and the loop never announces it (§A.3).
+
+There is a real, narrow consequence and it is about **testing, not running**: R2 via
+`resume "$thread_id" -` and its detector exemption would never once execute on the
+machine where they are written.
+
+**The coverage comes from a fixture, not from the author's kernel.** The detector is
+a real `jq` predicate over `codex --json`'s event stream, so a recorded stream tests
+it deterministically, with no sandbox involved:
+
+| Fixture | `command_execution` items | Correct classification |
+|---------|---------------------------|------------------------|
+| a native `review` round the sandbox blocked | 0 | **non-review** → retry embedded, never a silent clean |
+| a native `review` round that read the tree | ≥ 1 | review |
+| an **R2 critique** round arguing from session context | 0 | **review** — exempt (§B.2.1) |
+
+That third row is the whole exemption, and it is checkable without ever holding a
+`usable` sandbox. (Empirically it is also the rare case: this spec's own R2 ran five
+`command_execution` items, because refuting by reproduction means opening the file at
+the cited line.)
+
+Two consequences, neither of which is a gate on a human:
+
+1. **Restoring the native path is separate work.** It means changing the host's
+   AppArmor/sysctl policy (§A.3) — `sudo`, system-wide, every `bwrap` caller. `init`
+   may point at the reference; the author may then do it as its own task. It is not a
+   prerequisite for this spec, the implementation does not require it, the plan does
+   not schedule it, and its absence is not a defect. The fixture is the coverage.
+2. **What the fixture does not cover, the release notes disclose.** It exercises the
+   predicate and the routing decision; it does not prove `codex exec resume` behaves
+   as documented against a live `usable` sandbox. Shipping a branch nobody has watched
+   run is how spec 009's false clean shipped. Disclose the residue; do not imply
+   coverage you lack.
+
+### B.13 Files (Part B)
+
+- `plugins/review-loop/skills/review-loop/SKILL.md` — Phase A restructured
+  (§B.2); panelist invocation forms and the standalone brief (§B.2.1); mid-panel
+  death (§B.2.2); A4's thread/baseline/blocking rules (§B.2.3); the finding
+  record (§B.3) folded into *Tiers*; the auto-fix gate (§B.4); the convergence
+  prompt replaced (§B.6, 0.4.0 §A2 "Convergence rounds"); the ghost gate generalized
+  (§B.7); a *Facilitator* discipline subsection (§B.8); *Exit conditions* reports
+  the tier (§B.9).
+
+  **One existing mechanism does change: the `command_execution` detector gains an
+  exemption for R2 critique rounds** (§B.2.1). Sandbox routing, the embedded-diff
+  form, the sticky-embedded rule, exit-code triage, the Copilot phase and the
+  never-merge rule are untouched. An earlier draft of this spec claimed the
+  detector was untouched too; that was false — a critique round reads no files by
+  design, so an unmodified detector would fire on every healthy R2 and, via the
+  sticky-embedded rule, permanently demote a `usable` host.
+- `plugins/review-loop/skills/review-loop/references/why-adversarial.md` —
+  **new.** The rationale (decorrelation, verification advantage, GAN lineage,
+  the five observed anti-patterns) and credit to `makinux/adversarial-panel`
+  (MIT). Rationale belongs in a reference file; SKILL.md carries only what the
+  agent must execute.
+- `plugins/review-loop/commands/review-loop.md` — invariant lines: blind
+  round 1, cross-critique, never auto-fixes a low-confidence finding.
+- `.claude-plugin/marketplace.json` — `review-loop` → `0.5.0`.
+- `tools/review-loop/test-skill-content.sh` — new anchors (§ Testing).
+
+## Open questions
+
+Each carries a recommendation; they are the parts most worth arguing with.
+
+1. **A `quick` escape hatch?** A `/review-loop <target> quick` argument that
+   skips cross-critique for small diffs. *Recommendation: no, not yet.* The
+   source skill's Round-0 triage is run by the same model whose blind spots the
+   panel exists to catch — "you're confidently wrong exactly where the gate
+   won't open." review-loop is already explicitly invoked, so the user's
+   decision to run it *is* the triage. Revisit if R2 proves slow in practice.
+2. **Should `init` pick the `claude-alt` model automatically** (read the session
+   model, dispatch the subagent under a different one) rather than storing it?
+   *Recommendation: store it.* Auto-picking hides which panel ran, and §B.9
+   requires reporting the model actually set.
+3. **Is the project-level override (`<project>/.claude/review-loop.local.md`)
+   needed in 0.5.0?** Reviewer availability is a host fact. *Recommendation:
+   specify it, implement it second* — the plausible per-project need ("a clean
+   gate here requires Codex") is a policy statement that could equally live in
+   the repo's own `CLAUDE.md`.
+4. **Does the auto-fix gate bounce too much?** §B.4 now requires `survived` —
+   so on a Claude-only host, *every* T1 typo without a reproduction goes to the
+   author. That is the honest position, and it may also be an annoying one.
+   *Recommendation: ship it strict, measure via the review journal, loosen with
+   evidence.* The cheapest loosening, if needed: let a Claude-only run reach
+   `survived` by dispatching a second, method-divergent Claude panelist (§B.10)
+   rather than by weakening the gate.
+5. **Should `init` ever read the `chat-subagent` registry** to offer its aliases
+   as candidates? It would be one file read, no network. *Recommendation: no.*
+   The author's constraint is that `init` probes CLI presence and takes
+   everything else on request; an endpoint is named when it is wanted. Reading
+   another plugin's config also couples two independently-installable plugins.
+
+6. ~~**Split Part A and Part B into two specs / two versions?**~~ **Resolved: no
+   split** (author, 2026-07-10). Both parts ship as `0.5.0` under one spec, as
+   spec 010 did with its two parts. Fable 5's argument for splitting — one-way
+   dependency, and a Part B revert would drag a working roster out with it — is
+   sound but was outweighed: the two parts share one motivation, and the roster
+   exists *because* Part B needs to know which panel actually ran. The residual
+   risk is recorded rather than dismissed: if §B.2.1's native branch proves
+   unworkable, Part B is reverted by disabling cross-critique (a one-panelist run
+   is a legal configuration, §B.10), **not** by reverting the roster.
+
+## Non-goals
+
+- **Not a debate machine.** With the default 2-panelist panel, cross-critique is
+  **one round**. Two sanctioned additions, both bounded: a separate Round 3 when
+  **≥ 3 panelists** are live (§B.2), and the reversal-grounds ask (§B.6), which
+  fires only on a detected unexplained reversal. Panelist disagreement about
+  executable code is settled by a test (§B.1), not by more rounds.
+- **Not Round-0 triage.** The user invoking `/review-loop` is the triage.
+  (The triage-trap lesson — don't let the model's felt confidence decide whether
+  review happens — applies to the *user's* `CLAUDE.md` "default is inline" rule,
+  which is out of scope here.)
+- **Not autonomous.** The author still decides T2/T3 fixes and the merge.
+  Cross-critique adjudication that ends in a live disagreement is **surfaced**,
+  not resolved by the facilitator's preference.
+- **`init` is not a discovery engine.** Its *probe* is coding-CLI presence and
+  nothing else — no network, no credentials, no scanning of other plugins' or
+  repos' config. It *verifies invocation* by calling the CLIs it found (§A.3),
+  and takes everything else from the user (§A.1).
+- **Not a second endpoint registry.** Endpoints and keys stay in
+  `chat-subagent`'s files; review-loop stores a name (§A.4).
+- **`init` is not a precondition.** The zero-config loop keeps working (§A.7).
+- **Not an inventory of forge review agents.** Other forges have them. This spec
+  names none, ships none, and infers no clean-pass signal for one it has never
+  watched run (§A.4, §B.11). It ships the slot and one tested adapter.
+- **Not a claim that the native R2 path is tested.** It cannot be, on the host
+  where it is written (§B.12).
+- **Not changing** the sandbox routing, the embedded-diff form, the
+  `command_execution` **detector's jq predicate**, exit-code triage, the Copilot
+  adapter's behavior, or the never-merge rule. Two things in this list *do* change
+  and are named here so no one can satisfy this bullet by ignoring them: the
+  detector's **scope** gains an R2-critique exemption (§B.2.1), and Phase B's
+  *framing* becomes a forge slot while its Copilot behavior is preserved verbatim
+  (§B.11).
+- **Not changing** the targeted `review --base` form itself. But note where it ends up:
+  R1 becomes freeform (it must carry the record format, §B.2.1), R2 and A4 both
+  `resume "$thread_id" -`, and the fresh-native fallback is freeform too. So the
+  targeted form's only remaining home is **B3**, where Codex re-reviews pushed commits
+  and needs no prompt. An earlier draft of this bullet claimed convergence kept the
+  targeted form; convergence has always used `resume`. The implementation caught it.
+
+## Testing
+
+`SKILL.md` and the command docs are prose. Guard them with content anchors, and
+give the one new script a real test.
+
+**`tools/review-loop/test-skill-content.sh`** — extend. The harness has `need` and
+`refute`. Add a third helper, because the failure this spec keeps committing is not
+a wrong regex — it is a regex nobody ran against the old file:
+
+```bash
+# $1=regex, $2=description — must MATCH the new SKILL.md and NOT match the
+# pre-change one. An anchor that already passes guards nothing.
+need_new() {
+  grep -Eq "$1" "$SKILL" || fail "SKILL.md missing: $2"
+  if git -C "$REPO" show "$BASE_REF:$SKILL_REL" 2>/dev/null | grep -Eq "$1"; then
+    fail "vacuous anchor (already present before the change): $2"
+  fi
+  pass "$2"
+}
+```
+
+`BASE_REF` defaults to the merge-base with the default branch. **Three anchors
+proposed across this spec's own review rounds were vacuous** — `need 'confidence'`
+(SKILL.md:152 has "a bare `confidence is low`"), `need 'invocation'`
+(SKILL.md:119 has "a `review` invocation"), and `refute '^## Phase B — GitHub
+Copilot'` (the heading is `###`, so the regex never matched and the refute always
+passed). Every one was proposed by a model that had not run `grep` against the file
+it was making a claim about. `need_new` makes the mistake unrepeatable, which is
+worth more than the three corrected regexes.
+
+Anchors for **new** behavior use `need_new`; anchors guarding **pre-existing**
+behavior against regression keep plain `need`, since they must pass on both files.
+
+- `need_new 'blind'`, `need_new 'cross-critique'` — Phase A restructure.
+- `refute 'Are your earlier points resolved'` — the leading convergence prompt is
+  gone. (`refute` needs no novelty check: it asserts absence from the new file.)
+- `need_new 'falsification condition'` — the finding record. Not `'confidence'`.
+- `need_new 'refuted-undefended'` — the status that had to exist (§B.3).
+- `need_new 'survived'` — the gate turns on `survived`, not `!= refuted`.
+- `need_new 'weak evidence'` — same-family gate caveat.
+- `need_new 'critique rounds are.*exempt'` — the R2 detector exemption.
+- `need_new 'review-loop\.local\.md'`, `need_new 'Roster reconciliation'` — roster wiring.
+- `need_new 'forge reviewer'` and `refute '^### Phase B — GitHub Copilot'` — Phase B
+  is a slot, not a Copilot phase. Note the **three** hashes: SKILL.md:177 is an h3,
+  and the two-hash regex proposed earlier could never have matched.
+- `need_new 'invocation\.command'` — the learned recipe. Not bare `'invocation'`.
+- `need_new 'facilitator confirms the quote'` — prose `reproduced` is a check the
+  facilitator runs, not a capability the reviewer asserts (§B.5).
+- `need 'verbatim'` — pre-existing word, but the facilitator-capture rule is new;
+  anchor it on a phrase unique to that rule instead, e.g.
+  `need_new 'retain both verbatim texts'`.
+- Preserve every existing anchor (sandbox routing, detector predicate,
+  embedded-diff exemption, watch gate, group-commits offer). Only the detector's
+  *scope* changes; its jq predicate does not, so its anchor must still pass.
+
+**The harness only greps `SKILL.md`** (`SKILL=…/SKILL.md`), so the invariant lines
+this spec adds to `commands/review-loop.md` and `commands/init.md` are unguarded.
+Either parameterize the harness over a file list, or drop the claim that anchors
+cover the command docs. Do not leave it implied.
+
+**`tools/review-loop/test-detector-predicate.sh`** — new, with recorded
+`codex --json` fixtures under `tools/review-loop/fixtures/`. This is the one thing here
+worth materializing (§ "materialize critical knowledge only"), because the R2 detector
+exemption never executes on a host whose sandbox routes to embedded-diff (§B.12), and
+because the predicate has already been mis-transcribed once.
+
+- A native `review` round with **zero** `command_execution` items → **non-review**
+  (retry embedded; never a silent clean). Fixture also carries the corroborating text
+  marker.
+- A native `review` round with `command_execution` items → review.
+- An **R2 critique** round with zero `command_execution` items → **review (exempt)**.
+  This row is the exemption, and it is checkable with no sandbox at all.
+- The suite must be shown to *fail* when the exemption is removed. A test that cannot
+  fail is not a test.
+
+There is **no** `test-panel-detect.sh`, because there is no `panel-detect.sh` (§A.2).
+
+**Manual verification:**
+
+- `/review-loop:init` on a host with only `codex` → enrolls `codex`, asks which
+  model the `claude-alt` subagent should use, offers nothing else, writes
+  `~/.claude/review-loop.local.md`.
+- Re-running `init` → prints a no-op diff, preserves an `enabled: false` opt-out
+  and any user-declared endpoint.
+- Delete the config → the loop fields **the same roster** as 0.4.0 (Claude subagent
+  + Codex if present + forge reviewer for PR targets) and hints at `init` once. It
+  still runs the Part B protocol, because Part B is gated on panelist liveness, not
+  on a config file (§A.7). "Exactly as 0.4.0" would be the wrong assertion: 0.4.0 is
+  serial (`0.4.0 §A1` → fix → `0.4.0 §A2`), and this is not.
+- Zero config, `codex` present → panel runs blind-parallel, gate reports
+  **fresh-context only** (no `claude-alt.model`, so the subagent runs on the session
+  model) alongside the tier-1 CLI. Enrolling one model upgrades it to tier 2.
+- Enrolled `codex` removed from `PATH` → loop degrades, says so, and reports the
+  gate as same-family/weak.
+- `codex` present but not enrolled → one note pointing at `/review-loop:init`;
+  no auto-enrollment.
+- A diff with one real bug and one plausible-but-wrong finding → the wrong one
+  is refuted in cross-critique and never reaches a commit.
+- A Claude-only run → no cross-critique, and the clean verdict is labelled weak
+  evidence.
+
+## Acceptance criteria
+
+- [ ] `/review-loop:init` exists, is idempotent, re-probes on every run, prints a
+      diff of changes, and preserves explicit opt-outs and user-declared entries.
+- [ ] `init`'s **probe** is coding-CLI presence only — no network call, no
+      credential read, no other plugin's config. Endpoints and forge reviewers are
+      recorded only when the user names one.
+- [ ] `init` **verifies invocation by calling** each enrolled CLI once on a
+      throwaway target, bounded to two attempts, and stores the literal command
+      line that worked. A CLI whose invocation cannot be established is **detected
+      but not enrolled**, with the reason shown.
+- [ ] A stored `invocation` recipe never suppresses the preflight or the
+      `command_execution` detector; recipe drift is surfaced with a re-init hint.
+- [ ] Phase B is titled for the **enrolled forge reviewer**, skips silently when
+      none is enrolled, and preserves the existing Copilot behavior as the one
+      built-in adapter. A declared reviewer without a `clean_when` signal causes
+      the loop to surface comments and ask, never to invent a stop condition.
+- [ ] A prose finding that **cites the passage it contradicts** counts as
+      `reproduced`; a Claude-only run against a spec can therefore auto-fix a typo
+      without asking, while "this is unclear" still goes to the author.
+- [ ] R1 findings are shown to the author, marked `proposed`, before R2 runs.
+      Auto-fixed and refuted findings print as one line; the full five-field record
+      is reserved for findings the author must judge.
+- [ ] The presence probe is inline prose, not a shipped script, and names `gh` among
+      its candidates.
+- [ ] Config resolves project-over-global at `.claude/review-loop.local.md`,
+      references endpoints by name only, and carries a `review-loop-config`
+      schema stamp.
+- [ ] With no config, the loop fields the **same roster** as 0.4.0 and hints at
+      `init` once. (It runs the Part B protocol, which is gated on panelist
+      liveness, not on a config file — a zero-config host with `codex` has two
+      live panelists and therefore cross-critiques.)
+- [ ] Enrolled-but-absent and present-but-unenrolled drift are each handled per
+      §A.6 — surfaced, never silently followed.
+- [ ] `claude-alt.model` equal to the session model is detected and reported as
+      **fresh-context only**, not as tier 2.
+- [ ] Round 1 runs every live panelist **blind and in parallel against the same
+      unfixed diff**; no panelist sees another's findings. The Claude subagent's
+      brief is self-contained and specified in `SKILL.md`, not improvised.
+- [ ] Round 2 cross-critique runs whenever ≥ 2 panelists are live, reaches Codex
+      via `resume "$thread_id" -` (native) or a fresh embedded call, and each
+      panelist receives the others' findings verbatim.
+- [ ] R2 critique rounds are **exempt** from the `command_execution` detector; a
+      healthy R2 on a `usable` host never routes the run to embedded-diff.
+- [ ] Codex's R1 uses a **prompt-bearing** form on every host — freeform native
+      (`review -`) or embedded — so its findings carry `confidence` and
+      `falsification` from R1. The facilitator **never** imputes those fields.
+- [ ] R2's dispatch is specified for every panelist kind: Codex resumes;
+      `claude-alt` is a **fresh** subagent (one-shot `Task`, no resume) given its own
+      R1 findings back; other CLIs and endpoints get a fresh call carrying the diff
+      and the other findings.
+- [ ] A finding is `refuted-undefended` — surfaced as a live disagreement, never
+      auto-fixed, never silently dropped — whenever its author could not answer the
+      attack.
+- [ ] A prose finding reaches `reproduced` only after the **facilitator verifies the
+      citation with a command** and the fix is mechanically checkable. A quote plus
+      the reviewer's interpretation does not qualify.
+- [ ] `§B.3`/`§B.4` govern local-panel findings only; Phase B keeps 0.4.0's
+      T1-auto-fix rule for forge-reviewer comments.
+- [ ] The gate reports **fresh-context only** when the subagent's echoed model id
+      equals the session model, is absent, or the requested model was not
+      dispatchable.
+- [ ] The loop's start-up reconciliation asks presence only; `<cli> --version` runs
+      during `init` alone, so a review never spawns a subprocess per CLI.
+- [ ] `test-skill-content.sh` gains `need_new`, and every anchor guarding new
+      behavior uses it. The suite **fails** if an anchor already matches the
+      pre-change `SKILL.md`.
+- [ ] Auto-fix fires only under the §B.4 gate — `reproduced`, or `survived` +
+      high confidence + a concrete falsification condition. A Claude-only run
+      auto-fixes on `reproduced` alone.
+- [ ] An `unreproduced` correctness finding withholds the "gate clean" verdict
+      until the author waives it.
+- [ ] A panelist that dies between R1 and R2 leaves its findings at `proposed`
+      (surfaced, never auto-fixed), and §B.9 reports the panel **per round**.
+- [ ] A `refuted` verdict on a finding its author never answered is surfaced as a
+      live disagreement, not silently dropped.
+- [ ] Merged duplicate findings retain both verbatim texts and both attributions;
+      any downgrade of a tier-1 panelist's finding is surfaced.
+- [ ] The convergence prompt does not ask the reviewer to accept the author's fix
+      summary as evidence.
+- [ ] A non-substantive panelist return is re-run once, then dropped with
+      disclosure; the Codex detector's jq predicate is unchanged (only its scope
+      gains the R2 exemption).
+- [ ] The facilitator's own observations appear only under a labelled
+      *Facilitator* section and never gate the loop.
+- [ ] The gate verdict names the panel that actually ran, labels same-family
+      convergence as weak evidence, and never lets a `trust: user-asserted`
+      endpoint buy the heterogeneous tier.
+- [ ] `tools/review-loop/test-skill-content.sh` and `tools/review-loop/test-detector-predicate.sh`
+      both pass; all pre-existing anchors still pass. No anchor is vacuous — the harness
+      itself fails any anchor that already matches the unmodified 0.4.0 `SKILL.md`.
+- [ ] The R2 detector exemption is covered by fixtures, and the suite is demonstrated to
+      go red when the exemption is removed.
+- [ ] `review-loop` version bumped to 0.5.0 in `.claude-plugin/marketplace.json`.

--- a/docs/superpowers/specs/014-review-loop-adversarial-panel-design.md
+++ b/docs/superpowers/specs/014-review-loop-adversarial-panel-design.md
@@ -658,7 +658,8 @@ review` is not a chat interface.
   independence). A freeform Codex infers its target, and an inference is not a
   guarantee. Do not trust it — check it:
 
-  - The R1 prompt names the exact range, `<base>..<head-sha>`, not "this branch".
+  - The R1 prompt names the exact range, `<base>...<head-sha>` — **three dots, the same
+    range the check below runs**; a two-dot range differs the moment the base advances.
   - The prompt requires the review to **state the commit range and the file list it
     actually reviewed**, as its first line.
   - The facilitator compares that against `git diff --name-only <base>...<head>`. A

--- a/plugins/review-loop/.claude-plugin/plugin.json
+++ b/plugins/review-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "review-loop",
-  "description": "Assisted multi-reviewer convergence loop — local Claude + Codex gate first, then GitHub Copilot for PRs; tiers comments, auto-fixes mechanical ones, never merges autonomously",
+  "description": "Assisted adversarial review panel — reviewers answer blind, attack each other's findings, then converge; enrolled roster via /review-loop:init; never merges autonomously",
   "author": {
     "name": "caasi"
   },

--- a/plugins/review-loop/commands/init.md
+++ b/plugins/review-loop/commands/init.md
@@ -1,0 +1,47 @@
+---
+description: Discover which coding CLIs this host has, verify how to call each one by actually calling it, and record the enrolled reviewer roster — idempotent; re-run whenever the host changes
+---
+
+# /review-loop:init
+
+Invoke the `review-loop` skill and run the **init** routine. Pass `$ARGUMENTS`
+through as free-form context.
+
+**Usage:** `/review-loop:init`
+
+Load-bearing invariants the skill enforces:
+
+- **Probes presence, verifies invocation, asks for the rest.** The probe is a
+  `command -v` sweep plus `<cli> --version` — no script, no network, no credentials,
+  no other plugin's config. Everything it cannot probe is asked, not guessed.
+- **Verifies by trying.** Knowing `codex` exists tells you nothing about how to
+  drive it. `init` calls each enrolled CLI once, on a **throwaway fixture diff —
+  never your real working tree** — and stores the literal command line that worked
+  in `invocation.command`. Bounded to two attempts per CLI. A CLI whose invocation
+  cannot be established is **detected but not enrolled**, with the reason shown.
+- **Never asks for `sudo`, and never fixes your host.** If Codex's native sandbox is
+  blocked, `init` records `form: embedded` — a fully supported path — and may point
+  once at `references/codex-sandbox-host-fixes.md`. Restoring the native path is an
+  AppArmor/sysctl change affecting every `bwrap` caller on the machine: **separate
+  work, in its own session, which you own.** review-loop never gates on it, never
+  blocks for it, and never re-raises it.
+- **Presence is not authentication, and Copilot is not enrollable.** The built-in
+  GitHub Copilot adapter needs **no enrollment**: it runs for PR targets whenever `gh` is
+  authenticated **and `jq` is present**, unless you opt out. `init` checks `gh auth status`
+  *and* `command -v jq` so it can tell you whether Phase B will reach Copilot — it writes no
+  Copilot enrollment record. Enrollment
+  is for a *declared* reviewer on another forge.
+- **Endpoints are declared, never discovered.** `init` does not go looking through
+  other plugins' registries. Name one and it records the name — url and
+  `api_key_env` stay in `chat-subagent`'s files. **No secrets are ever written.**
+- **Idempotent, and it stamps its schema.** The config carries a `review-loop-config`
+  stamp. `init` writes it, and on re-run migrates an older one — removing the stale
+  stamp rather than leaving both behind. Re-running re-probes, prints a diff of what
+  changed, and preserves explicit opt-outs (`enabled: false` is a decision, not an
+  absence), declared endpoints, and forge reviewers.
+- **Never a precondition.** With no config the loop works exactly as it does today
+  and hints at `init` once.
+
+Writes `~/.claude/review-loop.local.md` (global), overridden per project by
+`<project-root>/.claude/review-loop.local.md`. Offers to add `.claude/*.local.md`
+to `.gitignore` if absent.

--- a/plugins/review-loop/commands/review-loop.md
+++ b/plugins/review-loop/commands/review-loop.md
@@ -1,5 +1,5 @@
 ---
-description: Run the assisted multi-reviewer review loop (local Claude + Codex gate, then Copilot for PRs)
+description: Run the assisted adversarial review panel — local reviewers answer blind on the same unfixed diff, then attack each other's findings; a forge reviewer follows for PR/MR targets; never merges autonomously
 argument-hint: "[PR-number | branch | (blank = current branch vs base)]"
 ---
 
@@ -11,7 +11,7 @@ Run the `review-loop` skill against a target.
 
 - `/review-loop` — review the current branch versus its base (local diff target).
 - `/review-loop <branch>` — review the given branch versus its base.
-- `/review-loop <PR-number>` — review an open GitHub PR (adds the Copilot phase).
+- `/review-loop <PR-number>` — review an open GitHub PR (adds the forge reviewer; GitHub Copilot is the built-in adapter and needs no enrollment).
 - append `watch` (e.g. `/review-loop watch`, `/review-loop 46 watch`) — open a live spectator pane for the Codex review; **requires a tmux session**. A lone `watch` token is the watch request against the default target, not a branch named `watch`.
 
 **Target:**
@@ -25,11 +25,22 @@ accuracy; TDD / one-commit-per-item discipline applies only to executable change
 Invoke the `review-loop` skill. Load-bearing invariants the skill enforces:
 
 - **Local gate first** — a Claude subagent always reviews; Codex (headless
-  `codex exec review`) joins when `codex` is on `PATH`; tmux is optional and
+  `codex exec --json --sandbox read-only review -`) joins when `codex` is live; tmux is optional and
   opens a live-watch pane **only when you ask** (the `watch` arg or an
   in-conversation request), never by default. The local gate must be clean
   before any GitHub PR is opened.
-- **Copilot is GitHub-only** — requested only for PR targets, after the local gate.
+- **Blind round 1, then one cross-critique round** — every live panelist reviews the
+  same unfixed diff without seeing the others, then attacks their findings. Never
+  auto-fixes a panelist's finding unless it was **reproduced**, or **survived** an adversary
+  with high confidence and a concrete falsification condition. A finding that was attacked and
+  not defended (`refuted-undefended`) faced an adversary and is still never auto-fixed.
+- **The built-in forge reviewer needs no enrollment** — GitHub Copilot is requested for
+  PR targets after the local gate, whenever `gh` is authenticated **and `jq` is present**,
+  unless you opt out.
+  Enrollment adds a *declared* reviewer for another forge. With none available, Phase B
+  is skipped.
+- **`/review-loop:init`** — optional; discovers which coding CLIs this host has and
+  verifies how to call each one by actually calling it.
 - **Never merges autonomously** — the author decides T2/T3 fixes and the final
   merge. Default to a merge commit to preserve history.
 - **After convergence** — offers to group the review fixup commits; never

--- a/plugins/review-loop/skills/review-loop/README.md
+++ b/plugins/review-loop/skills/review-loop/README.md
@@ -1,8 +1,9 @@
 # review-loop
 
-An assisted (not autonomous) multi-reviewer convergence loop for changes — code or
-design artifacts (specs, plans, docs). It runs local reviewers first and only then
-reaches for GitHub Copilot, and it never merges on its own.
+An assisted (not autonomous) adversarial review panel for changes — code or design
+artifacts (specs, plans, docs). Local reviewers answer blind on the same unfixed diff,
+then attack each other's findings. Only once that gate is clean does it reach for the
+forge reviewer (GitHub Copilot is the built-in adapter). It never merges on its own.
 
 ## What this is
 
@@ -12,12 +13,22 @@ architectural ones. The point of the local-first ordering: Claude and Codex
 reviewing **together** catch different classes of issues and tighten the diff before
 it ever reaches GitHub, so Copilot has much less to flag and rounds converge faster.
 
-## Reviewer roster (in priority order)
+## Reviewer roster (by heterogeneity)
 
-1. **Claude subagent** — always; needs nothing extra.
-2. **Codex** (headless `codex exec review`) — when `codex` is on `PATH`; tmux
-   opens a live-watch pane only when you ask (never by default).
-3. **GitHub Copilot** — only for GitHub PR targets, after the local gate is clean.
+Decorrelated error modes are the only reason a second reviewer catches what the first
+missed, so panelists are ranked by how different they are — not by how good they are.
+
+1. **Tier 1 — a different model family**, actually called: `codex`, another enrolled
+   coding CLI, or a user-declared endpoint (always `trust: user-asserted`, and never
+   counted as heterogeneous evidence).
+2. **Tier 2 — a different Claude model**, pinned by `/review-loop:init`. Same family,
+   so agreement here is *weak* evidence and the gate says so.
+3. **Fresh-context only** — a Claude subagent on the session's own model. What a
+   zero-config host gets. The weakest verdict there is.
+
+Panelists answer **blind and in parallel** on the same unfixed diff, then attack each
+other's findings. A **forge reviewer** (Phase B) is not a panelist: it appears only once
+a PR/MR exists. GitHub Copilot is the one built-in adapter.
 
 ## Requirements
 
@@ -25,11 +36,16 @@ it ever reaches GitHub, so Copilot has much less to flag and rounds converge fas
 - **Codex (optional):** the `codex` CLI on `PATH` (tmux optional — opens a
   live-watch pane only when you ask). `jq` is used to read the resume `thread_id` from `codex`'s
   `--json` stream; without it, Codex resume falls back to `--last`.
-- **Copilot phase (optional):** an authenticated `gh` CLI and `jq`; GitHub PRs only.
+- **Forge reviewer (optional):** the built-in adapter is GitHub Copilot — an authenticated
+  `gh` CLI and `jq`, GitHub PRs only, and **no enrollment needed**. Another forge's reviewer
+  is reachable by declaring it and its three commands.
 
 ## Tiers
 
-- **T1 mechanical** — typos, lint, null checks, doc fixes — auto-fixed.
+- **T1 mechanical** — typos, lint, null checks, doc fixes. Auto-fixed **only through the
+  gate**: a local panelist's T1 finding needs `reproduced`, or `survived` an adversary with
+  high confidence and a concrete falsification condition. A forge reviewer's T1 comment is
+  auto-fixed on its own merits — it never faced a panel.
 - **T2 local refactor** — extraction, naming, validation — resolved with you first.
 - **T3 architectural** — module moves, API shape, "should this exist" — your call.
 
@@ -54,5 +70,26 @@ Or the slash command:
 
 - Not autonomous — you decide T2/T3 fixes and the final merge.
 - Not a squash-merge tool — defaults to a merge commit to preserve history.
-- The Copilot path is GitHub-only; on other forges the local Claude + Codex gate
-  still applies.
+- The **built-in** forge adapter is GitHub-only (it uses `gh` + GitHub GraphQL). Other
+  forges are reachable by declaring a reviewer and its three commands; none ships. With
+  no forge reviewer available, the local panel is the whole loop.
+
+## `/review-loop:init` (optional)
+
+Discovers which coding CLIs this host has, works out **how to call each one by
+actually calling it**, and records the result in `~/.claude/review-loop.local.md`
+(project override: `<project-root>/.claude/review-loop.local.md`). Re-run it
+whenever the host changes; it is idempotent and preserves your opt-outs.
+
+It never writes a secret: endpoints are stored by name, and their url and
+`api_key_env` stay in the `chat-subagent` registry.
+
+**Copilot is one adapter, not the only possible remote reviewer.** Phase B is a
+forge-reviewer slot with three operations — request, poll, recognize a clean pass.
+GitHub Copilot ships as the built-in binding of those operations. Other forges have
+review agents; this skill names none and implements none, because an adapter nobody
+here can run would poll forever or report a clean pass that never happened. Declare
+one, supply its three commands and an unambiguous `clean_when`, and the loop drives
+it. The built-in Copilot adapter needs **no enrollment**: a GitHub PR with an
+authenticated `gh` reaches it exactly as before, unless you opt out. With no forge
+reviewer **available**, Phase B is skipped and the local panel is the whole loop.

--- a/plugins/review-loop/skills/review-loop/SKILL.md
+++ b/plugins/review-loop/skills/review-loop/SKILL.md
@@ -1,23 +1,33 @@
 ---
 name: review-loop
-description: General assisted review loop for changes — code or design artifacts (specs, plans, docs). Prefers local reviewers (Claude subagent + headless Codex via `codex exec review`) as the first gate; for GitHub PR targets, also requests Copilot after the PR is open. Loops each reviewer until clean or its usage limit, classifies comments into tiers, auto-fixes mechanical ones, pauses on architectural ones for user judgment. Never merges autonomously.
+description: General assisted review loop for changes — code or design artifacts (specs, plans, docs). Runs an adversarial panel of local reviewers: every live panelist answers blind on the same unfixed diff, then attacks the others' findings, before any fix is applied. Reviewers are discovered at loop start and may be enrolled by `/review-loop:init`, which is never a precondition; the gate names the panel that actually ran and calls same-family agreement weak evidence. For PR/MR targets a forge reviewer runs after the local gate is clean (GitHub Copilot is the built-in adapter and needs no enrollment). Findings carry a confidence and a falsification condition; a *panelist's* finding that neither faced an adversary nor was reproduced is never auto-fixed (a forge reviewer's comments are not gated this way). Never merges autonomously.
 ---
 
 # Review Loop (Assisted)
 
 Assisted, not autonomous. Preserves the author's architectural voice and learning across review cycles. General-purpose: the target may be a **local branch / working diff** (no remote needed) or a **GitHub PR**, and the changes under review may be **code or design artifacts** (specs, plans, docs).
 
-**Local reviewers are preferred and run first.** A Claude subagent and Codex (headless, via `codex exec review`) cost nothing extra and are fast, so they are the first gate. Codex runs wherever the `codex` CLI is on `PATH` — no tmux needed; tmux only adds a live-watch pane **when the user asks to watch** (never by default). GitHub Copilot is added only when the target is a GitHub PR, and only after the local gate is clean.
+**Local reviewers run first, and they run as a panel.** Every live panelist reviews the same **unfixed** diff blind — none sees another's findings — and then cross-critiques. Codex runs wherever the `codex` CLI is on `PATH` — no tmux needed; tmux only adds a live-watch pane **when the user asks to watch** (never by default). A forge reviewer (GitHub Copilot is the built-in adapter) is added only when the target is a PR/MR, and only after the local gate is clean.
 
 ## Why this loop exists
 
-Claude and Codex reviewing **together** produces noticeably better output than either model alone — they catch different classes of issues, and Codex's pass tightens the diff before it ever reaches GitHub. The downstream payoff: by the time Copilot sees the PR, there's much less for it to complain about, so review rounds converge faster. Front-loading combined local Claude+Codex review as the first gate is the entire reason this loop exists.
+A reviewer catches what the author missed only when their failure modes differ. A model asked to critique its own output draws that critique from the same weights that produced the blind spot, so a same-family panel agreeing is weaker evidence than it looks. Running Claude and Codex **blind and in parallel**, then having each attack the other's findings, is what decorrelates the errors — and it kills false positives before they become commits, tests, and convergence rounds. Serial review cannot do this: a reviewer shown the already-fixed tree is anchored on the first reviewer's judgement and can no longer dispute it. That is the entire reason this loop exists.
 
 ## Requirements
 
 - **Always usable:** the Claude subagent reviewer needs nothing extra.
-- **Codex reviewer (optional):** the `codex` CLI on `PATH`. Absent it, the Codex step is skipped silently. `jq` is used to capture the resume `thread_id` from `codex`'s `--json` stream — without `jq`, resume just falls back to `--last` (§ Convergence rounds). (tmux is **not** required — it only adds a live-watch pane **when you ask to watch**; see A2.)
-- **GitHub Copilot phase (optional):** the authenticated `gh` CLI and `jq`. Only used for GitHub PR targets.
+- **The roster is enrolled, not assumed.** Which reviewers this host can field is
+  answered by a `command -v` sweep at loop start (presence) plus
+  `~/.claude/review-loop.local.md` (enrollment + the invocation recipe
+  `/review-loop:init` learned by actually calling each CLI). With no config
+  the loop fields the same roster it always did and hints at `init` once; `init` is
+  never a precondition.
+- **Codex reviewer (optional):** the `codex` CLI on `PATH`. Never enrolled and absent → skipped silently. **Enrolled and absent → say so** and lower the gate's evidential tier (see *Roster reconciliation*); a reviewer the author asked for and did not get is not a silent skip. `jq` is used to capture the resume `thread_id` from `codex`'s `--json` stream — without `jq`, resume just falls back to `--last` (see the *Convergence rounds* bullet under *Codex mechanics*). (tmux is **not** required — it only adds a live-watch pane **when you ask to watch**; see *Codex mechanics*.)
+- **Forge reviewer (optional):** the one built-in adapter is GitHub Copilot, which needs
+  the **authenticated** `gh` CLI and `jq`, and runs only for GitHub PR targets. It needs
+  **no enrollment** — zero config reaches Copilot exactly as it always did. Presence of
+  `gh` is not authentication. Enrollment adds a *declared* reviewer or opts out of Copilot.
+  With no forge reviewer **available**, Phase B is skipped and the local panel is the whole loop.
 
 The skill and helper scripts resolve their CLI dependencies (`codex`, `gh`, `jq`, plus `tmux` only for the live-watch pane (used only when you ask to watch)) from `PATH`, so the skill is self-contained and portable across machines.
 
@@ -29,11 +39,56 @@ The skill and helper scripts resolve their CLI dependencies (`codex`, `gh`, `jq`
   - The diff may contain code, design artifacts (specs, plans, docs), or both — the loop reviews whatever changed.
 - Repo / base branch inferred from the current working directory.
 
-## Reviewer roster & priority
+## Reviewer roster
 
-1. **Local Claude subagent** — always. Dispatch a subagent (Task tool) to do the review.
-2. **Local Codex** (headless `codex exec review`) — when `codex` is on `PATH`. tmux is not required; it adds a live-watch pane **only when you ask to watch** (and you're in tmux). See A2.
-3. **GitHub Copilot** — only for GitHub PR targets, after the PR is open.
+Panelists are ranked by **heterogeneity** — decorrelated error modes are the only
+reason a second reviewer catches anything the first missed:
+
+1. **Tier 1 — a different model family**, actually called: `codex`, or another
+   enrolled coding CLI, or a user-declared OpenAI-compatible endpoint (which is
+   always `trust: user-asserted` and never counts as heterogeneous evidence).
+2. **Tier 2 — a different Claude model**, via the `Task` tool's `model` parameter.
+   Same family, so convergence here is weak evidence.
+3. **Fresh-context only** — a Claude subagent on the session's own model. This is
+   what a zero-config host gets, and the gate says so.
+
+`tier` is **derived from `kind`, not declared**: writing `tier: 1` on an endpoint is
+a lie the loop ignores.
+
+These tiers map onto the verdicts *Exit conditions* reports: a live tier-1 **CLI** →
+**Heterogeneous**; a tier-1 *endpoint* (always `trust: user-asserted`) → **User-asserted**,
+never Heterogeneous; tier 2 → **Same-family**; and the last row → **Fresh-context only**.
+
+**Forge reviewers are a separate slot** (Phase B) — they live on the code-hosting
+platform, appear only once a PR/MR exists, and are never panelists. GitHub Copilot
+is the one built-in adapter.
+
+### Roster reconciliation at loop start
+
+Probe presence inline — no script; a `command -v` loop is not knowledge worth
+materializing. Then compare against the config and **surface every disagreement —
+never silently follow a stale config**:
+
+```bash
+for cli in codex gemini cursor-agent opencode aider crush amp llm gh; do
+  command -v "$cli" >/dev/null 2>&1 && echo "$cli present" || echo "$cli absent"
+done
+```
+
+(`<cli> --version` is `/review-loop:init`'s business, not a review's: it spawns a real
+subprocess per CLI and only drift detection needs it.)
+
+- **Enrolled but absent** → degrade, note it, and lower the gate's evidential tier.
+- **Present but unenrolled** (e.g. `codex` installed after `init` ran) → note once:
+  "`codex` is on `PATH` but not enrolled — run `/review-loop:init` to add it."
+  Do **not** auto-enroll; enrollment is the author's decision.
+- **Recipe drift** — the CLI's version differs from `invocation.verified_with`, or
+  the preflight contradicts `invocation.form`. The stored recipe is a **learned
+  default, not gospel**: preflight and the post-round detector still run and still
+  win. Follow this run's evidence, then suggest re-running `init`. A recipe must
+  never suppress a detector.
+- **`claude-alt.model` equals the session model** → the panel is **fresh-context
+  only**, whatever the config asked for.
 
 ## Helper scripts
 
@@ -50,7 +105,79 @@ Reach for these first. Only hand-write a command when a script genuinely doesn't
 - **T2 local refactor**: method extraction, variable naming across a module, added validation.
 - **T3 architectural**: file/module moves, API shape, "should this exist", simplification, scope cuts.
 
-Per round: post the grouped findings, **resolve T2/T3 with the author first** (quote the comment, draft 2–3 approaches with trade-offs, recommend one, wait for their pick), **then** apply the fixes — T1 auto-fixed, T2/T3 done as chosen. One commit per item, TDD, and reply/note the commit hash. (TDD and one-commit-per-item apply to executable changes; for prose/doc targets there are no tests to write first — prefer one logical edit per finding and review for clarity, consistency, structure, and factual accuracy.) Architectural decisions always land before mechanical edits are committed.
+Per round: post the grouped findings, **resolve T2/T3 with the author first** (quote the comment, draft 2–3 approaches with trade-offs, recommend one, wait for their pick), **then** apply the fixes — T1 auto-fixed **only through the gate below**, T2/T3 done as chosen. One commit per item, TDD, and reply/note the commit hash. (TDD and one-commit-per-item apply to executable changes; for prose/doc targets there are no tests to write first — prefer one logical edit per finding and review for clarity, consistency, structure, and factual accuracy.) Architectural decisions always land before mechanical edits are committed.
+
+### The finding record
+
+**Scope: this and the auto-fix gate govern the local panel only.** A forge reviewer
+is not a panelist — it never enters R1 or R2, so its comments can never reach
+`survived`, and Copilot cannot be asked for a confidence. **Phase B is not gated by
+the panel rule.** A forge reviewer's T1 comment is auto-fixed on its own merits, and its
+T2/T3 comments go to the author — exactly as they did before the panel existed. Applying
+the panel's gate to Copilot would revoke an auto-fix that works today, for nothing: the
+gate exists to make a reviewer face an adversary, and there is no adversary left to face
+once the local gate has closed.
+
+Every finding **from a local panelist** carries: `reviewer` (Codex's text quoted
+**verbatim**, never paraphrased into Claude's voice), `claim`, `location`, `tier`,
+`confidence`, `falsification`, `status`.
+
+- **`tier`** is the cost and scope of the fix. **`confidence`** is whether the
+  finding is *true*. They are different axes — a T1 typo can simply be wrong.
+- **`falsification`** is a concrete, checkable condition under which this is *not* a
+  bug ("not a bug if `cfg` is non-null at every call site"). A generic one — "if
+  evidence emerges to the contrary" — is calibration theater and counts as **absent**.
+- **`confidence` authorizes nothing on its own.** The reviewer that raised the
+  finding assigns it, because nobody else can — a self-assessment by the same weights
+  that produced the finding. Its job is to inform the author and to be *attacked* in
+  R2. **The facilitator never imputes these fields**: filling them in for Codex would
+  be Claude judging whether Codex's finding is true and dressing the judgement as
+  Codex's.
+
+**Status ladder:**
+
+| Status | Means | Auto-fix? |
+|--------|-------|-----------|
+| `proposed` | raised, not yet critiqued | never |
+| `survived` | attacked in R2, and the attack failed | eligible |
+| `refuted` | attacked, and its author conceded or lost | never |
+| `refuted-undefended` | attacked, but its author never answered | never — **live disagreement** |
+| `reproduced` | a failing test (code), or a facilitator-verified citation (prose) | eligible |
+| `unreproduced` | a correctness finding nobody attempted to reproduce | never; withholds "gate clean" |
+
+### The auto-fix gate
+
+```
+tier == T1  ∧  ( status == reproduced
+               ∨ (status == survived ∧ confidence == high ∧ falsification present) )
+```
+
+`survived`, **not** `!= refuted`: an uncritiqued finding sits at `proposed`, which is
+trivially "not refuted", so gating on that would let a lone same-family reviewer grade
+its own finding `high` and auto-commit it. **A single-panelist run therefore auto-fixes
+on `reproduced` alone** — a lone reviewer has not earned the right to commit
+unsupervised.
+
+### Refute by reproduction
+
+- **Executable target:** a correctness finding is `reproduced` once a failing test
+  demonstrates it. (`codex exec review` is read-only and cannot run one — reproduction
+  is the facilitator's job, before the fix.) An `unreproduced` correctness finding does
+  not block automatic convergence but **withholds the "gate clean" verdict** until the
+  author waives it. Otherwise the facilitator — the party motivated to converge — could
+  walk past a real finding simply by never attempting a repro.
+- **Prose target:** there is nothing to run, so `reproduced` requires two mechanical
+  conditions, both **obligations**, not capabilities:
+  1. **The facilitator confirms the quote** occurs at the cited location — a `grep`,
+     not a reading. A fabricated or mis-located quotation is a known model failure, and
+     "a reader *can* check it" is capability, not a check.
+  2. **The defect's fix is itself mechanically checkable** — a typo, a stale line
+     reference, a regex that does not match the file it claims to guard.
+
+  "Line 152 already contains `confidence`, so this anchor passes against the unmodified
+  file" satisfies both. "This section is unclear" satisfies neither and goes to the
+  author. **A citation plus the reviewer's interpretation is model judgement wearing
+  evidence's clothes.**
 
 ## Flow
 
@@ -58,9 +185,108 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
 
 **A0. Author pass first** — before touching anything, ask: "Any simplifications you'd collapse across these changes before I start?" Capture as a commit-plan override.
 
-**A1. Claude subagent review** — dispatch a subagent to review the diff. Classify findings into T1/T2/T3, post the grouped list, resolve T2/T3 picks, then apply fixes (per *Tiers*). Commit fixes; push only if a remote/PR branch exists, otherwise commit locally.
+**A1. Round 1 — blind, parallel, on the same unfixed diff.** Every live panelist
+reviews *before any fix is applied*, and **no panelist sees another's findings**. A
+reviewer shown another's output anchors on it, and the panel's whole value is that
+their error modes differ.
 
-**A2. Codex review** (only if `codex` is on `PATH`; otherwise skip silently — don't block, don't mention it). Codex runs **headless** via `codex exec review` — no tmux, no pane, runs wherever `codex` is on `PATH`. The `review` subcommand is read-only by construction; Codex *finds* issues, Claude applies fixes (Codex never edits the tree).
+Post the R1 findings to the author as soon as they land, marked
+`proposed — not yet critiqued, none actionable`. The independence invariant binds
+*panelists*, not the human; making the author wait through two silent rounds to
+learn the loop is alive buys nothing.
+
+**How each panelist is invoked:**
+
+- **Codex, native path — the *freeform* form, not the targeted one.** A target flag
+  takes no prompt (`review --uncommitted -` errors rc=2), and without a prompt Codex
+  cannot be asked for the finding record, so its findings could never pass the
+  auto-fix gate. The freeform native form does take a prompt:
+  ```bash
+  printf '%s\n' "$brief" | codex exec --json --sandbox read-only review -
+  ```
+  **An inferred diff may not be the same diff, and R1 is the blind round.** So the
+  brief names the exact range `<base>...<head-sha>` — **three dots, the same range the check runs**; a two-dot range differs the moment the base advances — requires the review to state the
+  commit range and file list it actually reviewed as its first line, and the
+  facilitator compares that against `git diff --name-only "$base"..."$head"`. A
+  mismatch → re-run once with the diff embedded (which cannot be inferred wrong); a
+  second mismatch → *Ghost panelist gate*: drop, continue, disclose.
+- **Codex, embedded path** — unchanged, and it carries a prompt too. Both paths
+  request the same record format.
+- **Claude subagent** — a `Task` dispatch under the enrolled `claude-alt.model`. The
+  brief **stands alone** (the subagent sees none of this conversation): the diff, the
+  tier definitions, the finding-record format, the falsification-condition
+  instruction, "state your model id on the first line", and "your final message is
+  the review record; no preamble".
+- **Other enrolled CLIs / endpoints** — the stored `invocation.command`, with the
+  diff and the record format in the prompt.
+
+**A2. Round 2 — cross-critique, parallel.** Runs whenever **≥ 2 panelists are live**
+(true on a zero-config host that has `codex`). Each panelist receives the *others'*
+findings **verbatim** and is asked to attack them, then to restate its own, dropping
+any it now believes wrong.
+
+Do **not** mandate a disagreement. "You disagree with at least one central claim;
+find it" manufactures a refutation when the other panelist is right, and an invented
+refutation is worse than a missed one. Ask instead: *"name the central claim you
+tried hardest to break, and either break it or say why it held."* A round that
+refutes nothing is a legitimate outcome; a round that **attacks** nothing is the
+failed one. Refute by reproduction — "this fails on input X", not "I doubt this".
+
+- **Codex R2:** `codex exec --json --sandbox read-only resume "$thread_id" -` — the
+  trailing `-` reads the prompt from stdin and is valid on `resume`. On the embedded
+  path, a fresh embedded call carrying the complete current diff plus the other
+  findings (the sticky-embedded rule).
+- **Claude R2 is a *fresh* dispatch** — `Task` subagents are one-shot, so there is no
+  instance to resume. Its brief carries the same diff, its own R1 findings quoted
+  back to it, and the others' findings. A fresh instance defending text it did not
+  produce is a weaker epistemic act than a panelist answering for its own argument.
+  It is what the tool allows; say so rather than pretending otherwise.
+- **Every other panelist R2 — a fresh call, no resume assumed.** For a `kind: cli`
+  panelist other than Codex, and for a `kind: endpoint` panelist, re-invoke the stored
+  `invocation.command` with the complete current diff, that panelist's own R1 findings
+  quoted back to it, and the others' findings. Only Codex has a resume protocol; assume
+  none for anything else.
+- **Round 3** (each panelist answering critiques of its *own* findings) runs only
+  with **≥ 3 live panelists**. With two, R2 is the merged "critique, then restate".
+
+**R2 critique rounds are EXEMPT from the post-round `command_execution` detector.**
+Not because a critique round reads no files — a good one reads many, since
+reproduction means opening the file at the cited line. The detector's inference is
+"zero commands ⇒ never read the tree ⇒ the sandbox false-cleaned a **review**", and
+that is sound only when the round's job *is* to review the tree. An R2's subject is
+the findings. Convicting it of a false clean is a category error, and the
+sticky-embedded rule would then demote a `usable` host for the rest of the loop.
+Every other native round keeps the detector, and its guarantee, unchanged.
+
+**A panelist that dies between R1 and R2** (usage limit, or a double failure under *Ghost panelist gate*)
+leaves its R1 findings at `proposed`: surfaced, never auto-fixed *while proposed*,
+but not exiled — if the facilitator later reproduces one, it becomes `reproduced`
+and is auto-fixable like any other. A successful attack on a dead panelist's finding
+yields **`refuted-undefended`**, never `refuted`. Report the panel **per round**
+("R1 heterogeneous; R2 and convergence same-family — Codex hit its usage limit").
+
+**A3. Adjudicate → tier → resolve → fix.** Classify the surviving findings into
+T1/T2/T3, resolve T2/T3 with the author, then apply fixes per *Tiers*, gated by the
+auto-fix rule below. Commit fixes; push only if a remote/PR branch exists.
+
+**A4. Convergence.** Resume the **same `thread_id`** used by R1 and R2 (R2 used
+`resume`, so it did not fork). Verify against the **post-R2 restated list**, not the
+raw R1 list — a finding its own author dropped is not resurrected. `claude-alt`
+cannot resume: its convergence round is a fresh dispatch restating its surviving
+findings. **Every live panelist blocks**; a panelist dropped under *Ghost panelist gate* stops
+blocking the moment it is disclosed as dropped, and one that went clean then died
+does not un-clean the gate.
+
+**Output volume.** An auto-fixed finding prints as **one line** (claim, location,
+commit). A `refuted` finding prints as one line plus who refuted it and why. A
+**`refuted-undefended` finding prints as a live disagreement, never a one-liner** —
+a "refuted by X" one-liner hides that nobody checked. The full record is reserved
+for findings the author must judge: T2/T3, live disagreements, and anything that
+failed the auto-fix gate.
+
+#### Codex mechanics — how the Codex panelist is driven (used by R1, R2 and A4)
+
+This section is **not a step**. It is the machinery the Codex panelist runs on wherever it appears above: blind in R1, attacking in R2, verifying in A4. It applies only if `codex` is live. **Never enrolled and absent → skip silently.** **Enrolled and absent → say so** and lower the gate's evidential tier (*Roster reconciliation*): a reviewer the author asked for and did not get is not a silent skip. Codex runs **headless** via `codex exec` — no tmux, no pane. The `review` subcommand is read-only by construction; Codex *finds* issues, Claude applies fixes (Codex never edits the tree).
 
 - **Set up logs (once, at loop start):** pick a `<runid>` (PR number, branch slug, or `mktemp` suffix). `$log` is the **cumulative** feed for the optional watch pane *only*; each round also writes its own `$round` file, which is what Claude actually reads (so old rounds' findings are never replayed):
   ```bash
@@ -88,7 +314,7 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
   If the user asked to watch but `$TMUX` is unset (can't split a pane), note it once — "not in a tmux session, so I can't open a watch pane; Codex findings are still relayed in the tier list" — and continue headless. Never fail on this.
   The agent **never reads from this pane** — it reads `codex exec`'s stdout. All rounds append to the same `$log`, so the single pane keeps showing them. **Tear it down** at loop end (clean, usage-limit fallback, or abort) so it doesn't orphan — guard it so an unset/failed pane doesn't abort under `set -e`: `[ -n "${watch_pane:-}" ] && tmux kill-pane -t "$watch_pane" 2>/dev/null || true`. No tmux? Codex still runs — the human sees its findings relayed in Claude's own grouped tier list.
 
-- **Resolve the target into the working tree first.** `codex exec review` reviews the *current checkout*, so before reviewing, make the checkout match the requested target: for a `<branch>` target, `git checkout` it (or run from its worktree); for a `<PR-number>` target, `gh pr checkout <num>` first. Only then does `review --base "$base"` (or `--uncommitted`) look at the right diff. (If checkout isn't possible, **don't** pipe a diff into `review -`: both `codex exec -` and `review -` read the *prompt / instructions* from stdin, **never** a diff or review target — so it would still review the current checkout. Instead use the embedded-diff form (A2): put the diff in the prompt, e.g. `codex exec --json --sandbox read-only "Review this diff for correctness, design, and risk:\n$(gh pr diff <num>)"` — or tell the author the PR can't be reviewed without checkout.)
+- **Resolve the target into the working tree first.** `codex exec review` reviews the *current checkout*, so before reviewing, make the checkout match the requested target: for a `<branch>` target, `git checkout` it (or run from its worktree); for a `<PR-number>` target, `gh pr checkout <num>` first. Only then does `review --base "$base"` (or `--uncommitted`) look at the right diff. (If checkout isn't possible, **don't** pipe a diff into `review -`: both `codex exec -` and `review -` read the *prompt / instructions* from stdin, **never** a diff or review target — so it would still review the current checkout. Instead use the embedded-diff form (§ *Codex mechanics*): put the diff in the prompt, e.g. `codex exec --json --sandbox read-only "Review this diff for correctness, design, and risk:\n$(gh pr diff <num>)"` — or tell the author the PR can't be reviewed without checkout.)
 
 - **Route by sandbox state, not by target.** The preflight `$sandbox` decides which Codex form is primary:
   - `usable` → native `review` (below): it reads the local tree directly, correct for pushed *and* unpushed targets (no remote fallback happens).
@@ -114,19 +340,26 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
   # then embed "$unc" in the prompt. The trailing manifest is always appended so
   # genuinely empty new files (which produce no diff) are still part of the snapshot.
   ```
-  On a `usable` sandbox prefer native `review --uncommitted` instead (it covers all three directly).
+  On a `usable` sandbox the native form covers all three targets directly — but **R1 still uses
+  freeform `review -`**, naming the target in prose, because a target flag takes no prompt and R1's
+  prompt must request the finding record. The targeted forms belong where no prompt is needed (B3).
 
-- **First round — map the loop's target to a `review` invocation, with `--json`.** This is the round whose session id we need, so run it with `--json` and capture `thread_id` for resume (§ Convergence rounds). `--sandbox read-only` goes **before** the subcommand. Target flags take **no** prompt (they conflict with `[PROMPT]` — `review --uncommitted -` errors rc=2), so the targeted forms carry no instructions. Use `--base "$base"` as the canonical default-target form:
+- **First round (R1) — the freeform form, because R1 needs a prompt.** This is the round whose session id we need, so run it with `--json` and capture `thread_id` for resume (see the *Convergence rounds* bullet below). `--sandbox read-only` goes **before** the subcommand. Target flags take **no** prompt (they conflict with `[PROMPT]` — `review --uncommitted -` errors rc=2), so a targeted round carries no instructions — and R1 **must** carry instructions: its prompt names the exact `<base>...<head-sha>` and requests the §finding-record fields. A finding with no falsification condition can never be auto-fixed, which would disqualify the panel's only tier-1 reviewer. So R1 is freeform, and the facilitator checks the echoed file list against `git diff --name-only` because a freeform Codex infers its own diff (see A1):
   ```bash
   round="$(mktemp "${TMPDIR:-/tmp}/review-loop-codex.XXXXXX")"
   rc=0
-  codex exec --json --sandbox read-only review --base "$base"  >"$round" 2>"$err" || rc=$?   # branch vs base (default)
-  # other targets: review --uncommitted (working tree) · review --commit "$sha" (one commit)
+  printf '%s\n' "$brief" \
+    | codex exec --json --sandbox read-only review - >"$round" 2>"$err" || rc=$?   # R1: freeform, carries the prompt
+  # $brief names the range <base>...<head-sha> (three dots — matches the name-only check) and
+  # requests the finding-record fields.
+  # Targeted forms take NO prompt and so cannot serve R1. They remain available where
+  # no prompt is needed. B3 uses `review --base "$base"`; `review --uncommitted` and
+  # `review --commit "$sha"` are the other targeted forms, for manual use outside the panel.
   cat "$round" >>"$log"   # feed the watch pane
   [ "$rc" = 0 ] && thread_id=$(jq -r 'select(.type=="thread.started") | .thread_id' "$round" 2>/dev/null | head -1) || true   # parse only on success; non-fatal (no id → --last fallback). jq, not regex.
   ```
   With `--json` the stdout is a JSON **event stream**: Claude reads the review content from the assistant/agent-message events in `$round` and classifies it into T1/T2/T3, **and** extracts `thread_id` for resume. The human-readable findings still reach the author via Claude's own relayed tier list (Claude relays regardless), so JSON-on-stdout is fine.
-  For **custom focus** (e.g. steering a doc-artifact review), use the freeform form — no target flag, Codex infers the diff itself; name the target in prose. Keep `--json` here too, so a focused first round still captures `thread_id` for resume (otherwise convergence falls back to `--last`):
+  The freeform form is also what steers a **custom focus** (e.g. a doc-artifact review): no target flag, Codex infers the diff, so name the target in prose. Keep `--json`, so R1 still captures `thread_id` for resume (otherwise convergence falls back to `--last`). Reach for a **targeted** form only where a prompt is genuinely unnecessary (see B3). The freeform custom-focus form:
   ```bash
   round="$(mktemp "${TMPDIR:-/tmp}/review-loop-codex.XXXXXX")"
   rc=0
@@ -135,14 +368,14 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
   cat "$round" >>"$log"
   [ "$rc" = 0 ] && thread_id=$(jq -r 'select(.type=="thread.started") | .thread_id' "$round" 2>/dev/null | head -1) || true   # parse only on success; non-fatal (no id → --last fallback). jq, not regex.
   ```
-  Use the targeted form by default; reach for freeform only when custom focus is worth giving up the explicit target flag.
+  **Which form goes where.** R1 uses the **freeform** form (`review -`): it is the only native form that carries a prompt, and R1's prompt must request the finding record — a finding without a falsification condition can never be auto-fixed, which would disqualify the panel's only tier-1 reviewer. The price is that Codex infers the diff, so R1's prompt names the exact `<base>...<head-sha>` and the facilitator checks the echoed file list against `git diff --name-only` (see A1). **A4 convergence resumes the session** (`codex exec --json --sandbox read-only resume "$thread_id" -`), so it does not use a target flag either — and it keeps `--json`, without which the post-round detector has no `command_execution` items to count. The targeted `review --base "$base"` form's remaining home is **B3**, where Codex re-reviews pushed commits and needs no prompt.
 
 - **Capture the exit status, don't pipe it away.** Never `codex … | tee` — that makes `$?` reflect `tee`, not Codex, and the three-outcome split below needs Codex's real exit code. Redirect stdout to the per-round `$round` file and stderr to `$err`, capturing the code set-e-safely (`rc=0; … || rc=$?`, never a bare `; rc=$?`), then `cat "$round" >>"$log"` for the watch and read `$round` for classification.
 
 - **Model / effort — defer to the user's Codex config.** Pass **no `-m` and no reasoning-effort override**: `codex exec review` honors `~/.codex/config.toml`'s `review_model` (falling back to the session default). Only if the author names a model for the session ("use gpt-5.4") pass `-m` for the rest of the loop.
 
 - **Three outcomes** after each call — branch on `rc`:
-  - **`rc == 0` → first confirm Codex actually read the tree, *then* read the review.** Read **this round's `$round`** (not the cumulative `$log`). **Post-round detector (the guarantee) — all native-path rounds (initial `review`, `resume`, and the fresh native fallback):** a native round that ran **zero `command_execution` items** never executed a local command, so it never read the tree (a sandbox false-clean). `codex exec --json` nests item kinds under `.item.type`, not top-level `.type`, so test:
+  - **`rc == 0` → first confirm Codex actually read the tree, *then* read the review.** Read **this round's `$round`** (not the cumulative `$log`). **Post-round detector (the guarantee) — every native-path round whose job is to *review the tree* (initial `review`, the A4 convergence `resume`, and the fresh native fallback). R2 critique rounds are EXEMPT** (their subject is the other panelists' findings, not the tree, so zero commands there says nothing about sandbox health — see A2): a native round that ran **zero `command_execution` items** never executed a local command, so it never read the tree (a sandbox false-clean). `codex exec --json` nests item kinds under `.item.type`, not top-level `.type`, so test:
     ```bash
     # set -e-safe: `jq -e` exits non-zero on no match, so branch on it (never run it bare).
     if ! jq -e 'select(.type=="item.completed") | select(.item.type=="command_execution")' "$round" >/dev/null; then
@@ -157,7 +390,7 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
   ```bash
   round="$(mktemp "${TMPDIR:-/tmp}/review-loop-codex.XXXXXX")"
   rc=0
-  printf '%s\n' "I applied these fixes: <summary>. Are your earlier points resolved? Any new concerns?" \
+  printf '%s\n' "The fixes are applied. For each point you raised, verify it AGAINST THE CODE and state resolved or unresolved, with the evidence you used. Do not treat the author's description of the fix as evidence. Then state any new concerns." \
     | codex exec --json --sandbox read-only resume "$thread_id" - >"$round" 2>"$err" || rc=$?
   cat "$round" >>"$log"   # feed the watch pane; Claude reads "$round" (this round only)
   ```
@@ -167,14 +400,53 @@ Per round: post the grouped findings, **resolve T2/T3 with the author first** (q
 
 - **Loop Codex until clean or its usage limit:** each round classify its findings into tiers, resolve picks, fix, then `resume` for re-review. Repeat until **either** Codex reports no remaining problems (Codex gate clean) **or** it hits the usage-limit outcome above.
 
-- **Freeform plain-exec fallback (rare).** Drop to `codex exec "<instructions + diff>"` only when (a) the installed `codex` is too old to have `exec review`, or (b) the target is **not** a git diff (e.g. a pasted artifact outside any repo) — in case (b) **only**, add `--skip-git-repo-check` (unnecessary on the normal `review`/`resume` paths).
+- **Freeform plain-exec fallback (rare).** Drop to `codex exec --json --sandbox read-only "<instructions + diff>"` — keep both flags, or the detector cannot run and the round is not parseable — only when (a) the installed `codex` is too old to have `exec review`, or (b) the target is **not** a git diff (e.g. a pasted artifact outside any repo) — in case (b) **only**, add `--skip-git-repo-check` (unnecessary on the normal `review`/`resume` paths).
 
-- **Local, unpushed commits on `main` are a first-class case, not an edge case.** Under the docs-to-`main` convention, design-artifact reviews routinely target a freshly-committed, unpushed commit on `main`. On a `broken`/`unknown` host that is exactly where native `review` silently false-cleans (it falls back to the remote, which lacks the commit) — which is why A2 routes these to the embedded-diff form and guards every native round with the post-round detector.
+- **Local, unpushed commits on `main` are a first-class case, not an edge case.** Under the docs-to-`main` convention, design-artifact reviews routinely target a freshly-committed, unpushed commit on `main`. On a `broken`/`unknown` host that is exactly where native `review` silently false-cleans (it falls back to the remote, which lacks the commit) — which is why *Codex mechanics* routes these to the embedded-diff form and guards every tree-reading native round with the post-round detector.
 - **Host fixes (optional).** If you want the native `review` path back on a host where the preflight reports `broken`, see `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/references/codex-sandbox-host-fixes.md` — a menu (bwrap-userns-restrict, legacy-landlock, …). The skill never applies these; embedded-diff already works with no host change.
 
-**A3. Converge the local gate** — re-run A1/A2 after fixes until Claude is clean **and** Codex is clean *when available*. "Done" for Codex means any of: clean review, **or** Codex was unavailable this run — the `codex` CLI is absent, it stopped at its usage limit, or it **failed for a non-limit reason** (§4 "Codex failed": surfaced to the author, then degraded to Claude-only). In every unavailable case the gate proceeds on Claude alone; only an *available, not-yet-clean* Codex blocks. Only then proceed.
+#### Availability, not cleanliness — when a panelist stops blocking
 
-### Phase B — GitHub Copilot (only for GitHub PR targets)
+A4 converges when every **live** panelist is clean. "Done" for Codex means any of: a clean review, **or** Codex was unavailable this run — the `codex` CLI is absent, it stopped at its usage limit, or it **failed for a non-limit reason** ("Codex failed": surfaced to the author, then degraded). In every unavailable case the gate proceeds without it, and the verdict reports the panel that actually ran. Only an *available, not-yet-clean* panelist blocks.
+
+**"A4 converges" is not "gate clean".** Convergence is about panelists; the verdict is about evidence. An `unreproduced` correctness finding withholds the clean verdict until the author waives it, and where the panel's composition changed mid-run the verdict is reported **per round** — see *Exit conditions*.
+
+### Phase B — Forge reviewer (only when one is available and the target is a PR/MR)
+
+A **forge reviewer** lives on the code-hosting platform and is reachable only once the
+change is a pull/merge request. It has three operations: **request**, **poll for
+comments**, and **recognize a clean pass**. It is **not a panelist** — it never enters
+R1 or R2, so the finding record and the auto-fix gate do not govern it; the *Tiers*
+rules apply unchanged (T1 auto-fixed, T2/T3 to the author).
+
+**The built-in adapter needs no enrollment.** A GitHub PR target with an authenticated `gh`
+and `jq` reaches Copilot exactly as it did before the panel existed — zero config keeps the
+roster it always had. *Enrollment* is how you **add** a declared reviewer or **opt out** of
+Copilot (`enabled: false`), never a precondition for the adapter that ships.
+
+**No forge reviewer available → skip Phase B silently.** No `gh`, no authentication, an
+explicit opt-out, or a non-GitHub forge with nothing declared: the local panel is the whole
+loop.
+
+**GitHub Copilot is the one built-in adapter** (`adapter: builtin`), because
+`scripts/copilot.sh` and `scripts/pr-comments.sh` implement those three operations and
+have been exercised across many PRs. Steps B0–B5 below *are* that adapter.
+
+**Other forges have review agents. This skill names none and implements none.** An
+adapter written from documentation for a service nobody here can run is a ghost
+panelist one layer up: it would poll forever, or report a clean pass that never
+happened. A user with access declares the reviewer and supplies its commands —
+`request`, `poll`, and a `clean_when` regex.
+
+`clean_when` is load-bearing, and an unpinned regex *is* the false clean it exists to
+prevent. A declared reviewer inherits the builtin's contract: `poll` must emit reviews
+newest-first, one JSON object per line, each with a `body`; `clean_when` is a POSIX ERE
+applied with `grep -Eq` to the **newest item's `body` only**, never to the whole poll
+dump — matching the dump false-cleans forever the first time the bot ever said "no
+comments". A `poll` that cannot satisfy the interface is declared wrong: say so at
+enrollment and fall back to surface-and-ask. **If a declared reviewer has no unambiguous
+clean signal, the loop polls, surfaces its comments, and hands the stop decision to the
+author rather than inventing one.**
 
 **B0. Ensure a PR exists.** If the target is a branch with no PR yet, open it now with `gh pr create` — **only after Phase A is clean** (the local gate comes before opening a PR). If a PR number was given, skip creation.
 
@@ -187,7 +459,7 @@ First-time caveat: on some repos `gh pr edit --add-reviewer` returns 422 for the
 
 **B2. Pre-scan** — `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh fetch <num>` (paginated reviews + inline comments). Group unresolved comments into tiers, then handle them per *Tiers*.
 
-**B3. Re-request Copilot** after fixes push — Copilot won't re-examine otherwise: `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh rerequest <num>`. If `codex` is on `PATH`, have Codex review the new commits headlessly (`codex exec --sandbox read-only review --base "$base"`, or `resume "$thread_id" -` to continue the session) **before** re-requesting Copilot (local gate first).
+**B3. Re-request Copilot** after fixes push — Copilot won't re-examine otherwise: `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/copilot.sh rerequest <num>`. If Codex is **live** — enrolled, or present on a zero-config host — have it review the new commits headlessly **with `--json`**, so the post-round detector can run: `codex exec --json --sandbox read-only review --base "$base"`, or `codex exec --json --sandbox read-only resume "$thread_id" -` to continue the session. Without `--json` there are no `command_execution` items to count, and a sandbox that silently blocked the round would pass as a clean review. **Before** re-requesting Copilot (local gate first).
 
 **B4. Poll** — `/loop 3m` re-run `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh fetch <num>`. New comments → re-classify → B2.
 - **Copilot clean-pass stop signal:** when `${CLAUDE_PLUGIN_ROOT}/skills/review-loop/scripts/pr-comments.sh clean-pass <num>` exits 0 (newest Copilot review matches `generated no (new )?comments.` — "generated no comments." on a first review, "generated no new comments." on a re-review), **STOP immediately** — cancel the cron/`/loop` job, do not schedule another poll. Post: "Copilot review is clean — no new comments." Then run the **After convergence — offer to group commits** step (Exit conditions) *before waiting* — without it the offer is unreachable on the GitHub path — and wait for the author's call (group commits / review / merge / more work).
@@ -196,7 +468,15 @@ First-time caveat: on some repos `gh pr edit --add-reviewer` returns 422 for the
 
 ## Exit conditions
 
-- **Local gate clean + (for GitHub) Copilot clean pass** (matches "generated no comments." / "generated no new comments.") → stop and surface to the author. This is the primary, explicit stop signal — prefer it over inferring doneness from "no new comments for N polls".
+- **Local gate clean + (for a forge target) the forge reviewer's clean pass** → stop and surface to the author. This is the primary, explicit stop signal — prefer it over inferring doneness from "no new comments for N polls".
+- **"Clean" is not one verdict.** State the panel's composition and the evidential weight of its agreement:
+  - **Heterogeneous** — at least one live tier-1 **CLI** panelist alongside Claude → convergence is meaningful evidence.
+  - **User-asserted** — the only non-Claude panelist is a declared endpoint (`trust: user-asserted`). Report it as such; a config file must not buy the heterogeneous tier.
+  - **Same-family** — Claude plus a different Claude model → "gate clean at tier 2 — same-family panel, shared blind spots possible; this is **weak evidence**."
+  - **Fresh-context only** — the subagent's echoed model id equals the session model, is absent, or the requested model was not dispatchable. The weakest verdict there is. Say it.
+  - Report the panel that **actually ran, verified**: the model that actually *differed* (the subagent echoes its model id on the first line of its record — a self-report, weak, and still better than asserting a tier from a config field), the CLI that actually returned findings. Where the composition changed mid-run, report it **per round**, not by its best round.
+  - Any `unreproduced` correctness finding withholds "gate clean": report "clean except N unreproduced correctness findings" and let the author waive them.
+- **Degradation.** Only Claude available → single reviewer, no cross-critique, and the same-family caveat above. Two or more Claude panelists and no external CLI → force **method-level divergence**, not tone (first principles / base rates / disconfirming evidence only); a role name like "Red Team" does not decorrelate errors, a different method or an actual reproduction does — and the verdict stays same-family either way.
 - **Codex usage limit** → stop only the Codex sub-loop; the rest of the loop continues.
 - **Merge** — never merge autonomously. Only on an explicit `merge` instruction. Default to a merge commit (`gh pr merge --merge`, not `--squash`) to preserve history; ask before deleting the branch, and prefer leaving the local branch in place for the author to prune. Honor the project's own merge conventions if they differ.
 
@@ -219,6 +499,42 @@ When the loop reaches its clean/stop state and the current branch is a **non-def
   9. **abort/rollback on any failure before the push** — `git reset --hard <backup>`, restore the stash (remove operation-created untracked artifacts blocking it; never the user's content; if it still won't restore, STOP and surface `<backup>` + the stash entry), and do not push. Keep `<backup>` until verified success.
 - **Invariants:** never overwrite remote commits the regrouped branch lacks; on any lease mismatch, abort and surface — never auto-retry. **Grouping preserves the base relationship; it does not advance onto a moved base** (the merge commit reconciles that; advancing is a separate, explicit, user-driven rebase). Never offer on a primary branch.
 
+## Facilitator discipline
+
+The facilitator (this session) frames, dispatches, validates, adjudicates, and fixes.
+It may not put its own arguments in a panelist's mouth.
+
+- Findings are **attributed** in the round output — `[codex]`, `[claude-fable]` — and a
+  panelist's wording is preserved **verbatim**.
+- The facilitator's own observations go under a separate, labelled **Facilitator**
+  heading. They never count as panel findings and never gate anything.
+- **Merged duplicates retain both verbatim texts and both attributions.** "These two are
+  the same issue, I'll keep one phrasing" is the laundering the verbatim rule exists to
+  stop. Two panelists slicing one problem into different buckets are **not** agreeing;
+  recording them as one finding manufactures consensus.
+- Any **downgrade, merge, or dismissal of a tier-1 panelist's finding is surfaced** with
+  its reason. The facilitator may propose it; the author sees it.
+- **An unexplained full reversal is a sycophancy flag.** A panelist that abandons a
+  finding without a reason, or concedes every attack, is asked for the grounds before the
+  reversal is accepted. This ask is one extra panelist call and is the single sanctioned
+  exception to "cross-critique is one round" (the other being Round 3 with ≥3 panelists).
+
+Tiering (T1/T2/T3) remains facilitator judgement: scope-of-fix is not something a
+reviewer can assess for a repo it does not own.
+
+## Ghost panelist gate
+
+A status line, an empty result, or an error dump is **not a contribution**. If one enters
+the record, R2 critiques thin air and the panel degrades silently.
+
+- **Codex, native path:** the existing structural `command_execution` detector, unchanged.
+  Embedded-diff rounds stay exempt; **R2 critique rounds are now exempt too** (A2).
+- **Every other panelist:** the return must be a substantive review — findings, or an
+  explicit "no remaining problems". Re-run once; on a second failure **drop the panelist,
+  continue, and disclose which panel actually ran**.
+- **External CLIs run in the foreground** with a generous timeout (≈10 min). A wrapper
+  that backgrounds the call and returns early manufactures ghosts.
+
 ## Learning capture
 
 After each round, append to a review journal in the repo (e.g. `.claude/pr-review-journal.md`, create if absent):
@@ -226,6 +542,7 @@ After each round, append to a review journal in the repo (e.g. `.claude/pr-revie
 - Comment → fix pattern
 - T3 decisions + chosen approach + why
 - Repeat-issue escalations (these = gaps in the project's conventions; candidates for the project's guidelines doc)
+- **R2's kill rate and rounds consumed.** Cross-critique costs one extra call per panelist before the first fix, and usage limits are a first-class outcome — so the marginal cost is not "one more call" but "one fewer convergence round before the limit". That R2 pays for itself (false positives dying before they become a commit, a test, and a convergence round) is a **hypothesis**. Record the data so it can be checked.
 
 Periodically distill recurring patterns into the project's conventions/guidelines doc.
 
@@ -233,4 +550,6 @@ Periodically distill recurring patterns into the project's conventions/guideline
 
 - Not fully autonomous. The author decides T2/T3 fixes and the final merge.
 - Not a squash-merge tool. Default to a merge commit to preserve history.
-- The Copilot path is GitHub-only (uses `gh` + GitHub GraphQL). For other forges, the local Claude + Codex gate still applies; the remote-reviewer phase does not.
+- The **built-in** forge adapter is GitHub-only (it uses `gh` + GitHub GraphQL). Other forges are reachable by declaring a reviewer and its three commands; none ships. With no forge reviewer, the local panel gate is the whole loop.
+- **Not changing:** the sandbox routing, the embedded-diff form, the `command_execution` detector's **jq predicate**, exit-code triage, the Copilot adapter's behavior, or the never-merge rule. Two things *do* change and are named so nobody can satisfy this list by ignoring them: the detector's **scope** gains an R2-critique exemption (A2), and Phase B's *framing* becomes a forge slot while its Copilot behavior is preserved verbatim.
+- **Not a debate machine.** With the default two-panelist panel, cross-critique is **one round**. Two bounded additions: a separate Round 3 with **≥ 3** panelists, and the reversal-grounds ask. Panelist disagreement about executable code is settled by a test, not by more rounds.

--- a/plugins/review-loop/skills/review-loop/references/codex-sandbox-host-fixes.md
+++ b/plugins/review-loop/skills/review-loop/references/codex-sandbox-host-fixes.md
@@ -50,7 +50,7 @@ use_legacy_landlock = true
 Verify:
 
 ```bash
-codex exec --sandbox read-only review --commit <unpushed-sha>   # produces a real review
+codex exec --json --sandbox read-only review --commit <unpushed-sha>   # produces a real review
 ```
 
 ## 3. Hand-rolled `/etc/apparmor.d/bwrap` (inferior to `bwrap-userns-restrict`)
@@ -107,5 +107,5 @@ Verify (no host change — confirm the fallback itself yields a real review):
 ```bash
 sha=$(git rev-parse HEAD)
 printf '%s\n\n%s\n' "Review this diff for correctness and risk:" "$(git show "$sha")" \
-  | codex exec --sandbox read-only -        # produces a real review with no native sandbox
+  | codex exec --json --sandbox read-only -   # produces a real review with no native sandbox
 ```

--- a/plugins/review-loop/skills/review-loop/references/why-adversarial.md
+++ b/plugins/review-loop/skills/review-loop/references/why-adversarial.md
@@ -1,0 +1,88 @@
+# Why the reviewers are adversaries
+
+Background for `SKILL.md`'s Phase A. The skill carries only what the agent must
+execute; the reasoning lives here.
+
+## Credit
+
+The panel's three invariants — **independence**, **adversariality**, and
+**synthesis without averaging** — are borrowed, wholesale and deliberately, from
+the **`adversarial-panel`** Claude Code skill:
+
+- Repository: <https://github.com/makinux/adversarial-panel>
+- Author: makinux · Concept and design essay: Ryousuke Wayama (@wayama_ryousuke),
+  *"adversarial-panel:多モデル敵対的レビューという品質保証"*, 2026-07-09
+- Licence: **MIT** — Copyright (c) 2026 makinux
+
+So are the named anti-patterns this skill guards against: *ghost panelist*,
+*sycophantic convergence*, *facilitator capture*, *confidence theater*, and
+*diversity illusion*. `review-loop` re-implements them for a different target and
+adds rules of its own; it does not copy that skill's text.
+
+## The problem it solves
+
+An LLM's answer is most dangerous not when it is wrong, but when it is
+confidently wrong. Self-critique cannot catch that: the blind spot at generation
+time and the blind spot at critique time come from the same weights, and models
+demonstrably prefer their own output. A model reviewing its own diff is not a
+second opinion — it is an audit with a conflict of interest.
+
+Before this change, `review-loop` had two reviewers but arranged them as a queue:
+a Claude subagent reviewed, its fixes were committed, and only then did Codex
+read the already-fixed tree. Codex could never dispute Claude's reading of a
+finding, because it never saw what Claude saw.
+
+## The two properties that make a panel work
+
+Neither follows from merely having more than one reviewer. Both must be
+engineered.
+
+**Decorrelation.** A reviewer catches what the author missed only when their
+failure modes differ. Same-family panels share blind spots, so their agreement is
+weaker evidence than it looks. Hence the roster is ranked by *heterogeneity*, not
+by capability, and the gate verdict says which tier actually ran — a same-family
+"clean" is reported as weak evidence, and a `claude-alt` that turns out to equal
+the session model degrades to *fresh-context only*.
+
+**Verification advantage.** Refuting a claim is cheaper than producing one. So
+critics are pointed at *verifiable* claims and made to refute by reproduction —
+"this fails on input X", not "I doubt this". `review-loop` presses this further
+than its source can, because its target is a diff rather than a claim: where a
+finding is executable, a failing test settles it, and disagreement between
+panelists is converted into a test rather than into another round.
+
+## What we changed on purpose
+
+- **Reproduction outranks argument.** The source skill debates claims. We review
+  code, which has a runnable ground truth. A prose target gets an analogue — a
+  citation the *facilitator* verifies with a command — because "a reader can
+  check it" is a capability, not a check.
+- **`confidence` authorizes nothing.** It is a self-report by the weights that
+  produced the finding. What opens the auto-fix gate is `reproduced`, or `survived` (the
+  finding faced an adversary) **together with** high confidence and a concrete
+  falsification condition — confidence never opens it alone, and never without the
+  condition that says what would retract it. Gating on "not refuted" would admit a
+  finding no adversary ever examined; on a single-reviewer run that reduces to a
+  model grading its own work and committing it.
+- **`refuted` had to split.** An attack its author never answered is
+  `refuted-undefended`: a live disagreement for the author, never a verdict the
+  facilitator may act on.
+- **No forced disagreement.** The source's *"you disagree with at least one
+  central claim; find it"* manufactures a refutation when the other panelist is
+  right. We ask instead for the claim you tried hardest to break, and whether it
+  held. A round that refutes nothing is legitimate; a round that *attacks*
+  nothing is the failure.
+- **We keep a structural detector the source does not have.** A native Codex
+  round that ran zero `command_execution` items never read the tree — that is
+  evidence, not phrasing, and it cannot be talked around. Its one exemption is R2
+  critique rounds, whose subject is the other panelists' findings rather than the
+  tree, so zero commands there says nothing about sandbox health.
+
+## The cost, stated plainly
+
+Cross-critique adds one call per panelist before the first fix. Usage limits are
+a first-class outcome, so the real marginal cost is one fewer convergence round
+before the limit. That R2 pays for itself — false positives dying before they
+become a commit, a test, and a convergence round — is a **hypothesis**. The
+review journal records R2's kill rate and rounds consumed so it can be checked
+against reality rather than taste.

--- a/tools/review-loop/fixtures/codex-native-false-clean.jsonl
+++ b/tools/review-loop/fixtures/codex-native-false-clean.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-00000000face"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"The sandbox prevented reading the working tree, so I reviewed the connected GitHub repository instead. I found no issues, but my confidence is low."}}
+{"type":"turn.completed"}

--- a/tools/review-loop/fixtures/codex-native-real-review.jsonl
+++ b/tools/review-loop/fixtures/codex-native-real-review.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-00000000beef"}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"git diff main...HEAD","status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"sed -n '1,80p' src/ttl.ts","status":"completed"}}
+{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"src/ttl.ts:41 - expiry comparison uses `<`, so an entry expiring exactly now survives one extra get(). confidence: high. not a bug if expiry is intended to be exclusive."}}
+{"type":"turn.completed"}

--- a/tools/review-loop/fixtures/codex-r2-critique.jsonl
+++ b/tools/review-loop/fixtures/codex-r2-critique.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-00000000cafe"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"Attacking the other panelist's finding #2: it claims `opts` may be null, but their own quoted hunk shows `opts: Options = {}` on the line above. REFUTED. My own finding #1 I keep, at high confidence."}}
+{"type":"turn.completed"}

--- a/tools/review-loop/test-detector-predicate.sh
+++ b/tools/review-loop/test-detector-predicate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pins the post-round detector's decision, using recorded `codex --json` streams.
+# Pins the post-round detector's decision, using recorded `codex exec --json` streams.
 # No sandbox, no network, no codex binary required.
 set -euo pipefail
 

--- a/tools/review-loop/test-detector-predicate.sh
+++ b/tools/review-loop/test-detector-predicate.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Pins the post-round detector's decision, using recorded `codex --json` streams.
+# No sandbox, no network, no codex binary required.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIX="$SCRIPT_DIR/fixtures"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+# The predicate, verbatim from SKILL.md's detector.
+ran_a_command() {
+  jq -e 'select(.type=="item.completed") | select(.item.type=="command_execution")' "$1" >/dev/null 2>&1
+}
+
+# The routing decision the skill must make.
+#   review  round + zero commands -> non-review (sandbox false clean)
+#   critique round + zero commands -> review (exempt: its subject is the findings)
+classify_round() { # $1=kind ($2=file)
+  if ran_a_command "$2"; then echo "review"; return; fi
+  case "$1" in
+    critique) echo "review" ;;
+    *)        echo "non-review" ;;
+  esac
+}
+
+for f in codex-native-false-clean codex-native-real-review codex-r2-critique; do
+  [ -f "$FIX/$f.jsonl" ] || fail "missing fixture: $f.jsonl"
+  jq -e . "$FIX/$f.jsonl" >/dev/null || fail "fixture is not valid JSONL: $f"
+done
+pass "fixtures present and parse as JSONL"
+
+[ "$(classify_round review "$FIX/codex-native-false-clean.jsonl")" = "non-review" ] \
+  || fail "a sandbox-blocked native review must be a non-review, never a silent clean"
+pass "native review + zero commands -> non-review"
+
+[ "$(classify_round review "$FIX/codex-native-real-review.jsonl")" = "review" ] \
+  || fail "a native review that ran commands must be a review"
+pass "native review + commands -> review"
+
+# The exemption. This is the branch that cannot execute on a `broken` host.
+ran_a_command "$FIX/codex-r2-critique.jsonl" \
+  && fail "the critique fixture must have ZERO command_execution items to test the exemption"
+[ "$(classify_round critique "$FIX/codex-r2-critique.jsonl")" = "review" ] \
+  || fail "an R2 critique round with zero commands must be EXEMPT, not a non-review"
+pass "R2 critique + zero commands -> review (exempt)"
+
+# The false-clean fixture must also carry a corroborating text marker.
+grep -q 'sandbox prevented reading' "$FIX/codex-native-false-clean.jsonl" \
+  || fail "false-clean fixture lacks its corroborating text marker"
+pass "false-clean fixture carries a text marker"
+
+# thread_id is parseable from every fixture (resume depends on it).
+for f in "$FIX"/*.jsonl; do
+  jq -re 'select(.type=="thread.started") | .thread_id' "$f" >/dev/null \
+    || fail "no thread_id in $(basename "$f")"
+done
+pass "thread_id parseable from every fixture"
+
+# Cross-link: the exemption this test pins must actually be stated in SKILL.md.
+# Without this, Task 4 could land an exemption that contradicts these fixtures and
+# both suites would still pass.
+SKILL="$SCRIPT_DIR/../../plugins/review-loop/skills/review-loop/SKILL.md"
+# Both sites must state it, and each is asserted on its own. The operative statement
+# lives in Codex mechanics (it scopes the detector); the ghost-panelist gate restates it.
+# One regex matching either leaves the suite green when the operative one is deleted.
+grep -Eq 'R2 critique rounds are EXEMPT from the post-round' "$SKILL" \
+  || fail "Codex mechanics no longer scopes the detector to exempt R2 critique rounds"
+grep -Eq 'R2 critique rounds are now exempt too' "$SKILL" \
+  || fail "the ghost-panelist gate no longer restates the R2 critique exemption"
+grep -Eq 'zero .*command_execution' "$SKILL" \
+  || fail "SKILL.md no longer describes the zero-command detector condition"
+pass "SKILL.md states the exemption these fixtures pin"
+
+echo "All detector-predicate checks passed."

--- a/tools/review-loop/test-skill-content.sh
+++ b/tools/review-loop/test-skill-content.sh
@@ -23,7 +23,20 @@ refute() { # $1=regex, $2=description — fails if the regex IS present
 REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SKILL_REL="plugins/review-loop/skills/review-loop/SKILL.md"
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-BASE_REF="${BASE_REF:-$(git -C "$REPO" merge-base HEAD "$DEFAULT_BRANCH" 2>/dev/null || true)}"
+# A PR/CI checkout often has origin/main but no local main. Falling back to "no baseline"
+# there would silently disable novelty checking and let every vacuous anchor pass -- the
+# exact fail-open this helper exists to prevent. Try the local branch, then the
+# remote-tracking ref, and only then give up.
+_base_ref() {
+  local b
+  for b in "$DEFAULT_BRANCH" "origin/$DEFAULT_BRANCH"; do
+    if git -C "$REPO" rev-parse --verify --quiet "$b" >/dev/null; then
+      git -C "$REPO" merge-base HEAD "$b" 2>/dev/null && return 0
+    fi
+  done
+  return 1
+}
+BASE_REF="${BASE_REF:-$(_base_ref || true)}"
 
 # The frontmatter summarises every rule in the body, so grepping the whole file lets the
 # summary stand in for the rule it summarises: gut the body, keep the description, and the
@@ -32,9 +45,20 @@ BASE_REF="${BASE_REF:-$(git -C "$REPO" merge-base HEAD "$DEFAULT_BRANCH" 2>/dev/
 skill_body() { awk 'NR==1 && /^---$/ {fm=1; next} fm && /^---$/ {fm=0; next} !fm'; }
 
 need_new() { # $1=regex, $2=description — must match the BODY now, must NOT match it at $BASE_REF
-  skill_body < "$SKILL" | grep -Eq "$1" || fail "SKILL.md body missing (frontmatter does not count): $2"
+  # No pipeline into grep: with `set -o pipefail`, a consumer that exits early on a match
+  # can surface the producer's SIGPIPE as a non-zero pipeline status, turning a real match
+  # into a silent miss. Capture once, match with a here-string.
+  local body; body="$(skill_body < "$SKILL")"
+  grep -Eq "$1" <<<"$body" || fail "SKILL.md body missing (frontmatter does not count): $2"
   if [ -z "$BASE_REF" ]; then
-    echo "WARN: no BASE_REF (not a git checkout?) — novelty unchecked for: $2" >&2
+    # Outside a git checkout there is genuinely no baseline: warn and pass, so the harness
+    # stays runnable. INSIDE one, an unresolvable default branch is an error, not an
+    # absence -- passing there would silently disable novelty checking, the exact fail-open
+    # this helper exists to prevent.
+    if git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
+      fail "in a git checkout but cannot resolve a baseline (tried $DEFAULT_BRANCH, origin/$DEFAULT_BRANCH) for: $2"
+    fi
+    echo "WARN: no BASE_REF (not a git checkout) — novelty unchecked for: $2" >&2
     pass "$2"
     return
   fi
@@ -51,7 +75,8 @@ need_new() { # $1=regex, $2=description — must match the BODY now, must NOT ma
     fail "cannot read baseline $BASE_REF:$SKILL_REL for: $2"
   # Compare BODY to BODY. The baseline frontmatter summarises its own body, so grepping it
   # would report an anchor vacuous on the strength of a summary the body never contained.
-  if printf '%s\n' "$base_content" | skill_body | grep -Eq "$1"; then
+  local base_body; base_body="$(skill_body <<<"$base_content")"
+  if grep -Eq "$1" <<<"$base_body"; then
     fail "vacuous anchor (already in the SKILL.md body at $BASE_REF): $2"
   fi
   pass "$2"

--- a/tools/review-loop/test-skill-content.sh
+++ b/tools/review-loop/test-skill-content.sh
@@ -17,6 +17,46 @@ refute() { # $1=regex, $2=description — fails if the regex IS present
   pass "no longer present: $2"
 }
 
+# Novelty-checked anchor. An anchor that already matches the PRE-CHANGE SKILL.md
+# guards nothing: it passes before the work is done. Three such anchors were
+# proposed during spec 014's review and none of their authors had run grep.
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_REL="plugins/review-loop/skills/review-loop/SKILL.md"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+BASE_REF="${BASE_REF:-$(git -C "$REPO" merge-base HEAD "$DEFAULT_BRANCH" 2>/dev/null || true)}"
+
+# The frontmatter summarises every rule in the body, so grepping the whole file lets the
+# summary stand in for the rule it summarises: gut the body, keep the description, and the
+# anchor is still green. need_new therefore reads the BODY only. (refute keeps the whole
+# file: a phrase must be gone from everywhere, summary included.)
+skill_body() { awk 'NR==1 && /^---$/ {fm=1; next} fm && /^---$/ {fm=0; next} !fm'; }
+
+need_new() { # $1=regex, $2=description — must match the BODY now, must NOT match it at $BASE_REF
+  skill_body < "$SKILL" | grep -Eq "$1" || fail "SKILL.md body missing (frontmatter does not count): $2"
+  if [ -z "$BASE_REF" ]; then
+    echo "WARN: no BASE_REF (not a git checkout?) — novelty unchecked for: $2" >&2
+    pass "$2"
+    return
+  fi
+  # Once this branch merges, the suite runs on the default branch, where the merge-base
+  # IS HEAD -- the baseline and the working file are the same commit, so every anchor
+  # would report itself vacuous. Novelty is unknowable there; it was checked before merge.
+  if [ "$BASE_REF" = "$(git -C "$REPO" rev-parse HEAD)" ]; then
+    echo "WARN: BASE_REF == HEAD (on the baseline branch) — novelty unchecked for: $2" >&2
+    pass "$2"
+    return
+  fi
+  local base_content
+  base_content="$(git -C "$REPO" show "$BASE_REF:$SKILL_REL" 2>/dev/null)" || \
+    fail "cannot read baseline $BASE_REF:$SKILL_REL for: $2"
+  # Compare BODY to BODY. The baseline frontmatter summarises its own body, so grepping it
+  # would report an anchor vacuous on the strength of a summary the body never contained.
+  if printf '%s\n' "$base_content" | skill_body | grep -Eq "$1"; then
+    fail "vacuous anchor (already in the SKILL.md body at $BASE_REF): $2"
+  fi
+  pass "$2"
+}
+
 need 'sandbox-preflight\.sh'                              "preflight script reference"
 need 'Route by sandbox state'                            "sandbox-state routing rule"
 need 'Embedded-diff form'                                "embedded-diff form"
@@ -36,5 +76,28 @@ need 'After convergence'                                 "after-convergence offe
 need 'feature.branch'                                    "offer is feature-branch only"
 need 'force-with-lease'                                  "pinned-lease push guidance"
 need 'never automatic'                                   "offer is assisted, never automatic"
+
+# spec 014 Part A — roster, init, calibration
+need_new 'never silently follow a stale config'          "roster drift is surfaced, not followed"
+need_new 'review-loop\.local\.md'                        "enrollment config path"
+need_new 'derived from `kind`'                           "tier is derived, not declared"
+
+# spec 014 Part B — the adversarial panel
+need_new 'blind, parallel, on the same unfixed diff'     "round 1 is blind on the UNFIXED diff"
+need_new 'tried hardest to break'                        "R2's non-forcing critique rule, not its heading"
+need_new 'refuted-undefended'                            "the status that had to exist"
+need_new 'status == survived'                            "gate turns on survived, not != refuted"
+need_new 'a concrete, checkable condition'               "the record's falsification FIELD, not the word"
+need_new 'facilitator confirms the quote'                "prose reproduction is a check, not a capability"
+need_new 'retain both verbatim texts'                    "dedup cannot launder attribution"
+need_new 'weak evidence'                                 "same-family convergence is labelled weak"
+need_new 'critique rounds are now exempt'                "R2 detector exemption"
+need_new 'forge reviewer'                                "Phase B is a slot"
+need_new 'clean_when'                                    "declared reviewers pin their stop signal"
+
+# the leading convergence prompt is gone
+refute 'Are your earlier points resolved'                "leading convergence prompt"
+# the old Copilot-only Phase B heading is gone (note: it was an h3, not an h2)
+refute '^### Phase B — GitHub Copilot'                   "Copilot-only Phase B heading"
 
 echo "All SKILL.md content checks passed."


### PR DESCRIPTION
Implements [spec 014](docs/superpowers/specs/014-review-loop-adversarial-panel-design.md).

Prompted by [makinux/adversarial-panel](https://github.com/makinux/adversarial-panel) (MIT) and its design essay. Attribution and the borrowed-vs-changed accounting live in `plugins/review-loop/skills/review-loop/references/why-adversarial.md`.

## Why

`SKILL.md` is an LLM-read system prompt: an agent reads it and behaves accordingly, so **wording is behavior, and a runnable code sample is an instruction just as much as prose.**

Before this, the loop had two reviewers arranged as a queue: a Claude subagent reviewed, its fixes were committed, and only then did Codex read the **already-fixed tree**. Codex could never dispute Claude's reading of a finding, because it never saw what Claude saw. A model reviewing its own diff is not a second opinion — the blind spot at generation time and the blind spot at critique time come from the same weights.

## Part A — the roster is enrolled, not assumed

- `/review-loop:init` probes which coding CLIs exist, then **verifies how to call each one by actually calling it**, on a throwaway fixture diff — never your real working tree. A CLI whose invocation cannot be established is *detected but not enrolled*, with the reason shown.
- Presence of `gh` is not authentication. `init` never asks for `sudo` and never fixes your host: if Codex's native sandbox is blocked, it records `form: embedded` — a fully supported path — and stops.
- No new shipped script. The presence probe is a `command -v` loop the agent runs inline; wrapping it would calcify a decision a stronger model will make correctly unaided.
- Drift (enrolled-but-absent, present-but-unenrolled, stale recipe) is always surfaced, never silently followed. A stored recipe can never suppress the preflight or the `command_execution` detector.

## Part B — the reviewers become adversaries

- **Blind parallel round 1** on the same *unfixed* diff, then **one cross-critique round**. R1 uses Codex's freeform `review -` because the targeted form takes no prompt, and R1's prompt must request the finding record. Freeform infers its own diff, so the brief pins `<base>..<head-sha>` and the facilitator checks the echoed file list against `git diff --name-only`.
- Findings carry attribution, tier, **confidence**, and a concrete **falsification condition**. `confidence` is a self-report by the weights that produced the finding, so it **authorizes nothing**. What opens the auto-fix gate is `survived` (the finding faced an adversary) or `reproduced`. A single-panelist run auto-fixes on `reproduced` alone.
- `refuted` split: an attack its author never answered is `refuted-undefended` — a live disagreement for the author, never a verdict the facilitator may act on.
- Prose targets get a `reproduced` analogue, but the **facilitator is obliged to verify the citation with a command**. "A reader can check it" is a capability, not a check.
- The convergence prompt no longer asks a reviewer to accept the author's own summary of the author's own fixes as evidence.
- The gate verdict names the panel that **actually ran** and calls same-family agreement **weak evidence**.
- Phase B becomes a generic forge-reviewer slot. GitHub Copilot is the one built-in adapter; other forges' agents are neither named nor shipped, because an adapter nobody here can run would poll forever or report a clean pass that never happened.

## Tests

- `tools/review-loop/test-skill-content.sh` — 14 `need_new` anchors (must match the body, must **not** match `SKILL.md` at the merge-base) + 2 `refute`s. **Six anchors were found to pass for the wrong reason** during review and were retargeted at the rule rather than a word, a heading, or the frontmatter summary. `need_new` now reads the body only: the frontmatter summarises every rule, so grepping the whole file let the summary stand in for the rule it summarised.
- `tools/review-loop/test-detector-predicate.sh` — recorded `codex --json` fixtures pinning the R2 detector exemption, with each of its two statement sites asserted separately. The suite is demonstrated to go red when the exemption is removed.

## Known coverage gap

This host's Codex sandbox preflight reports `broken`, so every Codex round routes to the embedded-diff form — a **fully supported path**, not a degradation. The consequence is a testing gap, not a running one: the native R2 path (`resume` + the detector exemption) never executes here. The fixtures pin the predicate and the routing decision; they do not prove `codex exec resume` behaves as documented against a live `usable` sandbox. Disclosed rather than implied, per spec §B.12.

Restoring the native path is an AppArmor/sysctl change affecting every `bwrap` caller on the machine. Separate work; nothing here asks for `sudo`.

## Review trail

The spec was reviewed by Fable 5, then blind-reviewed in parallel by Codex (gpt-5.5) and Fable, who then cross-critiqued each other's findings — 31 findings, three live disagreements, all resolved by reproduction rather than argument. Implementation ran as 11 tasks with a fresh subagent and reviewer per task, a whole-branch review, and a convergence round in which Fable verified its own 19 findings against the shipped code (17 resolved, 2 partial, 0 unresolved).

Codex — the only tier-1, cross-family reviewer here — has not yet reviewed the implementation. By this branch's own rules, everything above is **same-family agreement, and therefore weak evidence.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)